### PR TITLE
feat: add clickwork.config.load_env_file() dotenv helper (Fixes #9)

### DIFF
--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -122,7 +122,7 @@ def _load_toml_from_bytes(data: bytes) -> dict:
 
 
 def _check_owner_only_permissions(fd: int, path: Path, kind: str) -> None:
-    """Raise ConfigError if the file behind ``fd`` is readable by group/others.
+    """Raise ConfigError unless the file behind ``fd`` is owner-only (chmod 600).
 
     Factored out of the user-config reader so the same permission guard can
     be reused by any secrets-bearing file (user config TOML, .env dotenv
@@ -150,8 +150,13 @@ def _check_owner_only_permissions(fd: int, path: Path, kind: str) -> None:
             caller sees which file failed the check.
 
     Raises:
-        ConfigError: If the file is readable by group or other users
-            (i.e., mode bits include S_IRGRP or S_IROTH).
+        ConfigError: If ANY group or other permission bits are set on the
+            file (read, write, OR execute). A group-writable file is a
+            tampering risk even when not group-readable, so the rejection
+            matches the "chmod 600" remediation -- owner rwx only, every
+            other bit off. The check looks at
+            ``stat.S_IRWXG | stat.S_IRWXO`` rather than just the read
+            bits for this reason.
     """
     # Skip the check entirely on Windows -- POSIX mode bits are meaningless
     # there, and fstat() on Windows typically returns 0o666 for any file.
@@ -160,8 +165,6 @@ def _check_owner_only_permissions(fd: int, path: Path, kind: str) -> None:
 
     st = os.fstat(fd)
     mode = stat.S_IMODE(st.st_mode)
-    # S_IRGRP = group-read bit, S_IROTH = other-read bit. Either being set
-    # means the file is too permissive for secrets.
     # Reject ANY group/other permission bits (not just read). A file with
     # mode 0o620 (owner rw, group w, other ---) has group-write, which
     # means another user could *tamper* with our secrets file -- still a
@@ -262,10 +265,13 @@ def load_env_file(path: Path) -> dict[str, str]:
     without reading the parser.
 
     Security: the file must be owner-only (``chmod 600``) on POSIX
-    platforms. Because ``.env`` files typically hold secrets, looser
-    permissions (anything readable by group or other) raise ConfigError.
-    On Windows the check is skipped -- POSIX mode bits do not apply there,
-    and callers are expected to protect the file via NTFS ACLs instead.
+    platforms. Because ``.env`` files typically hold secrets, any
+    group or other permission bit (read, write, OR execute) raises
+    ConfigError -- not just group/other readability. A group-writable
+    file is a tampering risk even when not group-readable, so the
+    rejection matches what ``chmod 600`` actually enforces. On Windows
+    the check is skipped -- POSIX mode bits do not apply there, and
+    callers are expected to protect the file via NTFS ACLs instead.
 
     Example usage::
 

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -404,12 +404,17 @@ def load_env_file(path: Path) -> dict[str, str]:
                 f"{path}: line {lineno}: empty key (missing name before '=')"
             )
 
-        # Strip ONE layer of leading whitespace from the value before
-        # looking for quotes. Common dotenv forms like ``KEY = value`` or
+        # Strip leading whitespace from the value before looking for
+        # quotes. Common dotenv forms like ``KEY = value`` or
         # ``KEY= "value"`` would otherwise produce values like ``" value"``
         # (with a real leading space) or leave the surrounding quotes
-        # intact (because value[0] is a space, not a quote). lstrip()
-        # matches what python-dotenv / direnv / shell-source do in
+        # intact (because value[0] is a space, not a quote). ``lstrip()``
+        # removes ALL leading whitespace characters (spaces, tabs, etc.)
+        # not just one -- but that's correct here: there is no legitimate
+        # dotenv form where "two spaces before the value" means anything
+        # different from "one space before the value", and quoted values
+        # still preserve their own internal whitespace. Matches what
+        # python-dotenv / direnv / shell-source do in
         # practice, while still letting QUOTED values preserve their own
         # leading whitespace:
         #   KEY = "  value"   -> value becomes "  value" (inside quotes)

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -152,11 +152,13 @@ def _check_owner_only_permissions(fd: int, path: Path, kind: str) -> None:
     Raises:
         ConfigError: If ANY group or other permission bits are set on the
             file (read, write, OR execute). A group-writable file is a
-            tampering risk even when not group-readable, so the rejection
-            matches the "chmod 600" remediation -- owner rwx only, every
-            other bit off. The check looks at
-            ``stat.S_IRWXG | stat.S_IRWXO`` rather than just the read
-            bits for this reason.
+            tampering risk even when not group-readable, so the check
+            covers all three bit classes for group/other rather than
+            just read bits. Owner bits are NOT constrained -- the helper
+            only cares that no one *else* can access the file; owner
+            execute (or setuid, etc.) is the caller's problem. This
+            matches the standard "chmod 600" remediation, which clears
+            every bit except owner read/write.
     """
     # Skip the check entirely on Windows -- POSIX mode bits are meaningless
     # there, and fstat() on Windows typically returns 0o666 for any file.
@@ -206,8 +208,11 @@ def _read_checked_user_config(path: Path) -> bytes | None:
         or None if the file does not exist.
 
     Raises:
-        ConfigError: If the file exists and is readable by group or other
-            users (i.e., mode bits include S_IRGRP or S_IROTH).
+        ConfigError: If the file exists and has ANY group/other permission
+            bit set (read, write, or execute). See
+            ``_check_owner_only_permissions`` for the precise rule --
+            this helper delegates the check there, so when the rule
+            tightens the behaviour here tightens too.
     """
     # Open the file first, then stat the open fd (TOCTOU-safe).
     # FileNotFoundError is caught instead of a pre-check with path.is_file()

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -18,6 +18,7 @@ is refused (not just warned) to prevent secret leakage.
 from __future__ import annotations
 
 import os
+import shlex
 import stat
 import sys
 from pathlib import Path
@@ -162,10 +163,14 @@ def _check_owner_only_permissions(fd: int, path: Path, kind: str) -> None:
     # S_IRGRP = group-read bit, S_IROTH = other-read bit. Either being set
     # means the file is too permissive for secrets.
     if mode & (stat.S_IRGRP | stat.S_IROTH):
+        # Shell-quote the path in the remediation hint so paths with
+        # spaces or leading '-' characters remain safe to copy/paste into
+        # a terminal. shlex.quote() wraps the string in single quotes
+        # when needed and leaves safe paths unchanged.
         raise ConfigError(
             f"{kind} {path} has unsafe permission {oct(mode)} "
             f"(readable by group/others). Secrets may be exposed.\n"
-            f"Fix with: chmod 600 {path}"
+            f"Fix with: chmod 600 {shlex.quote(str(path))}"
         )
 
 
@@ -275,14 +280,19 @@ def load_env_file(path: Path) -> dict[str, str]:
 
     Returns:
         Dict mapping keys to their (possibly unquoted) string values.
-        Insertion order matches the order keys appear in the file.
+        Insertion order matches the order each key *first* appears in
+        the file. If the file contains the same key twice, the later
+        value overwrites the earlier one but the dict slot stays at
+        the first occurrence's position -- if caller cares about order,
+        they should ensure no duplicate keys in the file.
 
     Raises:
         FileNotFoundError: If ``path`` does not exist.
         ConfigError: If the file has unsafe permissions (POSIX only), or
-            if any line is malformed (missing ``=`` separator). Malformed-
-            line errors include the 1-based line number so the caller
-            can locate the problem.
+            if any line is malformed -- missing ``=`` separator, or
+            producing an empty key (e.g. ``=value`` or ``export =v``).
+            Malformed-line errors include the 1-based line number so
+            the caller can locate the problem.
     """
     # Open then fstat -- same TOCTOU-safe pattern as _read_checked_user_config.
     # We deliberately do not catch FileNotFoundError: a missing .env is a
@@ -302,9 +312,11 @@ def load_env_file(path: Path) -> dict[str, str]:
     # error messages -- line 1 in the error should match line 1 in the file.
     for lineno, raw_line in enumerate(text.splitlines(), start=1):
         # Strip surrounding whitespace once; we'll work with the trimmed
-        # form from here on. This also normalizes trailing "\r" from
-        # CRLF files (universal-newline mode strips the "\n" but leaves "\r"
-        # when the file mixes line endings).
+        # form from here on. (Python text mode with default newline=None
+        # already normalizes "\r\n" and bare "\r" to "\n" via universal
+        # newlines, so we don't need to worry about stray carriage
+        # returns; .strip() is purely for leading/trailing spaces and
+        # tabs from hand-edited files.)
         line = raw_line.strip()
 
         # Skip blank lines and full-line comments. These two branches are
@@ -335,6 +347,15 @@ def load_env_file(path: Path) -> dict[str, str]:
         # We already stripped the whole line above, so key.strip() on top of
         # that is cheap and defensive against 'KEY =value' style spacing.
         key = key.strip()
+
+        # Empty-key guard: '=value' or 'export =value' would otherwise
+        # produce {"": "value"}, which is never a valid environment
+        # variable name and will blow up later when passed to
+        # subprocess/os.environ. Fail early with a clear line number.
+        if not key:
+            raise ConfigError(
+                f"line {lineno}: empty key (missing name before '='): {raw_line!r}"
+            )
 
         # Unwrap matching surrounding quotes. We only strip quotes when the
         # entire value is wrapped -- a value like 'foo"bar' stays literal.

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -259,7 +259,8 @@ def load_env_file(path: Path) -> dict[str, str]:
           ``"$OTHER"``; nothing is resolved from ``os.environ`` or from
           earlier entries in the file. If you need shell semantics, use
           ``sh -c 'set -a; source .env; env'`` and capture stdout.
-        * Backticks / command substitution (``K=`date```).
+        * Backticks / command substitution (e.g. ``K=$(date)`` or the
+          backtick form).
         * Heredocs and multi-line values.
         * Inline trailing comments (``K=val # comment`` is parsed as
           ``K`` -> ``"val # comment"`` because the literal '#' is part of
@@ -322,7 +323,13 @@ def load_env_file(path: Path) -> dict[str, str]:
     with os.fdopen(fd, "r", encoding="utf-8") as f:
         # Reuse the exact permission check (including the Windows carve-out)
         # used by user config. See _check_owner_only_permissions for details.
-        _check_owner_only_permissions(fd, path, kind=".env file")
+        #
+        # WHY path.name in the kind label: callers pass real files like
+        # .cf-secrets, .envrc, api-creds.env etc. Hardcoding ".env file"
+        # in the error would mislead the user about which file the
+        # check failed on. Using the actual filename makes the "Fix with:
+        # chmod 600 <path>" remediation unambiguous.
+        _check_owner_only_permissions(fd, path, kind=f"dotenv file {path.name!r}")
         text = f.read()
 
     result: dict[str, str] = {}

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -339,10 +339,9 @@ def load_env_file(path: Path) -> dict[str, str]:
         #
         # The shared helper already formats errors as
         # "{kind} {path} ..." so we only need to pass a generic
-        # category label here; the path itself comes from the
-        # helper's own interpolation. Keeping kind short avoids the
-        # "dotenv file '.env' /tmp/.../.env ..." double-labelling
-        # Copilot caught.
+        # category label here; the path itself is interpolated by
+        # the helper. Keeping kind short avoids double-labelling like
+        # "dotenv file '.env' /tmp/.../.env ...".
         _check_owner_only_permissions(fd, path, kind="dotenv file")
         text = f.read()
 
@@ -415,9 +414,14 @@ def load_env_file(path: Path) -> dict[str, str]:
         # leading whitespace:
         #   KEY = "  value"   -> value becomes "  value" (inside quotes)
         #   KEY =   value     -> value becomes "value"   (bare, space stripped)
-        # Trailing whitespace is NOT stripped: .env files seldom have
-        # trailing spaces, and preserving them is safer when someone does
-        # intentionally include one.
+        # Trailing whitespace of the BARE (unquoted) value is already
+        # gone because raw_line.strip() at the top of the loop stripped
+        # both ends of the whole line. That's fine: .env files don't
+        # conventionally carry trailing whitespace in values; anyone
+        # who needs a trailing space can preserve it inside quotes
+        # (the quote-unwrap below runs AFTER the quote characters are
+        # still intact, so "KEY = 'value '" yields "value " with the
+        # intended trailing space).
         value = value.lstrip()
 
         # Unwrap matching surrounding quotes. We only strip quotes when the

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -290,6 +290,7 @@ def load_env_file(path: Path) -> dict[str, str]:
 
     Example usage::
 
+        from pathlib import Path
         from clickwork.config import load_env_file
 
         env = load_env_file(Path(".env"))

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -381,7 +381,7 @@ def load_env_file(path: Path) -> dict[str, str]:
             # output. Just the line number is enough for the caller to
             # open the file and find the bad line.
             raise ConfigError(
-                f"line {lineno}: malformed entry (no '=' separator)"
+                f"{path}: line {lineno}: malformed entry (no '=' separator)"
             )
 
         # Keys are trimmed; values are *not* trimmed beyond outer whitespace.
@@ -397,7 +397,7 @@ def load_env_file(path: Path) -> dict[str, str]:
         # echo the bad line because it may contain secrets.)
         if not key:
             raise ConfigError(
-                f"line {lineno}: empty key (missing name before '=')"
+                f"{path}: line {lineno}: empty key (missing name before '=')"
             )
 
         # Unwrap matching surrounding quotes. We only strip quotes when the

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -122,7 +122,13 @@ def _load_toml_from_bytes(data: bytes) -> dict:
 
 
 def _check_owner_only_permissions(fd: int, path: Path, kind: str) -> None:
-    """Raise ConfigError unless the file behind ``fd`` is owner-only (chmod 600).
+    """Raise ConfigError if the file behind ``fd`` has any group/other perms.
+
+    "Owner-only" in the informal sense: nothing outside the file's owner
+    can read, write, or execute it. The owner's own bits are NOT
+    constrained (so ``0o600``, ``0o700``, ``0o400``, etc. all pass) --
+    the helper is about keeping *other* users out, not about the owner's
+    own mode choices.
 
     Factored out of the user-config reader so the same permission guard can
     be reused by any secrets-bearing file (user config TOML, .env dotenv
@@ -190,8 +196,11 @@ def _read_checked_user_config(path: Path) -> bytes | None:
     """Open, permission-check, and read a user config file in one operation.
 
     User config may contain secrets (API tokens, personal credentials), so
-    it must be owner-only (mode ``0o600``). On Windows this check is skipped
-    because the Unix permission model does not apply.
+    no one but the file's owner may access it. Any group/other permission
+    bit -- read, write, or execute -- raises ConfigError. ``chmod 600`` is
+    the canonical remediation, but ``0o400`` or ``0o700`` also pass the
+    check; only group/other bits are forbidden. On Windows this check is
+    skipped because the Unix permission model does not apply.
 
     The entire open-check-read sequence uses a single file descriptor to
     avoid TOCTOU (time-of-check/time-of-use) races: we open first, then

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -162,14 +162,21 @@ def _check_owner_only_permissions(fd: int, path: Path, kind: str) -> None:
     mode = stat.S_IMODE(st.st_mode)
     # S_IRGRP = group-read bit, S_IROTH = other-read bit. Either being set
     # means the file is too permissive for secrets.
-    if mode & (stat.S_IRGRP | stat.S_IROTH):
+    # Reject ANY group/other permission bits (not just read). A file with
+    # mode 0o620 (owner rw, group w, other ---) has group-write, which
+    # means another user could *tamper* with our secrets file -- still a
+    # compromise even though they can't read it directly. S_IRWXG and
+    # S_IRWXO cover all of read/write/execute for group/other, matching
+    # the "chmod 600" remediation we recommend.
+    if mode & (stat.S_IRWXG | stat.S_IRWXO):
         # Shell-quote the path in the remediation hint so paths with
         # spaces or leading '-' characters remain safe to copy/paste into
         # a terminal. shlex.quote() wraps the string in single quotes
         # when needed and leaves safe paths unchanged.
         raise ConfigError(
             f"{kind} {path} has unsafe permission {oct(mode)} "
-            f"(readable by group/others). Secrets may be exposed.\n"
+            f"(accessible by group/others). Secrets may be exposed or "
+            f"tampered with.\n"
             f"Fix with: chmod 600 {shlex.quote(str(path))}"
         )
 
@@ -339,8 +346,15 @@ def load_env_file(path: Path) -> dict[str, str]:
         if not sep:
             # No '=' in the line -- we can't tell what the caller meant.
             # Refuse rather than silently dropping or misinterpreting.
+            #
+            # WHY we don't echo raw_line in the error: .env files are the
+            # canonical home for secrets (that's the whole point of this
+            # parser). If a malformed line contained a partial secret
+            # assignment, echoing raw_line would leak it into logs/CI
+            # output. Just the line number is enough for the caller to
+            # open the file and find the bad line.
             raise ConfigError(
-                f"line {lineno}: malformed entry (no '=' separator): {raw_line!r}"
+                f"line {lineno}: malformed entry (no '=' separator)"
             )
 
         # Keys are trimmed; values are *not* trimmed beyond outer whitespace.
@@ -352,9 +366,11 @@ def load_env_file(path: Path) -> dict[str, str]:
         # produce {"": "value"}, which is never a valid environment
         # variable name and will blow up later when passed to
         # subprocess/os.environ. Fail early with a clear line number.
+        # (Same no-raw-line policy as the separator error above -- don't
+        # echo the bad line because it may contain secrets.)
         if not key:
             raise ConfigError(
-                f"line {lineno}: empty key (missing name before '='): {raw_line!r}"
+                f"line {lineno}: empty key (missing name before '=')"
             )
 
         # Unwrap matching surrounding quotes. We only strip quotes when the

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -296,8 +296,11 @@ def load_env_file(path: Path) -> dict[str, str]:
         env = load_env_file(Path(".env"))
         # env == {"API_TOKEN": "...", "REGION": "us-east-1"}
 
-        # Pass to a subprocess without mutating the parent environment:
-        ctx.run("./deploy.sh", env={**os.environ, **env})
+        # Pass to a subprocess without mutating the parent environment.
+        # Note the list form: ctx.run (and the underlying subprocess
+        # helpers) reject string commands as a shell-injection guardrail,
+        # so every cmd must be an argv list.
+        ctx.run(["./deploy.sh"], env={**os.environ, **env})
 
         # Or inject into the parent process:
         os.environ.update(env)

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -337,12 +337,13 @@ def load_env_file(path: Path) -> dict[str, str]:
         # Reuse the exact permission check (including the Windows carve-out)
         # used by user config. See _check_owner_only_permissions for details.
         #
-        # WHY path.name in the kind label: callers pass real files like
-        # .cf-secrets, .envrc, api-creds.env etc. Hardcoding ".env file"
-        # in the error would mislead the user about which file the
-        # check failed on. Using the actual filename makes the "Fix with:
-        # chmod 600 <path>" remediation unambiguous.
-        _check_owner_only_permissions(fd, path, kind=f"dotenv file {path.name!r}")
+        # The shared helper already formats errors as
+        # "{kind} {path} ..." so we only need to pass a generic
+        # category label here; the path itself comes from the
+        # helper's own interpolation. Keeping kind short avoids the
+        # "dotenv file '.env' /tmp/.../.env ..." double-labelling
+        # Copilot caught.
+        _check_owner_only_permissions(fd, path, kind="dotenv file")
         text = f.read()
 
     result: dict[str, str] = {}
@@ -403,6 +404,21 @@ def load_env_file(path: Path) -> dict[str, str]:
             raise ConfigError(
                 f"{path}: line {lineno}: empty key (missing name before '=')"
             )
+
+        # Strip ONE layer of leading whitespace from the value before
+        # looking for quotes. Common dotenv forms like ``KEY = value`` or
+        # ``KEY= "value"`` would otherwise produce values like ``" value"``
+        # (with a real leading space) or leave the surrounding quotes
+        # intact (because value[0] is a space, not a quote). lstrip()
+        # matches what python-dotenv / direnv / shell-source do in
+        # practice, while still letting QUOTED values preserve their own
+        # leading whitespace:
+        #   KEY = "  value"   -> value becomes "  value" (inside quotes)
+        #   KEY =   value     -> value becomes "value"   (bare, space stripped)
+        # Trailing whitespace is NOT stripped: .env files seldom have
+        # trailing spaces, and preserving them is safer when someone does
+        # intentionally include one.
+        value = value.lstrip()
 
         # Unwrap matching surrounding quotes. We only strip quotes when the
         # entire value is wrapped -- a value like 'foo"bar' stays literal.

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -120,6 +120,55 @@ def _load_toml_from_bytes(data: bytes) -> dict:
     return tomllib.load(io.BytesIO(data))
 
 
+def _check_owner_only_permissions(fd: int, path: Path, kind: str) -> None:
+    """Raise ConfigError if the file behind ``fd`` is readable by group/others.
+
+    Factored out of the user-config reader so the same permission guard can
+    be reused by any secrets-bearing file (user config TOML, .env dotenv
+    files, etc.) without duplicating the TOCTOU-safe fstat() logic or the
+    Windows carve-out.
+
+    The check uses ``os.fstat(fd)`` (not ``os.stat(path)``) so it operates
+    on the already-opened file descriptor. This closes the TOCTOU
+    (time-of-check/time-of-use) window: an attacker cannot swap the file
+    between permission check and read, because both operate on the same
+    kernel fd.
+
+    On Windows the Unix permission model does not apply (NTFS ACLs use a
+    completely different mechanism), so the check is a no-op there. Callers
+    should still gate file creation on platform-appropriate ACLs; this
+    helper only enforces the POSIX mode-bit portion.
+
+    Args:
+        fd: An open file descriptor to check. The caller retains ownership
+            -- this function does not close it.
+        path: The path used to open ``fd``; only used to build a helpful
+            error message pointing the user at the right file to chmod.
+        kind: Human-readable label for the file type (e.g., "User config",
+            ".env file"). Interpolated into the error message so the
+            caller sees which file failed the check.
+
+    Raises:
+        ConfigError: If the file is readable by group or other users
+            (i.e., mode bits include S_IRGRP or S_IROTH).
+    """
+    # Skip the check entirely on Windows -- POSIX mode bits are meaningless
+    # there, and fstat() on Windows typically returns 0o666 for any file.
+    if sys.platform == "win32":
+        return
+
+    st = os.fstat(fd)
+    mode = stat.S_IMODE(st.st_mode)
+    # S_IRGRP = group-read bit, S_IROTH = other-read bit. Either being set
+    # means the file is too permissive for secrets.
+    if mode & (stat.S_IRGRP | stat.S_IROTH):
+        raise ConfigError(
+            f"{kind} {path} has unsafe permission {oct(mode)} "
+            f"(readable by group/others). Secrets may be exposed.\n"
+            f"Fix with: chmod 600 {path}"
+        )
+
+
 def _read_checked_user_config(path: Path) -> bytes | None:
     """Open, permission-check, and read a user config file in one operation.
 
@@ -158,21 +207,148 @@ def _read_checked_user_config(path: Path) -> bytes | None:
     # short reads internally -- os.read() can return fewer bytes than
     # requested. closefd=True means the file object owns the fd.
     with os.fdopen(fd, "rb") as f:
-        # Skip permission check on Windows where Unix permission bits
-        # are not meaningful.
-        if sys.platform != "win32":
-            st = os.fstat(fd)
-            mode = stat.S_IMODE(st.st_mode)
-            # S_IRGRP = group-read bit, S_IROTH = other-read bit.
-            # Either being set means the file is too permissive for secrets.
-            if mode & (stat.S_IRGRP | stat.S_IROTH):
-                raise ConfigError(
-                    f"User config {path} has unsafe permission {oct(mode)} "
-                    f"(readable by group/others). Secrets may be exposed.\n"
-                    f"Fix with: chmod 600 {path}"
-                )
-
+        # Delegate the permission check to the shared helper so the
+        # dotenv loader and any future secrets-bearing reader can reuse
+        # exactly the same logic (including the Windows carve-out).
+        _check_owner_only_permissions(fd, path, kind="User config")
         return f.read()
+
+
+def load_env_file(path: Path) -> dict[str, str]:
+    """Parse a dotenv-style file into a plain dict of string key/value pairs.
+
+    This is a *standalone* helper -- it is **not** integrated into
+    ``load_config()``. The TOML pipeline handles structured config; this
+    helper covers the separate case where a command needs to source
+    credentials or environment variables from a ``.env`` file and pass
+    them to a subprocess (``ctx.run(env=...)``) or inject them into
+    ``os.environ``.
+
+    Supported syntax (deliberately tiny):
+
+        KEY=value              # simple assignment
+        export KEY=value       # optional shell-style 'export' prefix, stripped
+        KEY="value with ws"    # double-quoted value (quotes stripped)
+        KEY='value with ws'    # single-quoted value (quotes stripped)
+        # full-line comment    # skipped
+        <blank line>           # skipped
+
+    Explicitly **NOT supported** (by design -- do not add these):
+
+        * Variable substitution. ``K=$OTHER`` stores the literal string
+          ``"$OTHER"``; nothing is resolved from ``os.environ`` or from
+          earlier entries in the file. If you need shell semantics, use
+          ``sh -c 'set -a; source .env; env'`` and capture stdout.
+        * Backticks / command substitution (``K=`date```).
+        * Heredocs and multi-line values.
+        * Inline trailing comments (``K=val # comment`` is parsed as
+          ``K`` -> ``"val # comment"`` because the literal '#' is part of
+          the value, not a comment marker).
+
+    These omissions are intentional. A tiny grammar is a feature: it means
+    you can look at a ``.env`` file and know exactly what each line does
+    without reading the parser.
+
+    Security: the file must be owner-only (``chmod 600``) on POSIX
+    platforms. Because ``.env`` files typically hold secrets, looser
+    permissions (anything readable by group or other) raise ConfigError.
+    On Windows the check is skipped -- POSIX mode bits do not apply there,
+    and callers are expected to protect the file via NTFS ACLs instead.
+
+    Example usage::
+
+        from clickwork.config import load_env_file
+
+        env = load_env_file(Path(".env"))
+        # env == {"API_TOKEN": "...", "REGION": "us-east-1"}
+
+        # Pass to a subprocess without mutating the parent environment:
+        ctx.run("./deploy.sh", env={**os.environ, **env})
+
+        # Or inject into the parent process:
+        os.environ.update(env)
+
+    Args:
+        path: Path to the dotenv file to parse. Must exist (unlike user
+            config, a missing .env is an error -- the caller asked for
+            this file by name).
+
+    Returns:
+        Dict mapping keys to their (possibly unquoted) string values.
+        Insertion order matches the order keys appear in the file.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        ConfigError: If the file has unsafe permissions (POSIX only), or
+            if any line is malformed (missing ``=`` separator). Malformed-
+            line errors include the 1-based line number so the caller
+            can locate the problem.
+    """
+    # Open then fstat -- same TOCTOU-safe pattern as _read_checked_user_config.
+    # We deliberately do not catch FileNotFoundError: a missing .env is a
+    # real error for this function (the caller explicitly asked for it),
+    # unlike user config which is optional.
+    fd = os.open(str(path), os.O_RDONLY)
+    # os.fdopen(..., "r") gives us text mode with universal newlines so
+    # Windows CRLF files parse correctly alongside Unix LF files.
+    with os.fdopen(fd, "r", encoding="utf-8") as f:
+        # Reuse the exact permission check (including the Windows carve-out)
+        # used by user config. See _check_owner_only_permissions for details.
+        _check_owner_only_permissions(fd, path, kind=".env file")
+        text = f.read()
+
+    result: dict[str, str] = {}
+    # enumerate(..., start=1) gives 1-based line numbers for human-friendly
+    # error messages -- line 1 in the error should match line 1 in the file.
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        # Strip surrounding whitespace once; we'll work with the trimmed
+        # form from here on. This also normalizes trailing "\r" from
+        # CRLF files (universal-newline mode strips the "\n" but leaves "\r"
+        # when the file mixes line endings).
+        line = raw_line.strip()
+
+        # Skip blank lines and full-line comments. These two branches are
+        # the only lines that do not produce a key/value pair.
+        if not line or line.startswith("#"):
+            continue
+
+        # Strip the optional shell-style 'export ' prefix so the same file
+        # can be consumed by both load_env_file() and 'source .env'.
+        # We match 'export ' with a trailing space to avoid eating the
+        # 'export' portion of a legitimate key like 'exportKEY=v'.
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+
+        # Split on the *first* '=' only. Values may legitimately contain
+        # '=' (e.g., base64-encoded tokens), so str.partition is safer than
+        # str.split('=', 1) because it returns a 3-tuple even when '=' is
+        # absent, which we check for below.
+        key, sep, value = line.partition("=")
+        if not sep:
+            # No '=' in the line -- we can't tell what the caller meant.
+            # Refuse rather than silently dropping or misinterpreting.
+            raise ConfigError(
+                f"line {lineno}: malformed entry (no '=' separator): {raw_line!r}"
+            )
+
+        # Keys are trimmed; values are *not* trimmed beyond outer whitespace.
+        # We already stripped the whole line above, so key.strip() on top of
+        # that is cheap and defensive against 'KEY =value' style spacing.
+        key = key.strip()
+
+        # Unwrap matching surrounding quotes. We only strip quotes when the
+        # entire value is wrapped -- a value like 'foo"bar' stays literal.
+        # This matches the behaviour users expect from a minimal dotenv
+        # parser, without pulling in the full shell-quoting rules.
+        if len(value) >= 2 and (
+            (value[0] == '"' and value[-1] == '"')
+            or (value[0] == "'" and value[-1] == "'")
+        ):
+            value = value[1:-1]
+
+        result[key] = value
+
+    return result
 
 
 def load_config(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -468,3 +468,162 @@ class TestUserConfigPermissions:
             user_config_path=user_config,
         )
         assert config["region"] == "us-east-1"
+
+
+class TestLoadEnvFile:
+    """load_env_file() reads dotenv-style files into a plain dict.
+
+    This helper is intentionally *not* integrated into load_config() -- it
+    is a sibling utility so callers (deploy/release/admin commands) can
+    source credentials from a .env file and pass them to ctx.run(env=...)
+    or inject into os.environ themselves. Keeping it standalone means
+    the TOML pipeline stays focused on structured data, and the dotenv
+    grammar stays deliberately tiny (no variable substitution, no
+    command substitution, no heredocs -- see the module docstring for
+    the explicit out-of-scope list).
+    """
+
+    def test_load_env_file_parses_simple_key_value(self, tmp_path: Path):
+        """The simplest case: one KEY=VALUE line produces one dict entry."""
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("K=v\n")
+        # Owner-only permissions: this file may hold secrets, same treatment
+        # as user config.
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"K": "v"}
+
+    def test_load_env_file_strips_export_prefix(self, tmp_path: Path):
+        """A leading 'export ' (shell-style) is stripped so the same file
+        works with both ``source .env`` and load_env_file()."""
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("export K=v\n")
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"K": "v"}
+
+    def test_load_env_file_handles_double_quotes(self, tmp_path: Path):
+        """Values wrapped in double quotes have the quotes stripped so
+        spaces and other whitespace-adjacent characters survive parsing."""
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text('K="v with spaces"\n')
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"K": "v with spaces"}
+
+    def test_load_env_file_handles_single_quotes(self, tmp_path: Path):
+        """Single quotes are treated identically to double quotes for the
+        purposes of this minimal parser -- the grammar deliberately does
+        not distinguish shell's 'literal vs interpolated' semantics."""
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("K='v'\n")
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"K": "v"}
+
+    def test_load_env_file_skips_comments(self, tmp_path: Path):
+        """Full-line comments (# ...) are skipped; only full-line comments
+        are supported (inline trailing comments are NOT -- see the
+        does_not_expand_variables test for the anti-feature list)."""
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("# this is a comment\nK=v\n")
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"K": "v"}
+
+    def test_load_env_file_skips_blank_lines(self, tmp_path: Path):
+        """Blank lines (whitespace-only or empty) are harmless and ignored."""
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("\n\nK=v\n\n")
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"K": "v"}
+
+    def test_load_env_file_handles_multiple_keys(self, tmp_path: Path):
+        """Multiple KEY=VALUE lines produce multiple dict entries."""
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("A=1\nB=2\nC=3\n")
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"A": "1", "B": "2", "C": "3"}
+
+    def test_load_env_file_raises_on_missing_file(self, tmp_path: Path):
+        """Missing env file is an error -- unlike user config, callers
+        ask for this file by name, so absence is a bug, not a fallback."""
+        from clickwork.config import load_env_file
+
+        # Don't create the file -- load_env_file should raise.
+        # FileNotFoundError bubbles up from os.open; this keeps the
+        # semantics obvious to the caller.
+        with pytest.raises(FileNotFoundError):
+            load_env_file(tmp_path / "missing.env")
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX file-mode semantics don't apply on Windows",
+    )
+    def test_load_env_file_rejects_world_readable_file(self, tmp_path: Path):
+        """A .env file commonly holds secrets; refuse anything looser than 0o600."""
+        import os
+        from clickwork.config import load_env_file, ConfigError
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("K=v\n")
+        os.chmod(env_file, 0o644)  # world-readable
+
+        with pytest.raises(ConfigError, match="permission"):
+            load_env_file(env_file)
+
+    def test_load_env_file_raises_on_malformed_line(self, tmp_path: Path):
+        """A line without '=' is ambiguous -- the parser refuses it rather
+        than silently dropping or misinterpreting. The error message must
+        name the 1-based line number so the caller can locate the problem."""
+        import os
+        from clickwork.config import load_env_file, ConfigError
+
+        env_file = tmp_path / ".env"
+        # Line 1: valid. Line 2: malformed (no '='). Line 3: valid.
+        env_file.write_text("A=1\nBROKEN\nC=3\n")
+        os.chmod(env_file, 0o600)
+
+        with pytest.raises(ConfigError, match="line 2"):
+            load_env_file(env_file)
+
+    def test_load_env_file_does_not_expand_variables(self, tmp_path: Path):
+        """Variable substitution (K=$OTHER) is deliberately unsupported.
+
+        This is an anti-test: the parser stores the literal string '$OTHER'
+        rather than trying to resolve it from os.environ or other entries
+        in the file. If someone "helpfully" adds substitution later, this
+        test will flag it as a breaking change. Callers who want shell
+        semantics should use 'sh -c "set -a; source .env; env"' instead.
+        """
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("K=$OTHER\n")
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"K": "$OTHER"}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -604,6 +604,33 @@ class TestLoadEnvFile:
         with pytest.raises(ConfigError, match="permission"):
             load_env_file(env_file)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX file-mode semantics don't apply on Windows",
+    )
+    def test_load_env_file_rejects_group_writable_file(self, tmp_path: Path):
+        """Group-WRITE alone (0o620) must also fail -- tampering risk.
+
+        WHY: a group-writable secrets file lets another user replace or
+        modify our secrets even when they can't read them directly. The
+        permission guard rejects ANY group/other bit, not just readability.
+        This regression test pins that -- without it, someone could
+        accidentally relax the check back to S_IRGRP|S_IROTH and lose
+        tamper-resistance without any test failing.
+        """
+        import os
+        from clickwork.config import load_env_file, ConfigError
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("K=v\n")
+        # 0o620 = owner rw, group w only, other ---. Not group-readable,
+        # so a pre-tightening check (S_IRGRP | S_IROTH) would let this
+        # through. The current S_IRWXG | S_IRWXO check catches it.
+        os.chmod(env_file, 0o620)
+
+        with pytest.raises(ConfigError, match="permission"):
+            load_env_file(env_file)
+
     def test_load_env_file_raises_on_malformed_line(self, tmp_path: Path):
         """A line without '=' is ambiguous -- the parser refuses it rather
         than silently dropping or misinterpreting. The error message must

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -479,8 +479,9 @@ class TestLoadEnvFile:
     or inject into os.environ themselves. Keeping it standalone means
     the TOML pipeline stays focused on structured data, and the dotenv
     grammar stays deliberately tiny (no variable substitution, no
-    command substitution, no heredocs -- see the module docstring for
-    the explicit out-of-scope list).
+    command substitution, no heredocs -- see the load_env_file()
+    docstring itself for the explicit out-of-scope list; the module
+    docstring on config.py describes TOML layered config, not dotenv).
     """
 
     def test_load_env_file_parses_simple_key_value(self, tmp_path: Path):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -509,6 +509,68 @@ class TestLoadEnvFile:
 
         assert load_env_file(env_file) == {"K": "v"}
 
+    def test_load_env_file_strips_leading_whitespace_around_equals(self, tmp_path: Path):
+        """``KEY = value`` and ``KEY= value`` produce a value without the
+        leading space.
+
+        WHY this regression test exists: the partition-on-'=' parse
+        leaves leading whitespace on the value side for forms like
+        ``KEY = value`` (spaces around '=', a common shape in hand-edited
+        .env files). Without lstrip, the value would be ``" value"`` with
+        a real leading space -- easy to miss and trivial to mangle a
+        secret token. Pins the strip so a regression produces a loud
+        test failure rather than a silent content bug.
+        """
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY = value\nKEY2= value\nKEY3 =value\n")
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {
+            "KEY": "value",
+            "KEY2": "value",
+            "KEY3": "value",
+        }
+
+    def test_load_env_file_strips_whitespace_before_quote_unwrap(self, tmp_path: Path):
+        """``KEY = "value"`` must still unwrap the quotes.
+
+        If the value-side whitespace isn't stripped BEFORE the quote-
+        unwrap check, the check sees a value starting with a space and
+        doesn't recognise the quotes as wrapping. The parser would then
+        leave the quote characters literally in the stored value
+        (``' "value"'`` instead of ``"value"``) -- subtle enough that
+        callers wouldn't notice until the subprocess tries to use the
+        literal quoted form of the token.
+        """
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY = "wrapped"\nK2=   \'singly\'\n')
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"KEY": "wrapped", "K2": "singly"}
+
+    def test_load_env_file_preserves_whitespace_inside_quotes(self, tmp_path: Path):
+        """Leading whitespace INSIDE quotes is intentional and preserved.
+
+        The lstrip on the pre-quote-unwrap value removes only whitespace
+        AROUND the '=' operator; whitespace kept inside a quoted value is
+        a deliberate user choice (e.g. a token formatted with a leading
+        space, or a human-readable prefix) and must survive.
+        """
+        import os
+        from clickwork.config import load_env_file
+
+        env_file = tmp_path / ".env"
+        env_file.write_text('KEY = "  leading spaces preserved"\n')
+        os.chmod(env_file, 0o600)
+
+        assert load_env_file(env_file) == {"KEY": "  leading spaces preserved"}
+
     def test_load_env_file_handles_double_quotes(self, tmp_path: Path):
         """Values wrapped in double quotes have the quotes stripped so
         spaces and other whitespace-adjacent characters survive parsing."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -535,9 +535,11 @@ class TestLoadEnvFile:
         assert load_env_file(env_file) == {"K": "v"}
 
     def test_load_env_file_skips_comments(self, tmp_path: Path):
-        """Full-line comments (# ...) are skipped; only full-line comments
-        are supported (inline trailing comments are NOT -- see the
-        does_not_expand_variables test for the anti-feature list)."""
+        """Full-line comments (# ...) are skipped; inline trailing comments
+        are NOT supported -- the `#` in ``K=val # comment`` is treated as
+        part of the value. See the load_env_file() docstring's "Not
+        supported" section for the full anti-feature list (variable
+        substitution, inline comments, heredocs, etc.)."""
         import os
         from clickwork.config import load_env_file
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -610,6 +610,41 @@ class TestLoadEnvFile:
         with pytest.raises(ConfigError, match="line 2"):
             load_env_file(env_file)
 
+    def test_load_env_file_raises_on_empty_key(self, tmp_path: Path):
+        """'=value' (or 'export =value') has no variable name.
+
+        Without a guard, the parser would return {"": "value"}, which is
+        never a valid environment variable name and blows up later when
+        passed to subprocess or os.environ. Fail fast with a line number
+        so the caller can fix the bad line immediately.
+        """
+        import os
+        from clickwork.config import load_env_file, ConfigError
+
+        env_file = tmp_path / ".env"
+        # Line 1: valid. Line 2: empty key. Line 3: valid.
+        env_file.write_text("A=1\n=orphaned\nC=3\n")
+        os.chmod(env_file, 0o600)
+
+        with pytest.raises(ConfigError, match="line 2"):
+            load_env_file(env_file)
+
+    def test_load_env_file_raises_on_empty_key_after_export(self, tmp_path: Path):
+        """'export =value' is the same bug, just with the export prefix.
+
+        Ensures the empty-key guard runs AFTER the export strip so we
+        don't miss the bad case.
+        """
+        import os
+        from clickwork.config import load_env_file, ConfigError
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("export =value\n")
+        os.chmod(env_file, 0o600)
+
+        with pytest.raises(ConfigError, match="line 1"):
+            load_env_file(env_file)
+
     def test_load_env_file_does_not_expand_variables(self, tmp_path: Path):
         """Variable substitution (K=$OTHER) is deliberately unsupported.
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -587,7 +587,13 @@ class TestLoadEnvFile:
         reason="POSIX file-mode semantics don't apply on Windows",
     )
     def test_load_env_file_rejects_world_readable_file(self, tmp_path: Path):
-        """A .env file commonly holds secrets; refuse anything looser than 0o600."""
+        """A .env file commonly holds secrets; any group/other bit rejects it.
+
+        The implementation forbids any group or other permission bit
+        (read, write, or execute) -- not just "looser than 0o600". Modes
+        like 0o400 or 0o700 pass the check; 0o644 here fails because
+        group/other have the read bit set.
+        """
         import os
         from clickwork.config import load_env_file, ConfigError
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -469,6 +469,41 @@ class TestUserConfigPermissions:
         )
         assert config["region"] == "us-east-1"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX file-mode semantics don't apply on Windows",
+    )
+    def test_group_writable_config_is_refused(self, tmp_path: Path):
+        """User config with ANY group/other bit (e.g. 0o620) must fail.
+
+        WHY this regression test exists: the permission check was
+        extracted into _check_owner_only_permissions and tightened from
+        "group/other READ only" to "ANY group/other bit" so group-
+        writable secrets files (a tampering risk even when not readable)
+        are also rejected. The old test covered 0o644; this one pins
+        the group-WRITE-only case so a future reader can't relax the
+        check back to read-only without a loud test failure.
+        """
+        import os
+        from clickwork.config import load_config, ConfigError
+
+        user_config = tmp_path / "config.toml"
+        user_config.write_text('token = "secret"\n')
+        # 0o620 = owner rw, group w, other ---. Not group-readable,
+        # so a pre-tightening check (S_IRGRP | S_IROTH) would let this
+        # through. The current S_IRWXG | S_IRWXO check catches it.
+        os.chmod(user_config, 0o620)
+
+        repo_config = tmp_path / ".test-cli.toml"
+        repo_config.write_text("[default]\n")
+
+        with pytest.raises(ConfigError, match="permission"):
+            load_config(
+                project_name="test-cli",
+                repo_config_path=repo_config,
+                user_config_path=user_config,
+            )
+
 
 class TestLoadEnvFile:
     """load_env_file() reads dotenv-style files into a plain dict.


### PR DESCRIPTION
## Summary
Standalone ``clickwork.config.load_env_file(path) -> dict[str, str]`` for the ``KEY=value`` / ``.env`` / ``.cf-secrets`` pattern. Callers decide what to do with the dict — the TOML config pipeline stays focused on structured data.

**Supported (explicit scope):** ``KEY=value``, ``export KEY=value``, double/single quoted values, ``#`` comments, blank lines.

**Deliberately unsupported (anti-documented):** variable substitution (``$OTHER``), backticks, heredocs, multiline values, inline comments on value lines. The docstring points users to ``sh -c 'source file; env'`` for those.

**Security:** Factored the existing TOCTOU-safe owner-only permission check out of ``_read_checked_user_config`` into a shared ``_check_owner_only_permissions`` helper so both callers honor the same Windows carve-out without duplication.

Fixes #9.

## Test plan
- [x] 11 new tests in ``TestLoadEnvFile``: simple parse, export prefix, both quote styles, comments, blank lines, multi-key, missing file, world-readable file (Windows-skipped), malformed line with line number, anti-test for variable substitution
- [x] Full suite: 150 passed (139 baseline + 11 new), zero warnings
- [ ] Smoke test: `ctx.run(["wrangler", ...], env=load_env_file(".cf-secrets"))` in orbit-admin after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)