### PR TITLE
fix: make ctx.require patchable via clickwork.prereqs.require (Fixes #8)

### DIFF
--- a/src/clickwork/_types.py
+++ b/src/clickwork/_types.py
@@ -351,11 +351,11 @@ class CliContext:
 
     Tests can intercept this helper by patching ``clickwork.prereqs.require``
     (the public symbol). The CLI harness binds ``ctx.require`` through a
-    lazy lambda that re-reads the module attribute on every call, so
-    ``unittest.mock.patch("clickwork.prereqs.require")`` transparently takes
-    effect. Prior to issue #8's fix, tests had to reach for the internal
-    ``clickwork.cli._require`` alias; that alias no longer exists -- patch
-    ``clickwork.prereqs.require`` instead.
+    module-level wrapper function that re-reads the module attribute on
+    every call, so ``unittest.mock.patch("clickwork.prereqs.require")``
+    transparently takes effect. Prior to issue #8's fix, tests had to
+    reach for the internal ``clickwork.cli._require`` alias; that alias
+    no longer exists -- patch ``clickwork.prereqs.require`` instead.
     """
 
     confirm: Callable[..., bool] | None = field(

--- a/src/clickwork/_types.py
+++ b/src/clickwork/_types.py
@@ -347,7 +347,15 @@ class CliContext:
     require: Callable[..., None] | None = field(
         default=None, repr=False, compare=False,
     )
-    """Assert that a binary exists on PATH, raising PrerequisiteError if not."""
+    """Assert that a binary exists on PATH, raising PrerequisiteError if not.
+
+    Tests can intercept this helper by patching ``clickwork.prereqs.require``
+    (the public symbol). The CLI harness binds ``ctx.require`` through a
+    lazy lambda that re-reads the module attribute on every call, so
+    ``unittest.mock.patch("clickwork.prereqs.require")`` transparently takes
+    effect -- there is no need to reach for internal symbols like
+    ``clickwork.cli._require`` (issue #8).
+    """
 
     confirm: Callable[..., bool] | None = field(
         default=None, repr=False, compare=False,

--- a/src/clickwork/_types.py
+++ b/src/clickwork/_types.py
@@ -353,8 +353,9 @@ class CliContext:
     (the public symbol). The CLI harness binds ``ctx.require`` through a
     lazy lambda that re-reads the module attribute on every call, so
     ``unittest.mock.patch("clickwork.prereqs.require")`` transparently takes
-    effect -- there is no need to reach for internal symbols like
-    ``clickwork.cli._require`` (issue #8).
+    effect. Prior to issue #8's fix, tests had to reach for the internal
+    ``clickwork.cli._require`` alias; that alias no longer exists -- patch
+    ``clickwork.prereqs.require`` instead.
     """
 
     confirm: Callable[..., bool] | None = field(

--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -338,8 +338,20 @@ def create_cli(
         # WHY not @functools.partial or a closure over a local name: both
         # would also freeze the reference at bind time. The only shape that
         # defers lookup is one that re-reads the module attribute each call,
-        # which this lambda does via ``_prereqs.require``.
-        cli_ctx.require = lambda *args, **kwargs: _prereqs.require(*args, **kwargs)
+        # which this wrapper does via ``_prereqs.require``.
+        #
+        # WHY @functools.wraps(_prereqs.require) on the wrapper: the import-
+        # time reference is used solely to copy the *signature* and docstring
+        # onto the wrapper (via __wrapped__), so ``inspect.signature`` and
+        # IDE tooling show the real ``(binary: str, authenticated: bool = ...)``
+        # parameters rather than the generic ``(*args, **kwargs)``. The
+        # wrapper's *body* still goes through ``_prereqs.require`` on every
+        # call, so patching remains effective.
+        @functools.wraps(_prereqs.require)
+        def _require_via_prereqs(*args, **kwargs):
+            return _prereqs.require(*args, **kwargs)
+
+        cli_ctx.require = _require_via_prereqs
 
         # confirm() and confirm_destructive() close over yes so --yes propagates.
         cli_ctx.confirm = lambda msg: _confirm(msg, yes=cli_ctx.yes)

--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -38,6 +38,33 @@ EXIT_USER_ERROR = 1
 EXIT_FRAMEWORK_ERROR = 2
 
 
+# Module-level wrapper for the lazy require binding (issue #8).
+#
+# WHY defined here and not inside create_cli(): the inner cli_group()
+# factory runs every time the CLI is constructed, and defining a new
+# wrapper function object there creates needless per-invocation garbage.
+# A single module-level wrapper is created exactly once, and every
+# CliContext reuses the same object.
+#
+# WHY a wrapper function that dispatches through _prereqs.require at call
+# time, rather than binding cli_ctx.require to _prereqs.require directly:
+# binding the imported reference freezes it at import time, so tests that
+# do ``patch("clickwork.prereqs.require")`` silently have no effect -- the
+# CliContext already holds the original function. Resolving the attribute
+# through the ``_prereqs`` module object on every call means the patched
+# function is picked up naturally, matching what test authors expect.
+#
+# WHY @functools.wraps(_prereqs.require): copies the signature and docstring
+# from the import-time reference onto the wrapper (via __wrapped__), so
+# ``inspect.signature(ctx.require)`` shows the real
+# ``(binary: str, authenticated: bool = ...)`` parameters and IDE tooling
+# can introspect it. The wrapper's *body* still goes through
+# ``_prereqs.require`` on every call, so patching remains effective.
+@functools.wraps(_prereqs.require)
+def _require_via_prereqs(*args, **kwargs):
+    return _prereqs.require(*args, **kwargs)
+
+
 class MutuallyExclusive(click.Option):
     """Click option that is mutually exclusive with another option.
 
@@ -325,32 +352,10 @@ def create_cli(
 
         # require() has no dry_run / yes concept -- it's always a live check.
         # The call site is ctx.require("docker") not ctx.require("docker", dry_run=...).
-        #
-        # WHY a lambda that looks up prereqs.require at call time instead of
-        # capturing the imported function directly (issue #8): binding
-        # ``cli_ctx.require = _require`` freezes the reference at import time,
-        # so tests that do ``patch("clickwork.prereqs.require")`` silently
-        # have no effect -- the CliContext already holds the original
-        # function. Resolving the attribute through the ``_prereqs`` module
-        # object on every call means the patched function is picked up
-        # naturally, matching what test authors expect.
-        #
-        # WHY not @functools.partial or a closure over a local name: both
-        # would also freeze the reference at bind time. The only shape that
-        # defers lookup is one that re-reads the module attribute each call,
-        # which this wrapper does via ``_prereqs.require``.
-        #
-        # WHY @functools.wraps(_prereqs.require) on the wrapper: the import-
-        # time reference is used solely to copy the *signature* and docstring
-        # onto the wrapper (via __wrapped__), so ``inspect.signature`` and
-        # IDE tooling show the real ``(binary: str, authenticated: bool = ...)``
-        # parameters rather than the generic ``(*args, **kwargs)``. The
-        # wrapper's *body* still goes through ``_prereqs.require`` on every
-        # call, so patching remains effective.
-        @functools.wraps(_prereqs.require)
-        def _require_via_prereqs(*args, **kwargs):
-            return _prereqs.require(*args, **kwargs)
-
+        # Uses the module-level _require_via_prereqs wrapper (defined above)
+        # so patching clickwork.prereqs.require takes effect even though the
+        # binding here looks like a frozen reference. See that wrapper's
+        # comment block for the full "why" (issue #8).
         cli_ctx.require = _require_via_prereqs
 
         # confirm() and confirm_destructive() close over yes so --yes propagates.

--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -21,12 +21,12 @@ from pathlib import Path
 
 import click
 
+from clickwork import prereqs as _prereqs
 from clickwork._logging import setup_logging
 from clickwork._types import CliContext, CliProcessError, PrerequisiteError, normalize_prefix
 from clickwork.config import ConfigError, load_config
 from clickwork.discovery import discover_commands
 from clickwork.process import capture as _capture, run as _run, run_with_confirm as _run_with_confirm
-from clickwork.prereqs import require as _require
 from clickwork.prompts import confirm as _confirm, confirm_destructive as _confirm_destructive
 
 
@@ -324,9 +324,22 @@ def create_cli(
         cli_ctx.capture = lambda cmd, env=None: _capture(cmd, dry_run=cli_ctx.dry_run, env=env)
 
         # require() has no dry_run / yes concept -- it's always a live check.
-        # We bind it directly so the call site is ctx.require("docker") not
-        # ctx.require("docker", dry_run=...).
-        cli_ctx.require = _require
+        # The call site is ctx.require("docker") not ctx.require("docker", dry_run=...).
+        #
+        # WHY a lambda that looks up prereqs.require at call time instead of
+        # capturing the imported function directly (issue #8): binding
+        # ``cli_ctx.require = _require`` freezes the reference at import time,
+        # so tests that do ``patch("clickwork.prereqs.require")`` silently
+        # have no effect -- the CliContext already holds the original
+        # function. Resolving the attribute through the ``_prereqs`` module
+        # object on every call means the patched function is picked up
+        # naturally, matching what test authors expect.
+        #
+        # WHY not @functools.partial or a closure over a local name: both
+        # would also freeze the reference at bind time. The only shape that
+        # defers lookup is one that re-reads the module attribute each call,
+        # which this lambda does via ``_prereqs.require``.
+        cli_ctx.require = lambda *args, **kwargs: _prereqs.require(*args, **kwargs)
 
         # confirm() and confirm_destructive() close over yes so --yes propagates.
         cli_ctx.confirm = lambda msg: _confirm(msg, yes=cli_ctx.yes)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,6 +11,7 @@ Test structure:
 - TestPassCliContextDecorator: tests the @pass_cli_context decorator
 """
 from pathlib import Path
+from unittest.mock import patch
 import sys
 
 import click
@@ -377,6 +378,71 @@ class TestConvenienceMethods:
         result = runner.invoke(cli, ["--dry-run", "check"])
         assert result.exit_code == 0
         assert received["result"] is None
+
+
+class TestRequireMockPatchable:
+    """ctx.require() must be patchable via clickwork.prereqs.require (issue #8).
+
+    WHY this class exists: before the fix for issue #8, create_cli() bound
+    ``cli_ctx.require = _require`` where ``_require`` was imported at module
+    load time (``from clickwork.prereqs import require as _require``). That
+    snapshot meant ``patch("clickwork.prereqs.require")`` in a test had no
+    effect on ``ctx.require`` -- the CliContext already held the original
+    function reference. Users had to reach for the internal
+    ``clickwork.cli._require`` symbol, which is an implementation detail.
+
+    These tests pin the correct behaviour: patching the *public* module
+    attribute ``clickwork.prereqs.require`` intercepts ``ctx.require(...)``
+    calls made from inside a command.
+    """
+
+    def test_ctx_require_is_patchable_via_prereqs_module(self, tmp_path: Path):
+        """Patching clickwork.prereqs.require must intercept ctx.require().
+
+        WHY this matters: plugin authors writing tests for commands that
+        guard on ``ctx.require("docker")`` expect the natural
+        ``patch("clickwork.prereqs.require")`` to work. If the binding is
+        eager (module-level import captured at factory time), the patch
+        silently no-ops and the test either passes for the wrong reason or
+        fails because the real tool is present/absent on the test machine.
+
+        We assert the mock was called -- not the return value -- because the
+        test contract is "the framework routed the call through the patched
+        symbol", not "require returned X".
+        """
+        from clickwork.cli import create_cli
+
+        @click.command()
+        @click.pass_obj
+        def needs_git(ctx):
+            # Call ctx.require the same way a real command would.
+            # With the patch active, this should route through the mock
+            # rather than the real prereqs.require (which would consult PATH).
+            ctx.require("git")
+
+        cmd_dir = tmp_path / "commands"
+        cmd_dir.mkdir()
+
+        cli = create_cli(name="test-cli", commands_dir=cmd_dir)
+        cli.add_command(needs_git)
+
+        runner = CliRunner()
+        # Patch the PUBLIC symbol users reach for. If ctx.require is bound
+        # eagerly at factory time, this patch will not take effect and the
+        # test will fail (either because the real require runs, or because
+        # mock_req.called stays False).
+        with patch("clickwork.prereqs.require") as mock_req:
+            result = runner.invoke(cli, ["needs-git"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_req.called, (
+            "Expected clickwork.prereqs.require to be called via ctx.require(), "
+            "but the mock was never invoked -- ctx.require is likely bound to "
+            "a pre-import snapshot of the function (issue #8)."
+        )
+        # Double-check the call argument so a future regression that only
+        # forwards *some* calls (e.g. unconditionally eats them) is caught.
+        mock_req.assert_called_once_with("git")
 
 
 class TestFrameworkErrorHandling:


### PR DESCRIPTION
## Summary
Makes ``patch("clickwork.prereqs.require")`` work as users intuitively expect — previously tests had to patch the internal name ``clickwork.cli._require`` because the original import-time binding captured the function reference before any test mock could take effect.

**Approach: lambda (deferred lookup) rather than @property.** ``CliContext.require`` is a dataclass field with an existing test (``test_callable_fields_default_to_none``) asserting the default is ``None`` for a bare ``CliContext()``; a property would either break that test or force a wider dataclass restructure the plan forbids.

Fixes #8.

## Test plan
- [x] ``TestRequireMockPatchable::test_ctx_require_is_patchable_via_prereqs_module`` — builds a CLI with a command that calls ``ctx.require("git")``, wraps in ``patch("clickwork.prereqs.require")``, asserts ``mock_req.assert_called_once_with("git")``
- [x] Full suite: 127 passed (126 baseline + 1 new), zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)