### PR TITLE
feat: platform_dispatch decorator + dispatch() helper (Fixes #12)

### DIFF
--- a/src/clickwork/__init__.py
+++ b/src/clickwork/__init__.py
@@ -13,13 +13,17 @@ Public API:
     CliProcessError   - Exception raised when subprocess fails
     PrerequisiteError - Exception raised when a required tool is missing
     ConfigError       - Exception raised when config validation fails
+    platform_dispatch - Decorator that routes a command to a per-OS impl
+    platform          - Submodule exposing dispatch(), is_linux/macos/windows
 """
 
 __version__ = "0.1.0"
 
+from clickwork import platform
 from clickwork._types import CliContext, CliProcessError, PrerequisiteError, Secret, normalize_prefix
 from clickwork.cli import create_cli, pass_cli_context
 from clickwork.config import ConfigError, load_config
+from clickwork.platform import platform_dispatch
 
 __all__ = [
     "create_cli",
@@ -31,4 +35,6 @@ __all__ = [
     "ConfigError",
     "PrerequisiteError",
     "normalize_prefix",
+    "platform",
+    "platform_dispatch",
 ]

--- a/src/clickwork/platform.py
+++ b/src/clickwork/platform.py
@@ -1,8 +1,13 @@
-"""Platform detection and repository root finding.
+"""Platform detection, dispatch, and repository root finding.
 
 Platform helpers (is_linux, is_macos, is_windows) are thin wrappers around
 sys.platform. They exist so command code reads clearly: `if is_macos():`
 instead of `if sys.platform == "darwin":`.
+
+platform_dispatch (decorator) and dispatch() (functional helper) route a
+single command to the right per-OS implementation at call time. The two
+forms share ``_select_impl`` so the detection + error-message logic is
+single-sourced and can't drift.
 
 find_repo_root() walks up from a starting directory looking for .git as
 either a directory (normal repo) or a file (worktree/submodule). Falls back
@@ -10,9 +15,14 @@ to `git rev-parse --show-toplevel` if the walk fails.
 """
 from __future__ import annotations
 
+import functools
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
+
+import click
 
 
 def is_linux() -> bool:
@@ -40,6 +50,270 @@ def is_windows() -> bool:
         True when sys.platform is ``"win32"``, False otherwise.
     """
     return sys.platform == "win32"
+
+
+# ---------------------------------------------------------------------------
+# Platform dispatch (decorator + functional)
+# ---------------------------------------------------------------------------
+#
+# Both forms exist so command authors can pick the ergonomics that fit:
+#
+#   - ``@platform_dispatch(...)`` is the primary surface. Wrap a Click
+#     command and pass the three per-OS impls as kwargs; the decorator
+#     routes the call to the matching impl at invocation time.
+#
+#   - ``dispatch(ctx, ...)`` is the escape hatch for when you need to run
+#     pre-dispatch logic (loading config, validating args) *before* branching
+#     on platform. It takes the same kwargs and forwards ``ctx`` as the
+#     selected impl's first positional argument, matching the
+#     ``@pass_cli_context`` command-callback structure.
+#
+# Both forms share ``_select_impl`` below so the detection + error-message
+# logic lives in exactly one place.
+
+
+def _select_impl(
+    kwargs: dict[str, Any],
+) -> tuple[Callable[..., Any] | None, str | None, str]:
+    """Pick the per-OS impl and error message for the current platform.
+
+    This helper is the single source of truth for platform-dispatch logic.
+    Both ``platform_dispatch`` (decorator) and ``dispatch`` (functional)
+    call it, so the two forms can never drift on either the detection
+    mapping or the error-message defaults.
+
+    Args:
+        kwargs: The full kwargs dict passed to the decorator/functional form.
+            Expected keys: ``linux``, ``windows``, ``macos`` (the impls) and
+            optional ``linux_error``, ``windows_error``, ``macos_error``
+            (custom UsageError messages when the matching impl is None).
+            Keys are read via ``kwargs.get`` so callers may omit any key.
+
+    Returns:
+        A ``(impl, error_message, platform_name)`` triple:
+
+        - ``impl`` is the callable to dispatch to, or None if the matching
+          kwarg was None/missing.
+        - ``error_message`` is the custom ``<platform>_error`` value if
+          provided, otherwise None (callers should fall back to the default
+          ``f"{platform_name} not supported"`` string).
+        - ``platform_name`` is a human-readable name (``"linux"``, ``"windows"``,
+          ``"macos"``, or the raw ``sys.platform`` string for unknown OSes).
+          Unsupported platforms return ``(None, None, sys.platform)`` so the
+          caller can raise ``UsageError`` uniformly.
+    """
+    # is_linux / is_macos / is_windows are intentionally reused here rather
+    # than re-checking sys.platform inline: if those helpers ever gain new
+    # logic (WSL detection, for example), dispatch picks it up for free.
+    if is_linux():
+        return kwargs.get("linux"), kwargs.get("linux_error"), "linux"
+    if is_windows():
+        return kwargs.get("windows"), kwargs.get("windows_error"), "windows"
+    if is_macos():
+        return kwargs.get("macos"), kwargs.get("macos_error"), "macos"
+    # Unknown platform (e.g., "freebsd13", "cygwin"): return the raw platform
+    # string as the name so the default error message is informative.
+    return None, None, sys.platform
+
+
+def _raise_unsupported(custom_message: str | None, platform_name: str) -> None:
+    """Raise click.UsageError with a custom or default 'not supported' message.
+
+    Extracted so decorator and functional forms share the exact same wording
+    and exception type. click.UsageError is used (not a plain RuntimeError)
+    because platform-unsupported is a user-facing error, not a framework
+    bug -- Click prints it cleanly with exit code 2 and no traceback, which
+    is what we want.
+
+    Args:
+        custom_message: The caller-supplied ``<platform>_error`` string, or
+            None if the caller did not override the default message.
+        platform_name: The platform name used to build the default message
+            when ``custom_message`` is None.
+
+    Raises:
+        click.UsageError: Always. The message is either the custom message
+            or the default ``f"{platform_name} not supported"`` string.
+    """
+    message = custom_message if custom_message is not None else f"{platform_name} not supported"
+    raise click.UsageError(message)
+
+
+def platform_dispatch(
+    *,
+    linux: Callable[..., Any] | None = None,
+    windows: Callable[..., Any] | None = None,
+    macos: Callable[..., Any] | None = None,
+    linux_error: str | None = None,
+    windows_error: str | None = None,
+    macos_error: str | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorate a command so it dispatches to a per-OS implementation at call time.
+
+    The decorated function's body is never executed -- it exists purely to
+    carry the Click decorator stack (``@click.command``, ``@click.argument``,
+    ``@click.option``, ``@pass_cli_context``, etc.) and define the signature
+    that each platform impl must satisfy. At call time, the decorator detects
+    the current platform via ``sys.platform`` (using ``is_linux``/
+    ``is_windows``/``is_macos``) and forwards the caller's args/kwargs to the
+    matching impl.
+
+    The three ``*_error`` kwargs are part of the public API with no macOS
+    carve-out -- any platform can opt out of support by passing
+    ``<platform>=None`` plus an optional ``<platform>_error="..."`` message.
+    When a custom message is not provided, the default is
+    ``"<platform> not supported"``. The error is raised as
+    ``click.UsageError`` so Click prints it cleanly and exits with code 2,
+    matching clickwork's "user error, not framework bug" policy.
+
+    Args:
+        linux: Implementation to run on Linux (``sys.platform == "linux"``).
+            Pass None to signal "not supported on this platform"; the call
+            will raise ``click.UsageError`` when invoked on linux.
+        windows: Implementation to run on Windows (``sys.platform == "win32"``,
+            NOT ``"windows"``). Same None semantics as ``linux``.
+        macos: Implementation to run on macOS (``sys.platform == "darwin"``).
+            Same None semantics as ``linux``.
+        linux_error: Custom UsageError message when invoked on linux with
+            ``linux=None``. Defaults to ``"linux not supported"`` when None.
+        windows_error: Custom UsageError message when invoked on windows with
+            ``windows=None``. Defaults to ``"windows not supported"`` when None.
+        macos_error: Custom UsageError message when invoked on macos with
+            ``macos=None``. Defaults to ``"macos not supported"`` when None.
+
+    Returns:
+        A decorator that replaces the wrapped function with a dispatcher.
+        The dispatcher preserves the wrapped function's metadata via
+        ``functools.wraps`` so Click can still read ``__doc__`` / ``__name__``.
+
+    Example::
+
+        @clickwork.platform_dispatch(
+            linux=my_lib.linux.up,
+            windows=my_lib.windows.up,
+            macos=my_lib.macos.up,
+            macos_error="macOS not supported yet",
+        )
+        @click.command()
+        @click.argument("name")
+        @pass_cli_context
+        def runner_up(ctx, name): ...
+    """
+    # Bundle the kwargs so the inner wrapper can hand them to _select_impl
+    # without restating every key. Keeping this dict at decoration time means
+    # each call site pays the per-platform lookup cost once per invocation,
+    # not once per definition.
+    dispatch_kwargs: dict[str, Any] = {
+        "linux": linux,
+        "windows": windows,
+        "macos": macos,
+        "linux_error": linux_error,
+        "windows_error": windows_error,
+        "macos_error": macos_error,
+    }
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        """Wrap ``func`` in a platform-dispatching shim.
+
+        The shim is only invoked when Click calls the command; it does NOT
+        execute ``func``'s body because the original function exists only
+        to define the signature and carry the Click decorator stack. All
+        real work happens in the selected per-OS impl.
+        """
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            impl, error_message, platform_name = _select_impl(dispatch_kwargs)
+            if impl is None:
+                _raise_unsupported(error_message, platform_name)
+            # Forward the caller's args/kwargs verbatim. This is what makes
+            # signature forwarding "just work" -- Click's parsed options and
+            # arguments flow straight through to the per-OS impl with the
+            # same names the decorated function declared.
+            return impl(*args, **kwargs)
+        return wrapper
+
+    return decorator
+
+
+def dispatch(
+    ctx: Any,
+    *,
+    linux: Callable[..., Any] | None = None,
+    windows: Callable[..., Any] | None = None,
+    macos: Callable[..., Any] | None = None,
+    linux_error: str | None = None,
+    windows_error: str | None = None,
+    macos_error: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Functional escape hatch for platform-dispatching from inside a command.
+
+    Use this form when you need to run pre-dispatch logic (loading config,
+    validating args, printing a banner) *before* branching on platform. The
+    decorator form (``@platform_dispatch``) is the primary surface; reach
+    for ``dispatch`` only when the decorator's "body-is-never-run" semantics
+    get in the way.
+
+    The selected impl is called as ``impl(ctx, **kwargs)`` -- ``ctx`` is
+    always forwarded as the first positional argument, matching the shape of
+    ``@pass_cli_context`` command callbacks. Any extra keyword arguments
+    passed to ``dispatch`` are forwarded to the impl alongside ``ctx``.
+
+    The three ``*_error`` kwargs behave exactly like the decorator form:
+    when the matching impl kwarg is None, ``click.UsageError`` is raised
+    with the custom message if provided or ``f"{platform} not supported"``
+    by default.
+
+    Args:
+        ctx: The command's context object (typically a ``CliContext``).
+            Forwarded to the selected impl as its first positional argument.
+        linux: Impl to call when ``sys.platform == "linux"``. None means
+            unsupported (raises UsageError).
+        windows: Impl to call when ``sys.platform == "win32"``. None means
+            unsupported (raises UsageError).
+        macos: Impl to call when ``sys.platform == "darwin"``. None means
+            unsupported (raises UsageError).
+        linux_error: Custom UsageError message for ``linux=None`` on linux.
+        windows_error: Custom UsageError message for ``windows=None`` on win32.
+        macos_error: Custom UsageError message for ``macos=None`` on darwin.
+        **kwargs: Forwarded verbatim to the selected impl as keyword arguments.
+
+    Returns:
+        Whatever the selected impl returns.
+
+    Raises:
+        click.UsageError: If the current platform is unknown, or if the
+            impl kwarg for the current platform is None.
+
+    Example::
+
+        def runner_up(ctx, name: str) -> None:
+            ctx.logger.info("starting runner %s", name)
+            clickwork.platform.dispatch(
+                ctx,
+                linux=my_lib.linux.up,
+                windows=my_lib.windows.up,
+                macos=my_lib.macos.up,
+                macos_error="macOS not supported yet",
+                name=name,
+            )
+    """
+    # Reuse the shared selector so the detection mapping and error defaults
+    # match the decorator form byte-for-byte.
+    select_kwargs: dict[str, Any] = {
+        "linux": linux,
+        "windows": windows,
+        "macos": macos,
+        "linux_error": linux_error,
+        "windows_error": windows_error,
+        "macos_error": macos_error,
+    }
+    impl, error_message, platform_name = _select_impl(select_kwargs)
+    if impl is None:
+        _raise_unsupported(error_message, platform_name)
+    # ctx is forwarded as the first positional arg; this matches the
+    # @pass_cli_context callback shape that commands already use.
+    return impl(ctx, **kwargs)
 
 
 def find_repo_root(start: Path | None = None) -> Path | None:

--- a/src/clickwork/platform.py
+++ b/src/clickwork/platform.py
@@ -188,21 +188,31 @@ def platform_dispatch(
 
     Example::
 
+        # Decorator ORDER matters: @click.command() must be the outermost
+        # (applied last), with @platform_dispatch *below* it so Click sees
+        # the completed dispatch wrapper as the command callback. If you
+        # put @platform_dispatch on top, @click.command() has already
+        # converted the function into a click.Command object and
+        # platform_dispatch would end up wrapping that Command object,
+        # which breaks Click's registration.
+        @click.command()
+        @click.argument("name")
         @clickwork.platform_dispatch(
             linux=my_lib.linux.up,
             windows=my_lib.windows.up,
             macos=my_lib.macos.up,
             macos_error="macOS not supported yet",
         )
-        @click.command()
-        @click.argument("name")
         @pass_cli_context
         def runner_up(ctx, name): ...
     """
-    # Bundle the kwargs so the inner wrapper can hand them to _select_impl
-    # without restating every key. Keeping this dict at decoration time means
-    # each call site pays the per-platform lookup cost once per invocation,
-    # not once per definition.
+    # Bundle the kwargs into a single dict once, at decoration time, so the
+    # inner wrapper can hand them to _select_impl without restating every
+    # key. This dict is allocated ONCE per @platform_dispatch(...) site --
+    # it's captured by closure into the wrapper -- so we don't rebuild it
+    # on each invocation. The per-platform lookup inside _select_impl still
+    # runs on every call (it has to -- sys.platform is effectively constant
+    # per process but we don't cache it to avoid test-patching surprises).
     dispatch_kwargs: dict[str, Any] = {
         "linux": linux,
         "windows": windows,

--- a/src/clickwork/platform.py
+++ b/src/clickwork/platform.py
@@ -188,22 +188,29 @@ def platform_dispatch(
 
     Example::
 
-        # Decorator ORDER matters: @click.command() must be the outermost
-        # (applied last), with @platform_dispatch *below* it so Click sees
-        # the completed dispatch wrapper as the command callback. If you
-        # put @platform_dispatch on top, @click.command() has already
-        # converted the function into a click.Command object and
-        # platform_dispatch would end up wrapping that Command object,
-        # which breaks Click's registration.
+        # Decorator ORDER matters. platform_dispatch never calls the
+        # wrapped function's body -- it only uses it to carry the Click
+        # command metadata (name, help, args/options). That means any
+        # decorator applied ABOVE platform_dispatch (outer, applied
+        # later) sees platform_dispatch's dispatcher as the callable,
+        # and any decorator applied BELOW platform_dispatch (inner,
+        # applied earlier) never runs because platform_dispatch discards
+        # the body.
+        #
+        # Practical rule: put platform_dispatch at the *bottom* of the
+        # decorator stack (closest to ``def``) so ``@pass_cli_context``
+        # and any other callback-wrapping decorators have already added
+        # their injection logic to the enclosing stack. Click's
+        # ``@click.command()`` / ``@click.argument()`` go above, as usual.
         @click.command()
         @click.argument("name")
+        @pass_cli_context
         @clickwork.platform_dispatch(
             linux=my_lib.linux.up,
             windows=my_lib.windows.up,
             macos=my_lib.macos.up,
             macos_error="macOS not supported yet",
         )
-        @pass_cli_context
         def runner_up(ctx, name): ...
     """
     # Bundle the kwargs into a single dict once, at decoration time, so the

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -294,3 +294,76 @@ class TestPlatformDispatchFunctional:
                 windows=lambda *a, **k: None,
                 macos=lambda *a, **k: None,
             )
+
+
+class TestPlatformDispatchViaClickRunner:
+    """End-to-end test that platform_dispatch works through Click's CliRunner.
+
+    WHY this class exists (separate from the direct-call tests): the
+    decorator-order gotcha around ``@pass_cli_context`` only manifests
+    when Click actually invokes the command through its own callback
+    machinery. Direct-call tests bypass that, so they can pass while a
+    real Click invocation would crash. This class pins the working
+    decorator stack (platform_dispatch innermost, pass_cli_context
+    above, click.command / click.argument on top).
+    """
+
+    def test_dispatch_through_clirunner_hits_linux_impl(self, monkeypatch, tmp_path: Path):
+        """A Click command decorated with @platform_dispatch runs its linux impl.
+
+        Builds a CLI via ``create_cli`` so the CliContext injection flows
+        through ``@pass_cli_context`` and then into the dispatched impl.
+        Patches ``sys.platform`` to ``"linux"`` before invocation.
+        """
+        import click
+        from click.testing import CliRunner
+        from clickwork.cli import create_cli, pass_cli_context
+        from clickwork.platform import platform_dispatch
+
+        captured: dict = {}
+
+        # Inner per-platform impls receive the CliContext that
+        # @pass_cli_context injected upstream. Prove that by stashing
+        # the first arg and a known kwarg into captured[].
+        def _linux_up(ctx, *, name):
+            captured["impl"] = "linux"
+            captured["ctx_has_dry_run"] = hasattr(ctx, "dry_run")
+            captured["name"] = name
+
+        def _windows_up(ctx, *, name):
+            captured["impl"] = "windows"
+
+        def _macos_up(ctx, *, name):
+            captured["impl"] = "macos"
+
+        @click.command("runner-up")
+        @click.option("--name", default="test-runner")
+        @pass_cli_context
+        @platform_dispatch(
+            linux=_linux_up,
+            windows=_windows_up,
+            macos=_macos_up,
+        )
+        def runner_up(ctx, name): ...  # body intentionally empty -- platform_dispatch never calls it
+
+        cmd_dir = tmp_path / "commands"
+        cmd_dir.mkdir()
+        cli = create_cli(name="test-cli", commands_dir=cmd_dir)
+        cli.add_command(runner_up)
+
+        monkeypatch.setattr("sys.platform", "linux")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["runner-up", "--name", "rabbithole"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("impl") == "linux"
+        # If this is True, @pass_cli_context's injection actually reached
+        # the impl (CliContext has a dry_run attribute; a raw click.Context
+        # does not). If False, platform_dispatch consumed the @pass_cli_context
+        # wrapper without preserving its behaviour -- the decorator-order
+        # bug this test exists to catch.
+        assert captured.get("ctx_has_dry_run") is True, (
+            f"impl did not receive CliContext; got ctx={captured.get('ctx_has_dry_run')!r}. "
+            "Check that @platform_dispatch is the INNERMOST decorator on the stack."
+        )
+        assert captured.get("name") == "rabbithole"

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -4,11 +4,17 @@ Platform detection wraps sys.platform checks into readable helpers.
 Repo root finding walks up from cwd looking for .git (as directory or file),
 with a fallback to git rev-parse. This needs to handle worktrees where .git
 is a file pointing at the real gitdir.
+
+Platform dispatch (decorator + functional) routes a command to the right
+per-OS implementation at call time. Tests monkeypatch ``sys.platform`` to
+the strings clickwork's ``is_linux``/``is_macos``/``is_windows`` helpers
+check for: ``"linux"``, ``"darwin"``, and (importantly) ``"win32"``.
 """
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import click
 import pytest
 
 
@@ -66,3 +72,225 @@ class TestFindRepoRoot:
         subdir = tmp_path / "not" / "a" / "repo"
         subdir.mkdir(parents=True)
         assert find_repo_root(subdir) is None
+
+
+class TestPlatformDispatchDecorator:
+    """@platform_dispatch routes a decorated command to the right per-OS impl.
+
+    The decorator captures linux/windows/macos impls at definition time, then
+    at call time detects the current platform via sys.platform and forwards
+    the original args/kwargs to the matching impl. Missing impls for the
+    detected platform raise ``click.UsageError``.
+    """
+
+    def test_platform_dispatch_linux_calls_linux_impl(self, monkeypatch):
+        """On linux, the ``linux=`` impl runs with the caller's args/kwargs."""
+        from clickwork.platform import platform_dispatch
+
+        calls: list[tuple[tuple, dict]] = []
+
+        def linux_impl(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        def other_impl(*args, **kwargs):  # pragma: no cover - not selected
+            raise AssertionError("wrong platform impl called")
+
+        @platform_dispatch(linux=linux_impl, windows=other_impl, macos=other_impl)
+        def runner_up(name: str) -> None:
+            """Runner up command (body unused because dispatch takes over)."""
+
+        monkeypatch.setattr("sys.platform", "linux")
+        runner_up("alice")
+
+        assert calls == [(("alice",), {})]
+
+    def test_platform_dispatch_windows_calls_windows_impl(self, monkeypatch):
+        """On win32, the ``windows=`` impl is selected (NOT 'windows')."""
+        from clickwork.platform import platform_dispatch
+
+        calls: list[tuple[tuple, dict]] = []
+
+        def windows_impl(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        def other_impl(*args, **kwargs):  # pragma: no cover - not selected
+            raise AssertionError("wrong platform impl called")
+
+        @platform_dispatch(linux=other_impl, windows=windows_impl, macos=other_impl)
+        def runner_up(name: str) -> None: ...
+
+        # sys.platform is "win32" on Windows, not "windows".
+        monkeypatch.setattr("sys.platform", "win32")
+        runner_up("bob")
+
+        assert calls == [(("bob",), {})]
+
+    def test_platform_dispatch_macos_calls_macos_impl(self, monkeypatch):
+        """On darwin, the ``macos=`` impl is selected."""
+        from clickwork.platform import platform_dispatch
+
+        calls: list[tuple[tuple, dict]] = []
+
+        def macos_impl(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        def other_impl(*args, **kwargs):  # pragma: no cover - not selected
+            raise AssertionError("wrong platform impl called")
+
+        @platform_dispatch(linux=other_impl, windows=other_impl, macos=macos_impl)
+        def runner_up(name: str) -> None: ...
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        runner_up("carol")
+
+        assert calls == [(("carol",), {})]
+
+    def test_platform_dispatch_unsupported_platform_raises_usage_error(self, monkeypatch):
+        """Any platform that is not linux/win32/darwin raises UsageError."""
+        from clickwork.platform import platform_dispatch
+
+        def impl(*args, **kwargs):  # pragma: no cover - never called
+            raise AssertionError("should not be called on unsupported platform")
+
+        @platform_dispatch(linux=impl, windows=impl, macos=impl)
+        def runner_up() -> None: ...
+
+        monkeypatch.setattr("sys.platform", "freebsd13")
+        with pytest.raises(click.UsageError):
+            runner_up()
+
+    def test_platform_dispatch_linux_error_kwarg_overrides_message(self, monkeypatch):
+        """linux_error= replaces the default 'linux not supported' message."""
+        from clickwork.platform import platform_dispatch
+
+        @platform_dispatch(
+            linux=None,
+            windows=lambda *a, **k: None,
+            macos=lambda *a, **k: None,
+            linux_error="not yet",
+        )
+        def runner_up() -> None: ...
+
+        monkeypatch.setattr("sys.platform", "linux")
+        with pytest.raises(click.UsageError) as exc_info:
+            runner_up()
+        assert str(exc_info.value.message) == "not yet"
+
+    def test_platform_dispatch_windows_error_kwarg_overrides_message(self, monkeypatch):
+        """windows_error= replaces the default 'windows not supported' message."""
+        from clickwork.platform import platform_dispatch
+
+        @platform_dispatch(
+            linux=lambda *a, **k: None,
+            windows=None,
+            macos=lambda *a, **k: None,
+            windows_error="windows soon",
+        )
+        def runner_up() -> None: ...
+
+        monkeypatch.setattr("sys.platform", "win32")
+        with pytest.raises(click.UsageError) as exc_info:
+            runner_up()
+        assert str(exc_info.value.message) == "windows soon"
+
+    def test_platform_dispatch_macos_error_kwarg_overrides_message(self, monkeypatch):
+        """macos_error= replaces the default 'macos not supported' message."""
+        from clickwork.platform import platform_dispatch
+
+        @platform_dispatch(
+            linux=lambda *a, **k: None,
+            windows=lambda *a, **k: None,
+            macos=None,
+            macos_error="macOS not supported yet",
+        )
+        def runner_up() -> None: ...
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        with pytest.raises(click.UsageError) as exc_info:
+            runner_up()
+        assert str(exc_info.value.message) == "macOS not supported yet"
+
+    def test_platform_dispatch_signature_forwarding(self, monkeypatch):
+        """The decorated function's signature is preserved; impls receive the same args."""
+        from clickwork.platform import platform_dispatch
+
+        seen: dict = {}
+
+        def linux_impl(name: str, *, flag: bool = False) -> None:
+            seen["name"] = name
+            seen["flag"] = flag
+
+        @platform_dispatch(
+            linux=linux_impl,
+            windows=lambda *a, **k: None,
+            macos=lambda *a, **k: None,
+        )
+        def runner_up(name: str, *, flag: bool = False) -> None: ...
+
+        monkeypatch.setattr("sys.platform", "linux")
+        runner_up("dave", flag=True)
+
+        assert seen == {"name": "dave", "flag": True}
+
+
+class TestPlatformDispatchFunctional:
+    """clickwork.platform.dispatch() is the escape hatch for pre-dispatch logic.
+
+    Matches @pass_cli_context command structure: the selected impl is called
+    with ``ctx`` as its first positional arg, followed by any forwarded kwargs.
+    """
+
+    def test_dispatch_functional_linux(self, monkeypatch):
+        """On linux, the ``linux=`` impl receives ``ctx`` and forwarded kwargs."""
+        from clickwork.platform import dispatch
+
+        calls: list[tuple[tuple, dict]] = []
+
+        def linux_fn(*args, **kwargs):
+            calls.append((args, kwargs))
+
+        def other_fn(*args, **kwargs):  # pragma: no cover - not selected
+            raise AssertionError("wrong platform impl")
+
+        ctx = object()  # Stand-in for the CliContext.
+        monkeypatch.setattr("sys.platform", "linux")
+        dispatch(ctx, linux=linux_fn, windows=other_fn, macos=other_fn)
+
+        assert calls == [((ctx,), {})]
+
+    def test_dispatch_functional_forwards_kwargs(self, monkeypatch):
+        """Extra kwargs are forwarded alongside ctx to the selected impl."""
+        from clickwork.platform import dispatch
+
+        captured: dict = {}
+
+        def linux_fn(ctx, **kwargs):
+            captured["ctx"] = ctx
+            captured["kwargs"] = kwargs
+
+        ctx = object()
+        monkeypatch.setattr("sys.platform", "linux")
+        dispatch(
+            ctx,
+            linux=linux_fn,
+            windows=lambda *a, **k: None,
+            macos=lambda *a, **k: None,
+            extra="x",
+        )
+
+        assert captured["ctx"] is ctx
+        assert captured["kwargs"] == {"extra": "x"}
+
+    def test_dispatch_functional_raises_for_unsupported(self, monkeypatch):
+        """Unsupported platform raises click.UsageError, same as the decorator."""
+        from clickwork.platform import dispatch
+
+        ctx = object()
+        monkeypatch.setattr("sys.platform", "freebsd13")
+        with pytest.raises(click.UsageError):
+            dispatch(
+                ctx,
+                linux=lambda *a, **k: None,
+                windows=lambda *a, **k: None,
+                macos=lambda *a, **k: None,
+            )

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -315,7 +315,6 @@ class TestPlatformDispatchViaClickRunner:
         through ``@pass_cli_context`` and then into the dispatched impl.
         Patches ``sys.platform`` to ``"linux"`` before invocation.
         """
-        import click
         from click.testing import CliRunner
         from clickwork.cli import create_cli, pass_cli_context
         from clickwork.platform import platform_dispatch


### PR DESCRIPTION
## Summary
Two public surfaces in ``clickwork.platform`` for cross-platform commands:

- ``@platform_dispatch(linux=fn, windows=fn, macos=fn, linux_error="...", windows_error="...", macos_error="...")`` — decorator, the 80% case
- ``dispatch(ctx, *, linux=fn, windows=fn, macos=fn, *_error="...", **kwargs)`` — functional escape hatch for the 20% that need pre-dispatch logic; forwards ``ctx`` positionally to the selected impl

Shared ``_select_impl`` resolves ``(impl, error_message, platform_name)`` so detection and default-error wording can't drift between the two forms. Reuses existing ``is_linux``/``is_windows``/``is_macos`` helpers — future platform refinements land in one place.

Unsupported platforms raise ``click.UsageError`` (user error classification). All three ``*_error`` kwargs public — no macOS carve-out.

Fixes #12.

## Test plan
- [x] 8 decorator tests: each platform hit, each ``*_error`` kwarg, unsupported-platform raise, signature forwarding
- [x] 3 functional tests: ``ctx`` forwarded positionally, extra kwargs forwarded, unsupported raises
- [x] Full suite: 150 passed (139 baseline + 11 new), zero warnings
- [ ] Smoke test: orbit-admin runner commands refactored to use ``@platform_dispatch`` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)