### PR TITLE
fix: accept description kwarg to prevent --help docstring leak (#4)

### DIFF
--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -157,11 +157,12 @@ def pass_cli_context(f):
 
 def create_cli(
     name: str,
-    description: str | None = None,
     commands_dir: Path | None = None,
     discovery_mode: str = "auto",
     config_schema: dict | None = None,
     repo_config_path: Path | None = None,
+    *,
+    description: str | None = None,
 ) -> click.Group:
     """Create a Click CLI group with global flags and plugin discovery.
 
@@ -178,16 +179,18 @@ def create_cli(
 
     Args:
         name: CLI name (e.g., "orbit-admin"). Used for config paths and logging.
-        description: Short help summary shown at the top of ``<cli> --help``.
-            When omitted (None), an empty string is passed to Click so it
-            does NOT fall back to the inner cli_group callback's docstring,
-            which is a developer-only implementation detail. Plugin authors
-            should pass something like "Admin CLI for orbit" to give users
-            a one-line summary of what the CLI does.
         commands_dir: Path to the commands directory for dev-mode discovery.
         discovery_mode: "dev", "installed", or "auto".
         config_schema: Optional config schema dict for validation.
         repo_config_path: Optional path to repo-level config file.
+        description: Short help summary shown at the top of ``<cli> --help``.
+            Keyword-only to preserve positional compatibility for existing
+            callers that pass ``commands_dir`` positionally. When omitted
+            (None), an empty string is passed to Click so it does NOT fall
+            back to the inner cli_group callback's docstring, which is a
+            developer-only implementation detail. Plugin authors should
+            pass something like "Admin CLI for orbit" to give users a
+            one-line summary of what the CLI does.
 
     Returns:
         A configured Click group with all discovered commands registered.

--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -157,6 +157,7 @@ def pass_cli_context(f):
 
 def create_cli(
     name: str,
+    description: str | None = None,
     commands_dir: Path | None = None,
     discovery_mode: str = "auto",
     config_schema: dict | None = None,
@@ -177,6 +178,12 @@ def create_cli(
 
     Args:
         name: CLI name (e.g., "orbit-admin"). Used for config paths and logging.
+        description: Short help summary shown at the top of ``<cli> --help``.
+            When omitted (None), an empty string is passed to Click so it
+            does NOT fall back to the inner cli_group callback's docstring,
+            which is a developer-only implementation detail. Plugin authors
+            should pass something like "Admin CLI for orbit" to give users
+            a one-line summary of what the CLI does.
         commands_dir: Path to the commands directory for dev-mode discovery.
         discovery_mode: "dev", "installed", or "auto".
         config_schema: Optional config schema dict for validation.
@@ -186,10 +193,20 @@ def create_cli(
         A configured Click group with all discovered commands registered.
     """
 
+    # Resolve the help text shown by ``<cli> --help``.
+    #
+    # WHY an explicit fallback to "": Click's @click.group() decorator falls
+    # back to the callback function's __doc__ when ``help=`` is None. That
+    # behaviour would leak the inner cli_group() docstring -- which documents
+    # internal callback args like ctx/verbose/quiet -- to end users. Passing
+    # an empty string forces Click to render no description at all, instead
+    # of scraping the developer-facing docstring (issue #4).
+    group_help = description if description is not None else ""
+
     # Define the group callback as a local function so that 'name', 'config_schema',
     # and 'repo_config_path' from the outer scope are captured in the closure.
     # This is the standard Click pattern for parameterised group factories.
-    @click.group(name=name)
+    @click.group(name=name, help=group_help)
     @click.option(
         "--verbose", "-v",
         count=True,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -229,6 +229,58 @@ class TestCreateCli:
         assert result.exit_code == 0
         assert received["yes"] is True
 
+    def test_help_does_not_leak_internal_docstring(self, tmp_path: Path):
+        """--help must NOT expose the internal cli_group callback's docstring.
+
+        WHY this matters: the inner cli_group() function has a developer-facing
+        docstring documenting its callback args (ctx, verbose, quiet, etc.).
+        Click's @click.group() decorator falls back to the callback's __doc__
+        when no explicit ``help=`` is provided, so a plain create_cli() leaks
+        that internal docstring into user-visible --help output.
+
+        End users should never see phrases like "CLI entry point" or "Runs
+        before every subcommand" or a raw "Args:" block -- that's an
+        implementation detail of clickwork's factory, not the CLI they're
+        using. This test pins the regression fix for issue #4.
+        """
+        from clickwork.cli import create_cli
+
+        cli = create_cli(name="test-cli", commands_dir=tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        # These phrases come verbatim from cli_group's docstring. If any of
+        # them appear in --help, Click is still falling back to __doc__.
+        assert "CLI entry point" not in result.output
+        assert "Runs before every subcommand" not in result.output
+        assert "configure logging, load config" not in result.output
+        # The docstring also contains a Google-style "Args:" section with
+        # parameter descriptions; none of that should reach the user.
+        assert "Args:" not in result.output
+
+    def test_help_shows_description_when_provided(self, tmp_path: Path):
+        """When description= is passed, --help should display it.
+
+        WHY: plugin authors want the ability to provide a short summary of
+        what their CLI does (e.g., "Admin CLI for orbit"). Accepting a
+        description parameter gives them that lever without forcing them
+        to subclass or monkey-patch the Click group.
+        """
+        from clickwork.cli import create_cli
+
+        cli = create_cli(
+            name="test-cli",
+            description="My awesome CLI for testing",
+            commands_dir=tmp_path,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "My awesome CLI for testing" in result.output
+        # Regression guard: providing a description must still suppress
+        # the internal docstring, not append to it.
+        assert "CLI entry point" not in result.output
+
     def test_config_loaded_into_context(self, tmp_path: Path):
         """Config from a TOML file should be accessible as ctx.obj.config.
 


### PR DESCRIPTION
## Summary
- `create_cli()` now accepts a `description: str | None = None` kwarg and forwards it (or `""`) as `help=` on the `@click.group(...)` decorator.
- Blocks Click's fallback to the inner `cli_group.__doc__`, which was leaking developer-facing docstring content (callback args like `ctx`/`verbose`/`quiet`) into end-user `--help` output.
- Inner `cli_group` docstring preserved intact as source-level documentation.

Fixes #4.

## Test plan
- [x] New unit tests: `test_help_does_not_leak_internal_docstring`, `test_help_shows_description_when_provided`
- [x] Full suite: 123 passed (121 baseline + 2 new), zero warnings
- [x] Manual: `<cli> --help` with no description renders clean Options block; with `description=` renders the supplied string
- [ ] Consumer smoke test in orbit-admin (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)