### PR TITLE
docs: 0.2.0 roadmap spec for issues #8-#17

### DIFF
--- a/docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md
+++ b/docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md
@@ -1,0 +1,100 @@
+# clickwork 0.2.0 roadmap
+
+**Date:** 2026-04-17
+**Target release:** clickwork 0.2.0
+**Scope:** 10 open issues (#8 through #17)
+
+## Goal
+
+Ship all 10 open clickwork issues and cut a 0.2.0 release today. Each issue gets its own PR so reviews stay focused. Parallel execution where dependencies allow; serial merges per wave so `cli.py` conflicts stay manageable.
+
+## Roadmap-level decisions
+
+| Decision | Choice | Reasoning |
+|----------|--------|-----------|
+| Parallelism policy | Overlap next wave's worktree prep during current wave's Copilot wait (option B) | Throughput without file-conflict risk from full parallel across waves |
+| #8 approach | Lazy resolution (option 1) | Cleanest UX, matches Python `from X import Y` mental model, negligible perf cost, simplifies #16 |
+| #13 scope | Full CRUD (option B): `get/post/put/delete` + allowlist + JSON + bearer/basic auth | `put`/`delete` are trivial given `post`; `paginate()` deferred to follow-up PR |
+| Release version | 0.2.0 | Standard semver increment from 0.1.0 for a significant feature batch; no backwards-compat burden since user is sole consumer |
+
+## Wave structure
+
+Each wave runs in parallel worktrees under `/home/qbrd/qbrd-orbit-widener/worktrees/`. A per-wave just-in-time plan lives at `docs/plans/2026-04-17-wave-N-*.md` (matches existing clickwork convention), written at wave start. Each PR follows TDD (red-green-refactor) and the Copilot review loop.
+
+### Wave 1 — small unblockers (3 parallel PRs)
+
+- **#8** `testing: ctx.require() mocking footgun`
+  Switch `cli.py`'s `cli_ctx.require = _require` binding to lazy resolution so `patch("clickwork.prereqs.require")` works as users expect.
+- **#10** `feature: ctx.run(stdin_text=...)`
+  Add `stdin_text` kwarg to `ctx.run()` / `ctx.run_with_confirm()`; routes to `subprocess.run(..., input=..., text=True)`. Gates #11.
+- **#15** `feature: auto-configure sys.path`
+  Opt-in kwarg on `create_cli()` that inserts `commands_dir.parent` on `sys.path` so `from tools.lib.X import Y` works from command files.
+
+### Wave 2 — medium features (3 parallel PRs)
+
+- **#9** `feature: dotenv / shell-sourceable config source`
+  `clickwork.config.load_env_file(path)` handling `export KEY=val`, quoted/single-quoted values, comments, blank lines. Owner-only permission check via the existing TOCTOU-safe pattern.
+- **#12** `feature: platform-dispatch decorator`
+  Decorator or functional helper that routes to linux/windows/macos impls based on `sys.platform`. Style decision at per-wave plan time.
+- **#14** `feature: global flags at all levels`
+  Primitive that installs an option at root + every group + every subcommand, surfaced via `ctx.meta` regardless of where the user put it on the command line.
+
+### Wave 3 — runtime features built on Wave 1 (2 parallel PRs)
+
+- **#11** `feature: secret-passing helper to subprocess`
+  Rejects `Secret` values that appear in argv; routes them through env or stdin. Redacts in logs. Depends on #10's `stdin_text` landing first.
+- **#13** `feature: HTTP client with URL allowlist`
+  `clickwork.http.get/post/put/delete` using stdlib only; host allowlist; JSON auto-parse; bearer + basic auth; structured error with response body. `paginate()` deliberately deferred.
+
+### Wave 4 — docs (sequential, 2 PRs)
+
+- **#16** `docs: clickwork.testing helper + mix_stderr docs`
+  Scope reduced by #8 fix: ship `make_test_cli()` and `run_cli()` helpers; document `CliRunner`'s `mix_stderr=True` default. No `patch_require()` helper needed — resolved by Wave 1.
+- **#17** `docs: common footguns section in LLM_REFERENCE`
+  Consolidate known pitfalls. Items fixed in Waves 1–3 reference the fix PR instead of documenting workarounds.
+
+## Per-wave execution protocol
+
+1. **Plan.** Write `docs/plans/2026-04-17-wave-N-*.md` pinning per-issue task checklists, API shape decisions, and TDD test targets.
+2. **Setup.** Create worktrees for each issue in the wave (parallel).
+3. **Dispatch.** One subagent per issue; TDD red-green-refactor; leave changes unstaged for main-session review.
+4. **Review diffs** in main session before commit.
+5. **Commit + push + PR** with `Fixes #N` closing keyword.
+6. **Copilot review loop.** Request re-review via GraphQL `requestReviews` with `botIds: ["BOT_kgDOCnlnWA"]` if first push didn't auto-trigger. Iterate until Copilot runs out of new comments or repeats itself.
+7. **Merge** on user approval.
+8. **Prep next wave's worktrees during Copilot waits** (parallelism policy B).
+9. **Clean up** worktree + local branch after merge.
+
+## Open questions (resolved at per-wave planning)
+
+- **#10** `stdin_text`: bytes vs text? Accept `Secret` wrapper transparently or keep it explicit?
+- **#11** API shape: `ctx.run_with_secrets()` standalone vs. polymorphic kwargs on `ctx.run()`?
+- **#12** decorator (`@platform_dispatch(linux=..., windows=...)`) vs functional (`dispatch(ctx, linux=..., windows=...)`)?
+- **#14** registration API: decorator vs functional `clickwork.add_global_option(cli, ...)`?
+- **#15** opt-in kwarg name — `add_parent_to_path=True`, `auto_sys_path=True`, or other?
+- **#16** exact surface area — confirm what makes it in: `make_test_cli`, `run_cli`, `mock_run`, `mock_capture`?
+- **#17** specific entries — which currently-known pitfalls still apply after Waves 1–3?
+
+Per-wave plan docs pin these down before implementation.
+
+## Release process (end of day)
+
+After Wave 4 merges:
+1. Bump `version = "0.2.0"` in `pyproject.toml`.
+2. Write/update `CHANGELOG.md` summarizing the 10 issues closed.
+3. PR the version+changelog bump separately (clean tag target).
+4. Merge → `git tag v0.2.0 && git push origin v0.2.0` → optionally `gh release create`.
+
+## Out of scope for 0.2.0
+
+- **#13 `paginate()` helper** — deliberate scope cut, follow-up PR.
+- Custom HTTP auth schemes beyond bearer/basic.
+- Migration to `requests` or any third-party HTTP library.
+- Breaking API changes — none needed; all feature additions.
+
+## Risk / contingency
+
+- **If a Wave 3 PR balloons** (most likely #13): split it. Small focused PRs beat finishing today.
+- **If Copilot surfaces real issues across multiple PRs:** slow down; iterate. A correct 0.2.0 beats a fast one.
+- **If a wave's plan reveals unexpected complexity:** pause, brainstorm just that issue, update this roadmap.
+- **"Done today" is a stretch target, not a commitment.** The roadmap is correct even if delivery slips a day.

--- a/docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md
+++ b/docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md
@@ -60,7 +60,13 @@ Each wave runs in parallel worktrees under `/home/qbrd/qbrd-orbit-widener/worktr
 3. **Dispatch.** One subagent per issue; TDD red-green-refactor; leave changes unstaged for main-session review.
 4. **Review diffs** in main session before commit.
 5. **Commit + push + PR** with `Fixes #N` closing keyword.
-6. **Copilot review loop.** Request re-review via GraphQL `requestReviews` with `botIds: ["BOT_kgDOCnlnWA"]` if first push didn't auto-trigger. Iterate until Copilot runs out of new comments or repeats itself.
+6. **Copilot review loop.** Copilot only auto-reviews on the *first* push to a branch; subsequent pushes need a manual re-review request. The canonical way is the "Re-request review" button next to Copilot in the PR's Reviewers panel (GitHub UI). From the CLI, the REST `POST /repos/.../pulls/N/requested_reviewers` endpoint does **not** work for Copilot (it's a GitHub App, not a collaborator — the call silently returns 200 without queuing a review). What works is the GraphQL `requestReviews` mutation with `botIds:` populated:
+
+   ```bash
+   gh api graphql -f query='mutation { requestReviews(input: {pullRequestId: "<PR_NODE_ID>", botIds: ["BOT_kgDOCnlnWA"], union: true}) { pullRequest { number } } }'
+   ```
+
+   `BOT_kgDOCnlnWA` is Copilot's bot node ID — found via the PR timeline of any PR where Copilot previously reviewed (`gh api graphql` for `timelineItems` with `ReviewRequestedEvent`). Iterate until Copilot runs out of new comments or repeats itself.
 7. **Merge** on user approval.
 8. **Prep next wave's worktrees during Copilot waits** (parallelism policy B).
 9. **Clean up** worktree + local branch after merge.


### PR DESCRIPTION
## Summary
Captures the brainstormed plan for shipping clickwork 0.2.0 today — 10 issues, 4 waves, parallel execution.

**Roadmap-level decisions locked in:**
- Parallelism: overlap next wave's worktree prep during Copilot waits (option B)
- #8 approach: lazy resolution of ``prereqs.require`` (option 1)
- #13 scope: full CRUD (option B), ``paginate()`` deferred
- Release version: 0.2.0

**Wave structure:**
- Wave 1: #8, #10, #15 (small unblockers, parallel)
- Wave 2: #9, #12, #14 (medium features, parallel)
- Wave 3: #11, #13 (built on Wave 1, parallel)
- Wave 4: #16, #17 (docs, sequential)

Per-issue API shape decisions (e.g. ``stdin_text`` bytes vs text, ``#12`` decorator vs functional) are captured as open questions, resolved at per-wave planning time.

## Test plan
- [ ] User reviews roadmap before Wave 1 kicks off
- [ ] Each wave's plan doc lands in ``docs/plans/2026-04-17-wave-N-*.md`` before implementation
- [ ] Roadmap updated inline if a wave reveals unexpected complexity

🤖 Generated with [Claude Code](https://claude.com/claude-code)