### PR TITLE
feat: add stdin_text/stdin_bytes to ctx.run (Fixes #10)

### DIFF
--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -320,7 +320,17 @@ def create_cli(
         # keyword arguments at bind time, but we want them evaluated at
         # call time (from cli_ctx which could in theory be mutated later).
         # Lambdas defer the lookup to when the method is actually called.
-        cli_ctx.run = lambda cmd, env=None: _run(cmd, dry_run=cli_ctx.dry_run, env=env)
+        # stdin_text / stdin_bytes are forwarded through so callers can use
+        # ctx.run(cmd, stdin_text=secret) for the secrets-via-stdin pattern
+        # (wrangler secret put, gh auth login --with-token, etc.) without
+        # reaching around ctx to the underlying process.run() helper.
+        cli_ctx.run = lambda cmd, env=None, *, stdin_text=None, stdin_bytes=None: _run(
+            cmd,
+            dry_run=cli_ctx.dry_run,
+            env=env,
+            stdin_text=stdin_text,
+            stdin_bytes=stdin_bytes,
+        )
         cli_ctx.capture = lambda cmd, env=None: _capture(cmd, dry_run=cli_ctx.dry_run, env=env)
 
         # require() has no dry_run / yes concept -- it's always a live check.
@@ -336,8 +346,14 @@ def create_cli(
         # cli_ctx's flags. This keeps the logic single-sourced in process.py
         # (confirmation + execution + dry-run + signal forwarding) while still
         # letting ctx.run_with_confirm(cmd, msg) work without extra args.
-        cli_ctx.run_with_confirm = lambda cmd, msg, env=None: _run_with_confirm(
-            cmd, msg, yes=cli_ctx.yes, dry_run=cli_ctx.dry_run, env=env,
+        cli_ctx.run_with_confirm = lambda cmd, msg, env=None, *, stdin_text=None, stdin_bytes=None: _run_with_confirm(
+            cmd,
+            msg,
+            yes=cli_ctx.yes,
+            dry_run=cli_ctx.dry_run,
+            env=env,
+            stdin_text=stdin_text,
+            stdin_bytes=stdin_bytes,
         )
 
         # Attach the CliContext to Click's ctx.obj so all subcommands can

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -190,10 +190,14 @@ def run(
         dry_run: If True, print the command but don't execute it.
         env: Extra environment variables merged with os.environ. Use this
             for secrets instead of putting them in cmd (argv is visible in ps).
-        stdin_text: If set, pipe this string to the child's stdin (text mode,
-            UTF-8 by default). Mutually exclusive with stdin_bytes.
-        stdin_bytes: If set, pipe these raw bytes to the child's stdin
-            (binary mode). Mutually exclusive with stdin_text.
+        stdin_text: If set, encode this string as UTF-8 and pipe the bytes
+            to the child's stdin. Mutually exclusive with stdin_bytes.
+            (Implementation note: the child's stdin is always opened in
+            binary mode and we encode here -- this avoids platform-locale
+            surprises and newline translation, so secret/token values
+            arrive byte-exact regardless of OS.)
+        stdin_bytes: If set, pipe these raw bytes to the child's stdin.
+            Mutually exclusive with stdin_text.
 
     Returns:
         subprocess.CompletedProcess on success, or None if dry_run=True.
@@ -232,20 +236,26 @@ def run(
 
     full_env = _build_env(env)
 
-    # Decide whether we need to attach a stdin pipe. Only one of stdin_text
-    # or stdin_bytes can be set (enforced above); "stdin_payload" captures
-    # whichever one it is, and "stdin_is_text" tells us what mode Popen
-    # should open its stdin stream in.
-    stdin_payload: str | bytes | None
+    # Decide whether we need to attach a stdin pipe, and if so, normalize
+    # the payload to raw bytes. Only one of stdin_text or stdin_bytes can
+    # be set (enforced above).
+    #
+    # WHY always bytes on the wire (even for stdin_text): Popen(text=True)
+    # would wrap proc.stdin in a TextIOWrapper that uses the *platform
+    # locale encoding* -- not necessarily UTF-8 -- and can apply newline
+    # translation ("\n" -> "\r\n" on Windows). For secrets and tokens
+    # that must be transmitted byte-exactly (a flipped newline silently
+    # corrupts a token's hash, a locale mismatch breaks the first
+    # non-ASCII character), that's a real bug. Encoding stdin_text to
+    # UTF-8 ourselves and writing bytes directly bypasses both hazards
+    # and unifies the two code paths below.
+    stdin_payload: bytes | None
     if stdin_text is not None:
-        stdin_payload = stdin_text
-        stdin_is_text = True
+        stdin_payload = stdin_text.encode("utf-8")
     elif stdin_bytes is not None:
         stdin_payload = stdin_bytes
-        stdin_is_text = False
     else:
         stdin_payload = None
-        stdin_is_text = False  # unused when stdin_payload is None
 
     # Only open a pipe when we actually have data to write. When no stdin
     # payload is set, we inherit the parent's stdin (the existing behavior)
@@ -253,10 +263,9 @@ def run(
     popen_kwargs: dict = {"env": full_env, "shell": False}
     if stdin_payload is not None:
         popen_kwargs["stdin"] = subprocess.PIPE
-        # text=True makes proc.stdin a text stream; text=False (the default)
-        # makes it a binary stream. We set it explicitly so it tracks the
-        # payload type we're about to write.
-        popen_kwargs["text"] = stdin_is_text
+        # Deliberately NOT setting text=True: we normalized to bytes above
+        # so the child's stdin stream is binary. No locale dependency, no
+        # newline translation, byte-exact transmission.
 
     # Use Popen instead of subprocess.run so we can explicitly forward SIGINT
     # to the child and wait for it before propagating KeyboardInterrupt.
@@ -293,11 +302,25 @@ def run(
     # single pipe buffer write, so the write itself won't block either.
     if stdin_payload is not None and proc.stdin is not None:
         try:
-            proc.stdin.write(stdin_payload)  # type: ignore[arg-type]
+            proc.stdin.write(stdin_payload)
+        except BrokenPipeError:
+            # The child exited (or closed its stdin) before we finished
+            # writing. This is a legitimate flow for tools that validate
+            # arguments or environment before consuming stdin, then exit
+            # with a non-zero status. Swallow the write error here and
+            # let the wait path below report the child's real exit code
+            # via CliProcessError -- that message is more actionable than
+            # a BrokenPipeError traceback from the parent.
+            pass
         finally:
-            # Close in a finally so a write failure still sends EOF -- without
-            # it, a child waiting on stdin would hang forever.
-            proc.stdin.close()
+            # Close in a finally so a successful-but-partial write still
+            # sends EOF. Wrap the close in its own try because closing a
+            # pipe whose peer already closed can also raise BrokenPipeError
+            # on some platforms (it's the flush-on-close that fails).
+            try:
+                proc.stdin.close()
+            except BrokenPipeError:
+                pass
 
     returncode = _wait_with_signal_forwarding(proc)
     if returncode != 0:

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -148,10 +148,40 @@ def _wait_with_signal_forwarding(proc: subprocess.Popen) -> int:
 
 
 
+def _validate_stdin_params(
+    stdin_text: str | None, stdin_bytes: bytes | None
+) -> None:
+    """Enforce mutual exclusivity between stdin_text and stdin_bytes.
+
+    WHY two separate kwargs instead of one polymorphic stdin=str|bytes:
+    self-documenting call sites. ``run(cmd, stdin_text=token)`` is
+    unambiguous; ``run(cmd, stdin=token)`` forces the reader to check
+    the type to know whether the child sees text or bytes. Splitting the
+    parameter makes the intent explicit at every call site. The cost is
+    this one-time validation that the caller didn't pass both.
+
+    Args:
+        stdin_text: Text payload for the child's stdin, or None.
+        stdin_bytes: Binary payload for the child's stdin, or None.
+
+    Raises:
+        ValueError: If both parameters are set. Passing neither is fine
+            (it means "don't attach anything to stdin").
+    """
+    if stdin_text is not None and stdin_bytes is not None:
+        raise ValueError(
+            "Pass stdin_text OR stdin_bytes, not both. "
+            "Use stdin_text for UTF-8 strings; use stdin_bytes for raw bytes."
+        )
+
+
 def run(
     cmd: list[str],
     dry_run: bool = False,
     env: dict[str, str] | None = None,
+    *,
+    stdin_text: str | None = None,
+    stdin_bytes: bytes | None = None,
 ) -> subprocess.CompletedProcess | None:
     """Execute a command, streaming output in real-time.
 
@@ -160,6 +190,10 @@ def run(
         dry_run: If True, print the command but don't execute it.
         env: Extra environment variables merged with os.environ. Use this
             for secrets instead of putting them in cmd (argv is visible in ps).
+        stdin_text: If set, pipe this string to the child's stdin (text mode,
+            UTF-8 by default). Mutually exclusive with stdin_bytes.
+        stdin_bytes: If set, pipe these raw bytes to the child's stdin
+            (binary mode). Mutually exclusive with stdin_text.
 
     Returns:
         subprocess.CompletedProcess on success, or None if dry_run=True.
@@ -167,8 +201,29 @@ def run(
     Raises:
         CliProcessError: If the command exits with non-zero status.
         TypeError: If cmd is a string instead of a list.
+        ValueError: If both stdin_text and stdin_bytes are set.
+
+    Passing data on stdin (secrets-via-stdin):
+        Many tools accept a secret on stdin so it never appears in argv
+        (which is visible in ``ps`` output). Common examples:
+
+        - ``wrangler secret put API_KEY`` reads the secret from stdin
+        - ``gh auth login --with-token`` reads the token from stdin
+        - ``docker login --password-stdin`` reads the password from stdin
+
+        Use ``stdin_text`` for UTF-8 text (the common case), or
+        ``stdin_bytes`` for raw binary payloads. Never pass secrets via
+        ``cmd`` (argv is world-readable in ``ps``); prefer ``env`` for
+        env-var-based secrets and ``stdin_text`` for stdin-based ones.
+
+        Example::
+
+            ctx.run(["wrangler", "secret", "put", "API_KEY"], stdin_text=token)
     """
     _validate_cmd(cmd)
+    # Validate stdin mutual exclusivity BEFORE the dry_run short-circuit so
+    # callers catch the programming mistake in both live and dry-run modes.
+    _validate_stdin_params(stdin_text, stdin_bytes)
 
     if dry_run:
         # Log what would have run so dry-run mode is still informative.
@@ -177,11 +232,37 @@ def run(
 
     full_env = _build_env(env)
 
+    # Decide whether we need to attach a stdin pipe. Only one of stdin_text
+    # or stdin_bytes can be set (enforced above); "stdin_payload" captures
+    # whichever one it is, and "stdin_is_text" tells us what mode Popen
+    # should open its stdin stream in.
+    stdin_payload: str | bytes | None
+    if stdin_text is not None:
+        stdin_payload = stdin_text
+        stdin_is_text = True
+    elif stdin_bytes is not None:
+        stdin_payload = stdin_bytes
+        stdin_is_text = False
+    else:
+        stdin_payload = None
+        stdin_is_text = False  # unused when stdin_payload is None
+
+    # Only open a pipe when we actually have data to write. When no stdin
+    # payload is set, we inherit the parent's stdin (the existing behavior)
+    # so interactive tools that read from the TTY still work.
+    popen_kwargs: dict = {"env": full_env, "shell": False}
+    if stdin_payload is not None:
+        popen_kwargs["stdin"] = subprocess.PIPE
+        # text=True makes proc.stdin a text stream; text=False (the default)
+        # makes it a binary stream. We set it explicitly so it tracks the
+        # payload type we're about to write.
+        popen_kwargs["text"] = stdin_is_text
+
     # Use Popen instead of subprocess.run so we can explicitly forward SIGINT
     # to the child and wait for it before propagating KeyboardInterrupt.
     # subprocess.run() has no hook for signal interception.
     try:
-        proc = subprocess.Popen(cmd, env=full_env, shell=False)
+        proc = subprocess.Popen(cmd, **popen_kwargs)
     except FileNotFoundError:
         # The binary doesn't exist. This is a user/environment error (like
         # PrerequisiteError), not a framework bug. Surface it as exit code 1
@@ -191,6 +272,33 @@ def run(
                 returncode=127, cmd=cmd, stderr=f"Command not found: {cmd[0]}"
             )
         )
+
+    # If we opened a stdin pipe, write the payload and close it so the child
+    # sees EOF and can proceed. We do this BEFORE _wait_with_signal_forwarding
+    # so the child isn't blocked waiting for stdin input we haven't sent yet.
+    #
+    # WHY manual write-and-close instead of proc.communicate(input=...):
+    # communicate() internally calls proc.wait(), which bypasses our
+    # _wait_with_signal_forwarding helper and therefore breaks Ctrl-C
+    # SIGINT forwarding to the child. A manual write-then-close keeps the
+    # existing wait path intact -- the child sees the stdin payload and
+    # EOF, and the parent still forwards SIGINT on KeyboardInterrupt.
+    #
+    # Risk: if the child produces a huge stdout/stderr burst while we're
+    # writing to stdin, the OS pipe buffer could fill and deadlock. In
+    # practice, we don't capture stdout/stderr (they inherit the parent's
+    # file descriptors), so the child's output streams freely to the
+    # terminal and never fills a buffer we control. And stdin payloads
+    # for this use case (secrets, tokens) are small enough to fit in a
+    # single pipe buffer write, so the write itself won't block either.
+    if stdin_payload is not None and proc.stdin is not None:
+        try:
+            proc.stdin.write(stdin_payload)  # type: ignore[arg-type]
+        finally:
+            # Close in a finally so a write failure still sends EOF -- without
+            # it, a child waiting on stdin would hang forever.
+            proc.stdin.close()
+
     returncode = _wait_with_signal_forwarding(proc)
     if returncode != 0:
         raise CliProcessError(
@@ -253,6 +361,9 @@ def run_with_confirm(
     yes: bool = False,
     dry_run: bool = False,
     env: dict[str, str] | None = None,
+    *,
+    stdin_text: str | None = None,
+    stdin_bytes: bytes | None = None,
 ) -> subprocess.CompletedProcess | None:
     """Prompt for confirmation, then execute a destructive command.
 
@@ -266,11 +377,28 @@ def run_with_confirm(
         yes: If True, skip the prompt (--yes flag).
         dry_run: If True, print the command but don't execute it.
         env: Extra environment variables merged with os.environ.
+        stdin_text: If set, pipe this string to the child's stdin (text mode).
+            Mutually exclusive with stdin_bytes. See ``run()`` for the
+            secrets-via-stdin pattern this supports.
+        stdin_bytes: If set, pipe these raw bytes to the child's stdin (binary
+            mode). Mutually exclusive with stdin_text.
 
     Returns:
         subprocess.CompletedProcess on success, or None if denied/dry-run.
+
+    Raises:
+        ValueError: If both stdin_text and stdin_bytes are set.
+
+    See Also:
+        ``run()`` -- full documentation of the secrets-via-stdin pattern
+        (``wrangler secret put``, ``gh auth login --with-token``,
+        ``docker login --password-stdin``).
     """
     _validate_cmd(cmd)
+    # Validate stdin arguments here too so callers get the same early
+    # ValueError they'd get from run(), rather than a confusing error that
+    # only surfaces after the confirmation prompt has been answered.
+    _validate_stdin_params(stdin_text, stdin_bytes)
 
     # Delegate to the framework's TTY-aware confirm() from prompts.py.
     # When yes=True, confirm() returns True immediately and skips the prompt.
@@ -279,6 +407,12 @@ def run_with_confirm(
         logger.info("Cancelled: %s", _format_cmd(cmd))
         return None
 
-    # Delegate to run() so dry-run, env passing, and signal forwarding are
-    # handled consistently in one place.
-    return run(cmd, dry_run=dry_run, env=env)
+    # Delegate to run() so dry-run, env passing, stdin piping, and signal
+    # forwarding are all handled consistently in one place.
+    return run(
+        cmd,
+        dry_run=dry_run,
+        env=env,
+        stdin_text=stdin_text,
+        stdin_bytes=stdin_bytes,
+    )

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -220,7 +220,11 @@ def run(
         ``cmd`` (argv is world-readable in ``ps``); prefer ``env`` for
         env-var-based secrets and ``stdin_text`` for stdin-based ones.
 
-        Example::
+        Example (calling this module-level function directly)::
+
+            run(["wrangler", "secret", "put", "API_KEY"], stdin_text=token)
+
+        Via CliContext::
 
             ctx.run(["wrangler", "secret", "put", "API_KEY"], stdin_text=token)
     """
@@ -368,8 +372,12 @@ def run(
             # already closed.)
             try:
                 proc.stdin.close()
-            except (BrokenPipeError, ValueError):
-                # ValueError: stdin already closed by the KI branch.
+            except (BrokenPipeError, OSError, ValueError):
+                # BrokenPipeError / OSError: child already closed its side
+                # of the pipe (race, fast exit, etc.).
+                # ValueError: stdin already closed by the KI branch above.
+                # In every case, the semantic goal (send EOF; don't mask
+                # the real exit code) is already satisfied -- swallow.
                 pass
 
     returncode = _wait_with_signal_forwarding(proc)

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -323,18 +323,40 @@ def run(
             # of exactly when during the call the signal arrived.
             # Without this, the KI would propagate up past ``proc``
             # entirely and leave the child running until OS cleanup.
+            #
+            # Every child-process interaction below is guarded against
+            # ProcessLookupError / OSError because the Ctrl-C could have
+            # arrived right *after* the child already exited on its own
+            # (signals and fast-exiting children race). When that happens
+            # we still want the KeyboardInterrupt to propagate cleanly to
+            # the caller -- not be masked by an ignored "no such process"
+            # error during cleanup.
             try:
                 proc.stdin.close()
-            except BrokenPipeError:
+            except (BrokenPipeError, OSError):
                 pass
-            proc.send_signal(signal.SIGINT)
+            try:
+                proc.send_signal(signal.SIGINT)
+            except (ProcessLookupError, OSError):
+                # Child already exited; SIGINT delivery is moot.
+                pass
             try:
                 proc.wait(timeout=SIGINT_TIMEOUT_SECONDS)
             except subprocess.TimeoutExpired:
                 # Child ignored SIGINT; escalate to SIGKILL so we don't
                 # hang the terminal waiting on a wedged child.
-                proc.kill()
-                proc.wait()
+                try:
+                    proc.kill()
+                except (ProcessLookupError, OSError):
+                    pass
+                try:
+                    proc.wait()
+                except OSError:
+                    pass
+            except OSError:
+                # wait() itself can raise on some platforms if the child
+                # is already gone -- also fine, we're done either way.
+                pass
             raise
         finally:
             # Close in a finally so a successful-but-partial write still

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -452,9 +452,11 @@ def run_with_confirm(
         env: Extra environment variables merged with os.environ.
         stdin_text: If set, encode this string as UTF-8 and pipe the bytes
             to the child's stdin. Mutually exclusive with stdin_bytes.
-            (Implementation note: delegates to ``run()``, which always
-            opens stdin in binary mode and encodes here -- no locale
-            dependency, no newline translation.)
+            (Implementation note: this function delegates to ``run()``,
+            which opens stdin in binary mode and itself encodes
+            ``stdin_text`` to UTF-8 before writing -- so the encoding
+            happens in ``run()``, not here. No locale dependency, no
+            newline translation.)
         stdin_bytes: If set, pipe these raw bytes to the child's stdin.
             Mutually exclusive with stdin_text.
 

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -257,9 +257,12 @@ def run(
     else:
         stdin_payload = None
 
-    # Only open a pipe when we actually have data to write. When no stdin
-    # payload is set, we inherit the parent's stdin (the existing behavior)
-    # so interactive tools that read from the TTY still work.
+    # Only open a pipe when stdin_text or stdin_bytes was provided (even
+    # if the resulting payload is an empty string/bytes -- that's a valid
+    # "send immediate EOF" case, e.g. for a command that wants to see
+    # closed stdin as a signal). When neither was provided, we inherit
+    # the parent's stdin (the existing behavior) so interactive tools
+    # that read from the TTY still work.
     popen_kwargs: dict = {"env": full_env, "shell": False}
     if stdin_payload is not None:
         popen_kwargs["stdin"] = subprocess.PIPE
@@ -312,14 +315,39 @@ def run(
             # via CliProcessError -- that message is more actionable than
             # a BrokenPipeError traceback from the parent.
             pass
+        except KeyboardInterrupt:
+            # User pressed Ctrl-C while we were still writing stdin. Do
+            # the same SIGINT-forward + wait-with-escalation dance that
+            # ``_wait_with_signal_forwarding`` does when it catches KI
+            # mid-wait, so the child gets a chance to clean up regardless
+            # of exactly when during the call the signal arrived.
+            # Without this, the KI would propagate up past ``proc``
+            # entirely and leave the child running until OS cleanup.
+            try:
+                proc.stdin.close()
+            except BrokenPipeError:
+                pass
+            proc.send_signal(signal.SIGINT)
+            try:
+                proc.wait(timeout=SIGINT_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                # Child ignored SIGINT; escalate to SIGKILL so we don't
+                # hang the terminal waiting on a wedged child.
+                proc.kill()
+                proc.wait()
+            raise
         finally:
             # Close in a finally so a successful-but-partial write still
             # sends EOF. Wrap the close in its own try because closing a
             # pipe whose peer already closed can also raise BrokenPipeError
             # on some platforms (it's the flush-on-close that fails).
+            # (The KeyboardInterrupt branch above already closes before
+            # raising; this finally is a no-op there because stdin is
+            # already closed.)
             try:
                 proc.stdin.close()
-            except BrokenPipeError:
+            except (BrokenPipeError, ValueError):
+                # ValueError: stdin already closed by the KI branch.
                 pass
 
     returncode = _wait_with_signal_forwarding(proc)
@@ -400,11 +428,13 @@ def run_with_confirm(
         yes: If True, skip the prompt (--yes flag).
         dry_run: If True, print the command but don't execute it.
         env: Extra environment variables merged with os.environ.
-        stdin_text: If set, pipe this string to the child's stdin (text mode).
-            Mutually exclusive with stdin_bytes. See ``run()`` for the
-            secrets-via-stdin pattern this supports.
-        stdin_bytes: If set, pipe these raw bytes to the child's stdin (binary
-            mode). Mutually exclusive with stdin_text.
+        stdin_text: If set, encode this string as UTF-8 and pipe the bytes
+            to the child's stdin. Mutually exclusive with stdin_bytes.
+            (Implementation note: delegates to ``run()``, which always
+            opens stdin in binary mode and encodes here -- no locale
+            dependency, no newline translation.)
+        stdin_bytes: If set, pipe these raw bytes to the child's stdin.
+            Mutually exclusive with stdin_text.
 
     Returns:
         subprocess.CompletedProcess on success, or None if denied/dry-run.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -350,6 +350,82 @@ class TestConvenienceMethods:
         assert result.exit_code == 0
         assert all(received.values()), f"Some methods not bound: {received}"
 
+    def test_ctx_run_forwards_stdin_text(self, tmp_path: Path, capfd):
+        """ctx.run(stdin_text=...) must forward the payload through to process.run().
+
+        WHY this test exists (in addition to the process.run()-level tests in
+        test_process.py): the ctx.run/ctx.run_with_confirm bindings in
+        create_cli() are forwarding lambdas that could silently swallow the
+        new kwargs on a bad refactor. Unit-testing the ctx level directly
+        via CliRunner pins the forwarding contract separately from the
+        process-layer tests.
+        """
+        from clickwork.cli import create_cli
+
+        received = {}
+
+        @click.command()
+        @click.pass_obj
+        def echo_stdin(ctx):
+            # Round-trip a payload through the child's stdin using
+            # sys.executable so the test is portable across OSes.
+            result = ctx.run(
+                [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())"],
+                stdin_text="ctx-forwarded-token",
+            )
+            received["returncode"] = result.returncode if result is not None else None
+
+        cmd_dir = tmp_path / "commands"
+        cmd_dir.mkdir()
+
+        cli = create_cli(name="test-cli", commands_dir=cmd_dir)
+        cli.add_command(echo_stdin)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["echo-stdin"])
+        assert result.exit_code == 0, f"CLI failed: {result.output!r}"
+        assert received["returncode"] == 0
+        captured = capfd.readouterr()
+        assert captured.out == "ctx-forwarded-token", (
+            f"Expected stdin payload to round-trip through ctx.run; got {captured.out!r}"
+        )
+
+    def test_ctx_run_with_confirm_forwards_stdin_text(self, tmp_path: Path, capfd):
+        """ctx.run_with_confirm(stdin_text=...) must also forward.
+
+        Same rationale as test_ctx_run_forwards_stdin_text, but covers the
+        other forwarding lambda. yes=True short-circuits the prompt so the
+        test is non-interactive.
+        """
+        from clickwork.cli import create_cli
+
+        received = {}
+
+        @click.command()
+        @click.pass_obj
+        def echo_stdin_confirm(ctx):
+            result = ctx.run_with_confirm(
+                [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())"],
+                "Round-trip a stdin payload?",
+                stdin_text="confirm-token",
+            )
+            received["returncode"] = result.returncode if result is not None else None
+
+        cmd_dir = tmp_path / "commands"
+        cmd_dir.mkdir()
+
+        cli = create_cli(name="test-cli", commands_dir=cmd_dir)
+        cli.add_command(echo_stdin_confirm)
+
+        runner = CliRunner()
+        # --yes bypasses the confirmation prompt that run_with_confirm would
+        # otherwise block on.
+        result = runner.invoke(cli, ["--yes", "echo-stdin-confirm"])
+        assert result.exit_code == 0, f"CLI failed: {result.output!r}"
+        assert received["returncode"] == 0
+        captured = capfd.readouterr()
+        assert captured.out == "confirm-token"
+
     def test_ctx_run_respects_dry_run(self, tmp_path: Path):
         """ctx.run() in dry-run mode should not execute the command (returns None).
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -101,7 +101,19 @@ class TestRun:
             run(["definitely-not-a-real-binary-xyz123"])
 
     def test_run_with_stdin_text_delivers_value(self, capfd):
-        """stdin_text should be piped to the child process as a text stream.
+        """stdin_text should be UTF-8 encoded and piped to the child's stdin.
+
+        Implementation detail pinned here for future readers: run() always
+        opens the child's stdin pipe in **binary** mode and encodes
+        stdin_text to UTF-8 itself. We do NOT use ``Popen(text=True)``
+        because that would pick up the platform locale encoding and could
+        apply Windows "\\n" -> "\\r\\n" newline translation -- both of
+        which silently corrupt secret/token payloads. See the WHY-always-
+        bytes comment in process.py.
+
+        The child-side Python here uses ``sys.stdin.read()`` which decodes
+        using the child's locale. Since our payload "hello" is pure ASCII,
+        the round-trip is lossless regardless of what that locale is.
 
         WHY: this is the primary use case for secret-via-stdin tools like
         ``wrangler secret put``, ``gh auth login --with-token``, and

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -100,6 +100,89 @@ class TestRun:
         with pytest.raises(CliProcessError, match="Command not found"):
             run(["definitely-not-a-real-binary-xyz123"])
 
+    def test_run_with_stdin_text_delivers_value(self, capfd):
+        """stdin_text should be piped to the child process as a text stream.
+
+        WHY: this is the primary use case for secret-via-stdin tools like
+        ``wrangler secret put``, ``gh auth login --with-token``, and
+        ``docker login --password-stdin`` -- pass the secret on stdin so
+        it never appears in argv (which is visible in ``ps`` output).
+        """
+        from clickwork.process import run
+
+        # Child process echoes its stdin to stdout. We then use capfd to
+        # confirm the child actually received "hello" over its stdin pipe.
+        result = run(
+            [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())"],
+            stdin_text="hello",
+        )
+        assert result.returncode == 0
+        captured = capfd.readouterr()
+        assert captured.out == "hello"
+
+    def test_run_with_stdin_bytes_delivers_value(self, capfdbinary):
+        """stdin_bytes should be piped to the child process as a binary stream.
+
+        WHY: some tools want raw bytes on stdin (e.g., binary tokens, keys
+        with non-UTF-8 encodings). Keeping a distinct ``stdin_bytes`` kwarg
+        -- rather than overloading ``stdin_text`` with ``str | bytes`` --
+        makes the mode explicit at the call site.
+        """
+        from clickwork.process import run
+
+        # Child echoes raw bytes from stdin to stdout via the binary buffer
+        # so byte-for-byte fidelity is preserved across the pipe boundary.
+        result = run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.buffer.write(sys.stdin.buffer.read())",
+            ],
+            stdin_bytes=b"world",
+        )
+        assert result.returncode == 0
+        captured = capfdbinary.readouterr()
+        assert captured.out == b"world"
+
+    def test_run_rejects_both_stdin_text_and_stdin_bytes(self):
+        """Passing both stdin_text and stdin_bytes is a programming error.
+
+        WHY: there's no coherent semantics for "text and bytes at the same
+        time" -- the caller clearly meant one or the other. Raise early
+        with a ValueError so the mistake surfaces immediately, rather than
+        silently picking one and dropping the other.
+        """
+        from clickwork.process import run
+
+        with pytest.raises(ValueError, match="stdin_text.*stdin_bytes"):
+            run(
+                [sys.executable, "-c", "pass"],
+                stdin_text="hello",
+                stdin_bytes=b"world",
+            )
+
+    def test_run_stdin_text_dry_run_does_not_execute(self):
+        """With dry_run=True, stdin_text must NOT trigger process execution.
+
+        WHY: dry-run should be safe even when callers pass a real secret as
+        stdin_text. If dry-run spawned the process (just to feed it stdin)
+        it could leak the secret into the child -- which is the exact
+        behavior dry-run is supposed to prevent.
+        """
+        from clickwork.process import run
+
+        # Sentinel: if the child actually runs, it exits 1, which would
+        # raise CliProcessError. Dry-run must short-circuit before that.
+        with patch("subprocess.Popen") as mock_popen:
+            result = run(
+                [sys.executable, "-c", "import sys; sys.exit(1)"],
+                dry_run=True,
+                stdin_text="secret-value",
+            )
+
+        assert result is None
+        mock_popen.assert_not_called()
+
 
 class TestFormatCmd:
     """_format_cmd() renders an argv list as a display string."""
@@ -219,3 +302,46 @@ class TestRunWithConfirm:
             dry_run=True,
         )
         assert result is None
+
+    def test_stdin_text_happy_path(self, capfd):
+        """run_with_confirm should forward stdin_text to the child process.
+
+        WHY: destructive commands that consume secrets on stdin (e.g., a
+        "rotate production token" workflow using ``wrangler secret put``)
+        still want the confirmation prompt. Forwarding stdin_text from
+        run_with_confirm through to run() keeps the call site symmetric
+        with run() and avoids a second code path for stdin injection.
+        """
+        from clickwork.process import run_with_confirm
+
+        # yes=True skips the prompt entirely so we can isolate the stdin
+        # delivery behavior from the confirmation logic.
+        result = run_with_confirm(
+            [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())"],
+            "Rotate production token?",
+            yes=True,
+            stdin_text="s3cret-token",
+        )
+        assert result is not None
+        assert result.returncode == 0
+        captured = capfd.readouterr()
+        assert captured.out == "s3cret-token"
+
+    def test_rejects_both_stdin_text_and_stdin_bytes(self):
+        """run_with_confirm should also enforce stdin mutual exclusivity.
+
+        WHY: the validation must happen in both public entry points so
+        callers hitting run_with_confirm get the same clear error as
+        callers hitting run() directly -- not a confusing error from
+        deep inside the process machinery.
+        """
+        from clickwork.process import run_with_confirm
+
+        with pytest.raises(ValueError, match="stdin_text.*stdin_bytes"):
+            run_with_confirm(
+                [sys.executable, "-c", "pass"],
+                "Do it?",
+                yes=True,
+                stdin_text="hello",
+                stdin_bytes=b"world",
+            )


### PR DESCRIPTION
## Summary
Adds keyword-only ``stdin_text: str | None`` and ``stdin_bytes: bytes | None`` params to ``ctx.run()`` and ``ctx.run_with_confirm()``. Mutually exclusive (raises ``ValueError`` if both). Unlocks the secrets-via-stdin pattern for tools that accept sensitive input on stdin instead of argv (``wrangler secret put``, ``gh auth login --with-token``, ``docker login --password-stdin``).

**Preserves the existing ``Popen`` + ``_wait_with_signal_forwarding`` path** — does NOT switch to ``subprocess.run(input=...)``, which would regress Ctrl-C SIGINT forwarding. Uses manual ``proc.stdin.write()`` + ``close()`` in a ``try/finally`` so a write error still sends EOF.

Two separate params (rather than one polymorphic ``stdin=``) is deliberate per Wave 1 plan: self-documenting at the call site.

Fixes #10. Gates #11 (secret-passing helper).

## Test plan
- [x] ``test_run_with_stdin_text_delivers_value`` — round-trip via ``sys.executable -c`` stdin-echo
- [x] ``test_run_with_stdin_bytes_delivers_value`` — binary round-trip
- [x] ``test_run_rejects_both_stdin_text_and_stdin_bytes`` — ``ValueError``
- [x] ``test_run_stdin_text_dry_run_does_not_execute`` — secret never reaches a child in dry-run
- [x] ``run_with_confirm`` happy-path + validation mirror
- [x] Full suite: 132 passed (126 baseline + 6 new), zero warnings
- [ ] Manual smoke test via orbit-admin deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)