### PR TITLE
feat: add_global_option() installs option at every CLI level (Fixes #14)

### DIFF
--- a/src/clickwork/__init__.py
+++ b/src/clickwork/__init__.py
@@ -6,6 +6,7 @@ common utilities so command authors can focus on business logic.
 
 Public API:
     create_cli        - Build a CLI with global flags and plugin discovery
+    add_global_option - Install a Click option at root + every group + every subcommand
     load_config       - Load layered TOML config (for custom config scenarios)
     CliContext         - Typed context object passed to every command
     pass_cli_context   - Decorator for commands (handles nested group footgun)
@@ -20,9 +21,11 @@ __version__ = "0.1.0"
 from clickwork._types import CliContext, CliProcessError, PrerequisiteError, Secret, normalize_prefix
 from clickwork.cli import create_cli, pass_cli_context
 from clickwork.config import ConfigError, load_config
+from clickwork.global_options import add_global_option
 
 __all__ = [
     "create_cli",
+    "add_global_option",
     "load_config",
     "CliContext",
     "pass_cli_context",

--- a/src/clickwork/discovery.py
+++ b/src/clickwork/discovery.py
@@ -139,9 +139,18 @@ class LazyEntryPointCommand(click.Command):
         # make_context() -> Context(), and Context accepts obj as a keyword arg.
         # parent=ctx wires the loaded command's context into this proxy's
         # context chain -- see the docstring above for why that matters.
+        #
+        # WHY prog_name=ctx.info_name (not ctx.command_path): Click computes
+        # a context's command_path as ``parent.command_path + " " + info_name``
+        # by walking the parent chain. With parent=ctx set, passing the full
+        # command_path as prog_name would double-count -- the loaded command's
+        # command_path would end up like "myapp plugin-cmd myapp plugin-cmd"
+        # and show up duplicated in Usage / help / error messages. Passing
+        # just the info_name lets Click reconstruct the full path from the
+        # chain, giving the correct "myapp plugin-cmd" output.
         return loaded.main(
             args=list(ctx.args),
-            prog_name=ctx.command_path,
+            prog_name=ctx.info_name,
             standalone_mode=False,
             obj=ctx.obj,
             parent=ctx,

--- a/src/clickwork/discovery.py
+++ b/src/clickwork/discovery.py
@@ -115,15 +115,23 @@ class LazyEntryPointCommand(click.Command):
         real command's context and ``@pass_cli_context`` / ``@click.pass_obj``
         keep working.
 
-        We also pass ``parent=ctx`` so the loaded command's context joins the
-        existing context chain instead of rooting a fresh one. WHY this
-        matters: anything that walks to the root via ``ctx.find_root()``
-        -- notably ``clickwork.add_global_option`` writing to
-        ``ctx.find_root().meta`` -- needs to see the REAL root's meta dict,
-        not a detached one. Without ``parent=ctx`` the loaded plugin
-        command's ``find_root()`` would return its own fresh context and
-        global-option values written at the parent level would be silently
-        invisible to the plugin.
+        We also pass ``parent=ctx.parent`` (NOT ``parent=ctx``) so the
+        loaded command's context joins the existing context chain without
+        becoming a child of the proxy. WHY this matters: anything that
+        walks to the root via ``ctx.find_root()`` -- notably
+        ``clickwork.add_global_option`` writing to ``ctx.find_root().meta``
+        -- needs to see the REAL root's meta dict, not a detached one. If
+        we passed no parent at all, the loaded plugin command's
+        ``find_root()`` would return its own fresh context and global-
+        option values written at the root level would be silently invisible
+        to the plugin. If we passed ``parent=ctx`` (the proxy itself),
+        Click would double-count the command name in ``command_path``
+        (proxy + loaded both contribute the same info_name to the chain),
+        producing duplicated Usage/help text like "myapp plugin-cmd
+        plugin-cmd". Passing ``ctx.parent`` threads the chain correctly:
+        the loaded command *replaces* the proxy at the plugin-cmd level,
+        inheriting the proxy's own parent so ``find_root()`` still reaches
+        the true root.
 
         Args:
             ctx: The Click context, whose ``ctx.args`` contains the

--- a/src/clickwork/discovery.py
+++ b/src/clickwork/discovery.py
@@ -137,23 +137,34 @@ class LazyEntryPointCommand(click.Command):
         # Pass obj=ctx.obj so the new context created by loaded.main() carries
         # the CliContext forward.  Click forwards **extra kwargs through
         # make_context() -> Context(), and Context accepts obj as a keyword arg.
-        # parent=ctx wires the loaded command's context into this proxy's
-        # context chain -- see the docstring above for why that matters.
         #
-        # WHY prog_name=ctx.info_name (not ctx.command_path): Click computes
-        # a context's command_path as ``parent.command_path + " " + info_name``
-        # by walking the parent chain. With parent=ctx set, passing the full
-        # command_path as prog_name would double-count -- the loaded command's
-        # command_path would end up like "myapp plugin-cmd myapp plugin-cmd"
-        # and show up duplicated in Usage / help / error messages. Passing
-        # just the info_name lets Click reconstruct the full path from the
-        # chain, giving the correct "myapp plugin-cmd" output.
+        # WHY parent=ctx.parent (NOT parent=ctx): Click builds
+        # ``command_path`` as ``parent.command_path + " " + info_name`` by
+        # walking the parent chain. The proxy ctx ALREADY represents the
+        # plugin-cmd level in the chain. If we passed parent=ctx the loaded
+        # command would become a *child* of the proxy and its command_path
+        # would be "myapp plugin-cmd" (proxy's path) + " " + "plugin-cmd"
+        # (loaded's info_name) = "myapp plugin-cmd plugin-cmd" -- duplicated
+        # in Usage / help / error messages.
+        #
+        # Passing parent=ctx.parent instead makes the loaded command's
+        # context a *sibling* of the proxy in the tree: it replaces the
+        # proxy in the chain rather than appending to it. That gives
+        # command_path = "myapp" + " " + "plugin-cmd" = "myapp plugin-cmd"
+        # (correct) while keeping ctx.find_root() reachable from the loaded
+        # ctx -- the whole reason we wire the chain at all, so
+        # clickwork.add_global_option values live on a shared root.meta.
+        #
+        # WHY prog_name=ctx.info_name: once parent is ctx.parent, info_name
+        # needs to be just the command's own name (e.g. "plugin-cmd"),
+        # not the full command path -- Click rebuilds the path from the
+        # chain.
         return loaded.main(
             args=list(ctx.args),
             prog_name=ctx.info_name,
             standalone_mode=False,
             obj=ctx.obj,
-            parent=ctx,
+            parent=ctx.parent,
         )
 
     def get_short_help_str(self, limit: int = 45) -> str:

--- a/src/clickwork/discovery.py
+++ b/src/clickwork/discovery.py
@@ -115,6 +115,16 @@ class LazyEntryPointCommand(click.Command):
         real command's context and ``@pass_cli_context`` / ``@click.pass_obj``
         keep working.
 
+        We also pass ``parent=ctx`` so the loaded command's context joins the
+        existing context chain instead of rooting a fresh one. WHY this
+        matters: anything that walks to the root via ``ctx.find_root()``
+        -- notably ``clickwork.add_global_option`` writing to
+        ``ctx.find_root().meta`` -- needs to see the REAL root's meta dict,
+        not a detached one. Without ``parent=ctx`` the loaded plugin
+        command's ``find_root()`` would return its own fresh context and
+        global-option values written at the parent level would be silently
+        invisible to the plugin.
+
         Args:
             ctx: The Click context, whose ``ctx.args`` contains the
                 unparsed extra arguments collected by the proxy and whose
@@ -127,11 +137,14 @@ class LazyEntryPointCommand(click.Command):
         # Pass obj=ctx.obj so the new context created by loaded.main() carries
         # the CliContext forward.  Click forwards **extra kwargs through
         # make_context() -> Context(), and Context accepts obj as a keyword arg.
+        # parent=ctx wires the loaded command's context into this proxy's
+        # context chain -- see the docstring above for why that matters.
         return loaded.main(
             args=list(ctx.args),
             prog_name=ctx.command_path,
             standalone_mode=False,
             obj=ctx.obj,
+            parent=ctx,
         )
 
     def get_short_help_str(self, limit: int = 45) -> str:

--- a/src/clickwork/discovery.py
+++ b/src/clickwork/discovery.py
@@ -142,6 +142,51 @@ class LazyEntryPointCommand(click.Command):
             Whatever the real command's ``main()`` returns.
         """
         loaded = self._load()
+
+        # Defensive flag-collision check for entry-point plugins.
+        #
+        # WHY this check exists: ``clickwork.add_global_option`` installs
+        # options on this proxy at CLI-build time, but the proxy has no
+        # way to introspect the plugin's own options until the plugin
+        # module is actually loaded (the whole point of laziness). So
+        # add_global_option's conflict detector cannot see a plugin's
+        # private ``--json`` (or whatever) -- it only sees the proxy's
+        # ``self.params``. If the plugin's loaded command declares the
+        # same flag, Click would parse that flag at the PROXY level
+        # first, consume the token, and the plugin would never see its
+        # own option. Behaviour would look like "the flag is silently
+        # ignored by the plugin", which is a nasty debugging experience.
+        #
+        # Now that we actually have ``loaded``, compare its declared
+        # flag strings against the proxy's. Any overlap is a genuine
+        # conflict between a plugin-declared option and a globally-
+        # installed option; surface it as a ``click.UsageError`` (user-
+        # classification, matches the rest of clickwork's error policy)
+        # with a pointer to both sides so the caller can fix whichever
+        # makes sense for their setup.
+        proxy_flag_strings: set[str] = set()
+        for proxy_param in self.params:
+            proxy_flag_strings.update(getattr(proxy_param, "opts", ()))
+            proxy_flag_strings.update(getattr(proxy_param, "secondary_opts", ()))
+        for loaded_param in loaded.params:
+            loaded_flag_strings: set[str] = set(
+                getattr(loaded_param, "opts", ())
+            )
+            loaded_flag_strings.update(
+                getattr(loaded_param, "secondary_opts", ())
+            )
+            overlap = proxy_flag_strings & loaded_flag_strings
+            if overlap:
+                raise click.UsageError(
+                    f"Entry-point plugin {self.name!r} declares option "
+                    f"{sorted(overlap)!r} which collides with a globally-"
+                    f"installed option on the CLI root. The global option "
+                    f"consumes the flag before the plugin sees it, so "
+                    f"whichever side you want to act on it should be the "
+                    f"only one that declares it. Either rename the plugin's "
+                    f"option or omit the global install for that flag."
+                )
+
         # Pass obj=ctx.obj so the new context created by loaded.main() carries
         # the CliContext forward.  Click forwards **extra kwargs through
         # make_context() -> Context(), and Context accepts obj as a keyword arg.

--- a/src/clickwork/discovery.py
+++ b/src/clickwork/discovery.py
@@ -183,19 +183,42 @@ class LazyEntryPointCommand(click.Command):
         # nested commands it contains. Group membership check uses the
         # public isinstance on click.Group; Groups always expose their
         # subcommands via ``.commands``.
+        #
+        # WHY we track the REGISTERED name (the dict key in Group.commands)
+        # rather than ``cmd.name``: a plugin can register a command under
+        # an alias with ``Group.add_command(cmd, name="alias")``, in which
+        # case ``cmd.name`` differs from the name the user actually types
+        # on the command line. The error message needs the invocation
+        # path, so we thread the dict key down through the recursion
+        # instead of relying on ``cmd.name``. For the top-level call we
+        # use ``self.name`` -- the proxy IS registered under that name
+        # at the CLI root, so starting the walk with just that name
+        # (and NOT appending ``loaded.name`` again) avoids the
+        # "plugin plugin" duplication an earlier draft produced.
         collisions: list[tuple[str, str]] = []
 
-        def _walk(cmd: click.Command, prefix: str) -> None:
-            path = f"{prefix} {cmd.name}".strip()
+        def _walk(cmd: click.Command, path: str) -> None:
+            # path is the FULL qualified path (registered names, space-
+            # separated) for ``cmd`` as the user would type it. Every
+            # param declared directly on ``cmd`` that collides with a
+            # proxy flag gets appended with this path.
             for p in cmd.params:
                 cmd_flags = set(getattr(p, "opts", ()))
                 cmd_flags.update(getattr(p, "secondary_opts", ()))
                 for flag in cmd_flags & proxy_flag_strings:
                     collisions.append((path, flag))
             if isinstance(cmd, click.Group):
-                for sub in cmd.commands.values():
-                    _walk(sub, path)
+                # Iterate .items() so we get the REGISTERED name (dict
+                # key), not the underlying cmd.name attribute -- these
+                # can differ when a plugin aliased the command.
+                for registered_name, sub in cmd.commands.items():
+                    sub_path = f"{path} {registered_name}".strip()
+                    _walk(sub, sub_path)
 
+        # Start with the proxy's own registered name. We do NOT append
+        # loaded.name to this: the proxy IS the loaded command's entry
+        # point, and Click parses from the proxy's registered name, so
+        # "self.name" alone is the correct root of the path.
         _walk(loaded, self.name or "")
 
         if collisions:

--- a/src/clickwork/discovery.py
+++ b/src/clickwork/discovery.py
@@ -164,28 +164,59 @@ class LazyEntryPointCommand(click.Command):
         # classification, matches the rest of clickwork's error policy)
         # with a pointer to both sides so the caller can fix whichever
         # makes sense for their setup.
+        #
+        # WHY we walk the FULL loaded tree (not just loaded.params): if
+        # the plugin's entry-point target is a ``click.Group``, the
+        # group's own params don't include the options declared on its
+        # subcommands. A nested subcommand that declares ``--json``
+        # still has its token consumed at the proxy level because the
+        # proxy installed the ``--json`` option via add_global_option
+        # and Click's parser greedily matches it at whichever level
+        # declares it (the proxy, here) before descending. Walking the
+        # full tree catches those deeper collisions.
         proxy_flag_strings: set[str] = set()
         for proxy_param in self.params:
             proxy_flag_strings.update(getattr(proxy_param, "opts", ()))
             proxy_flag_strings.update(getattr(proxy_param, "secondary_opts", ()))
-        for loaded_param in loaded.params:
-            loaded_flag_strings: set[str] = set(
-                getattr(loaded_param, "opts", ())
+
+        # Collect (qualified_path, flag_string) pairs from loaded and any
+        # nested commands it contains. Group membership check uses the
+        # public isinstance on click.Group; Groups always expose their
+        # subcommands via ``.commands``.
+        collisions: list[tuple[str, str]] = []
+
+        def _walk(cmd: click.Command, prefix: str) -> None:
+            path = f"{prefix} {cmd.name}".strip()
+            for p in cmd.params:
+                cmd_flags = set(getattr(p, "opts", ()))
+                cmd_flags.update(getattr(p, "secondary_opts", ()))
+                for flag in cmd_flags & proxy_flag_strings:
+                    collisions.append((path, flag))
+            if isinstance(cmd, click.Group):
+                for sub in cmd.commands.values():
+                    _walk(sub, path)
+
+        _walk(loaded, self.name or "")
+
+        if collisions:
+            # Group collisions by flag so the error message names each
+            # conflicting flag once with all the command paths that
+            # declare it -- easier to read than one line per occurrence.
+            by_flag: dict[str, list[str]] = {}
+            for cmd_path, flag in collisions:
+                by_flag.setdefault(flag, []).append(cmd_path)
+            details = "; ".join(
+                f"{flag!r} declared on " + ", ".join(sorted(paths))
+                for flag, paths in sorted(by_flag.items())
             )
-            loaded_flag_strings.update(
-                getattr(loaded_param, "secondary_opts", ())
+            raise click.UsageError(
+                f"Entry-point plugin {self.name!r} contains option(s) that "
+                f"collide with a globally-installed option on the CLI root: "
+                f"{details}. The global option consumes these flags before "
+                f"the plugin command/subcommand sees them. Either rename "
+                f"the plugin-side option(s) or omit the global install for "
+                f"the colliding flag(s)."
             )
-            overlap = proxy_flag_strings & loaded_flag_strings
-            if overlap:
-                raise click.UsageError(
-                    f"Entry-point plugin {self.name!r} declares option "
-                    f"{sorted(overlap)!r} which collides with a globally-"
-                    f"installed option on the CLI root. The global option "
-                    f"consumes the flag before the plugin sees it, so "
-                    f"whichever side you want to act on it should be the "
-                    f"only one that declares it. Either rename the plugin's "
-                    f"option or omit the global install for that flag."
-                )
 
         # Pass obj=ctx.obj so the new context created by loaded.main() carries
         # the CliContext forward.  Click forwards **extra kwargs through

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -1,0 +1,309 @@
+"""add_global_option: install a Click option at root + every group + every subcommand.
+
+This module implements the ``add_global_option`` primitive documented in
+issue #14. The goal is to let plugin authors declare an option ONCE and have
+it accepted at every level of their CLI hierarchy, with sensible merging
+semantics into ``ctx.meta``.
+
+Design choices worth reading before changing this file:
+
+1. **Option callback, not invoke wrapper.** Click fires option ``callback=``
+   functions during parsing, exactly when it has the parsed value in hand and
+   the Click context for the *current* command level. Hooking at this point
+   means we don't have to introspect CliRunner results, monkey-patch
+   ``invoke``, or intercept group callbacks -- we just observe the parsed
+   value where Click naturally exposes it.
+
+2. **Root-context meta as the single source of truth.** Each level's callback
+   walks to ``ctx.find_root()`` and merges into that meta dict. Subcommand
+   callbacks run AFTER group callbacks because Click parses the group's
+   options, invokes its callback, then recurses into the subcommand. This
+   parse order guarantees that a merge callback using
+   "innermost wins when explicitly set" on each level arrives at the correct
+   final value for value-options.
+
+3. **Call-time snapshot, not retroactive.** The caller hands us the current
+   ``cli`` tree and we walk it immediately. Commands attached LATER don't get
+   the option. This is intentional: a retroactive scheme would need to
+   monkey-patch ``Group.add_command`` and would introduce surprising
+   lifecycle interactions with lazy plugin loading. If you need to cover
+   commands added later, call ``add_global_option`` again after adding them.
+
+4. **Detecting "explicitly set".** For value options we must distinguish "the
+   user passed ``--env=prod``" from "Click filled in the default of ``None``".
+   Click exposes ``ctx.get_parameter_source(name)`` for this, returning
+   ``ParameterSource.COMMANDLINE`` for user-supplied values and
+   ``ParameterSource.DEFAULT`` for defaults. We only overwrite meta when the
+   source is not DEFAULT, so a root-level ``--env=prod`` followed by a bare
+   subcommand still leaves ``meta['env'] == 'prod'``.
+
+   Flags get simpler treatment: any truthy occurrence wins via OR, because
+   the flag's presence is itself the signal regardless of the default.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import click
+from click.core import ParameterSource
+
+
+def add_global_option(
+    cli: click.Group,
+    *param_decls: str,
+    **option_kwargs: Any,
+) -> None:
+    """Install a Click option at root + every group + every subcommand of ``cli``.
+
+    The option is accepted at ANY level of the CLI hierarchy. The resolved
+    value is merged into the root Click context's ``meta`` dict under the
+    option's Python-identifier name (e.g., ``--foo-bar`` -> ``meta['foo_bar']``).
+    Read it from command callbacks via::
+
+        root_meta = click.get_current_context().find_root().meta
+        value = root_meta[name]
+
+    Merge semantics:
+        * Flags (``is_flag=True``) use **OR across levels**: a truthy value
+          at ANY level wins, so ``meta[name]`` is ``True`` if the user passed
+          the flag at root OR group OR subcommand (or any combination).
+        * Value options (strings, ints, enums, ...) use **innermost-wins**:
+          the deepest level that explicitly supplied the option on the
+          command line provides the final value. Levels that parsed only the
+          default do NOT overwrite an already-set value.
+        * Not passed anywhere: ``meta[name]`` is ``False`` for flags and the
+          Click-resolved default (usually ``None``) for value options.
+
+    Snapshot behaviour:
+        Registration is a **call-time snapshot** of ``cli``'s command tree.
+        Commands attached to ``cli`` AFTER ``add_global_option`` returns do
+        NOT retroactively receive the option. This is deliberate: retroactive
+        registration would require monkey-patching ``Group.add_command`` and
+        introduces lifecycle surprises. Call ``add_global_option`` again if
+        you need to cover later additions.
+
+    Args:
+        cli: The root Click group to install the option on. Walked recursively
+            to discover nested groups and leaf commands.
+        *param_decls: Click parameter declarations -- the same strings you'd
+            pass to ``@click.option(...)``, e.g., ``"--json"`` or
+            ``"--env", "-e"``.
+        **option_kwargs: Keyword arguments forwarded to ``click.Option``. Use
+            ``is_flag=True`` for boolean flags, ``default=...`` for value
+            options, etc. The ``callback=`` kwarg is reserved by this
+            function; passing it raises ``TypeError``.
+
+    Raises:
+        TypeError: If ``option_kwargs`` contains a ``callback`` key -- we own
+            the callback slot to implement the merge semantics. Wrap the
+            click.Option yourself and register it manually if you need a
+            custom callback.
+
+    Examples:
+        Flag with OR semantics, read anywhere in your code::
+
+            cli = clickwork.create_cli(name="myapp", commands_dir=...)
+            clickwork.add_global_option(cli, "--json", is_flag=True,
+                                        help="Output as JSON.")
+
+            # All three invocations leave ctx.find_root().meta['json'] == True:
+            #   myapp --json sub-cmd
+            #   myapp sub-cmd --json
+            #   myapp group --json sub-cmd
+
+        Value option with innermost-wins::
+
+            clickwork.add_global_option(cli, "--env", default=None,
+                                        help="Target environment.")
+
+            # myapp --env=prod sub-cmd --env=staging
+            #   => ctx.find_root().meta['env'] == 'staging'   (inner wins)
+            # myapp --env=prod sub-cmd
+            #   => ctx.find_root().meta['env'] == 'prod'      (outer alone)
+            # myapp sub-cmd
+            #   => ctx.find_root().meta['env'] is None        (Click default)
+    """
+    # Guard: we install our own callback to implement the merge. If the
+    # caller supplies one, silently dropping it would lead to confusing bugs
+    # where their side effect never runs. Raise loudly instead.
+    if "callback" in option_kwargs:
+        raise TypeError(
+            "add_global_option() owns the 'callback=' kwarg; pass a "
+            "plain option config without callback, or register the option "
+            "manually with click.option() if you need custom callback logic."
+        )
+
+    # Derive the option name (the key under which Click stores the parsed
+    # value, and the key we use in ctx.meta) by constructing a throwaway
+    # Option. Click's own name-derivation logic handles edge cases like
+    # flag/slash syntax (``--shout/--no-shout``) and aliases so we don't
+    # have to reimplement it.
+    name = _derive_option_name(param_decls, option_kwargs)
+
+    # Flags use OR, value options use innermost-wins. Capture this once; the
+    # merge callback branches on it.
+    is_flag = bool(option_kwargs.get("is_flag", False))
+
+    def _merge_callback(
+        ctx: click.Context,
+        _param: click.Parameter,
+        value: Any,
+    ) -> Any:
+        """Merge this level's parsed value into the root context's meta.
+
+        Runs once per level where the option is installed (root group,
+        intermediate groups, and the leaf subcommand). Click invokes it with
+        the already-parsed value for this level.
+
+        Args:
+            ctx: The Click context for the CURRENT level (root, intermediate
+                group, or leaf command). We walk to ``ctx.find_root()`` to
+                write into the top-level meta dict.
+            _param: The click.Parameter instance for this option at this
+                level. Unused -- we use the outer ``name`` variable instead.
+            value: The value Click parsed for this level -- either from the
+                command line, from the default, or (rarely) from an
+                environment variable.
+
+        Returns:
+            ``value`` unchanged. Click requires callbacks to return the
+            value that will be passed to the command's callback, and we
+            don't want to alter local-level behaviour.
+        """
+        root_meta = ctx.find_root().meta
+
+        if is_flag:
+            # OR across levels: any truthy occurrence wins. We read the
+            # current meta (defaulting to False so first-call initialization
+            # and "not-yet-set" look the same) and OR in the new value. This
+            # naturally handles:
+            #   - no flag at any level     -> False OR False = False
+            #   - flag at outer only       -> False OR True  = True (later
+            #                                  inner False OR True = True)
+            #   - flag at inner only       -> False OR False = False, then
+            #                                  False OR True = True
+            #   - flag at both levels      -> True OR True   = True
+            root_meta[name] = bool(root_meta.get(name, False)) or bool(value)
+        else:
+            # Innermost-wins for value options. We overwrite only when this
+            # level's value was EXPLICITLY supplied (command line, env var,
+            # or default_map) -- never when it came from the plain default,
+            # which would stomp on an explicit outer value with None.
+            #
+            # get_parameter_source() returns None if the parameter wasn't
+            # processed for this context (shouldn't happen here since the
+            # callback only fires when it WAS processed), and one of the
+            # ParameterSource values otherwise.
+            source = ctx.get_parameter_source(name)
+            if source is not None and source != ParameterSource.DEFAULT:
+                root_meta[name] = value
+            elif name not in root_meta:
+                # First time we see the option at any level and it's just
+                # the default. Record the default so downstream code can
+                # read ctx.meta[name] without a .get()-with-default dance.
+                root_meta[name] = value
+            # Else: an outer level already wrote an explicit value; a later
+            # default-only level should NOT overwrite it. Do nothing.
+
+        return value
+
+    # Merge our callback into the kwargs we'll forward to click.Option below.
+    # We've already rejected caller-supplied callbacks above, so this assign
+    # is safe.
+    #
+    # WHY expose_value=False: the caller's existing command callbacks weren't
+    # written expecting this option as a keyword argument -- they shouldn't
+    # have to change just because we installed a global option on their
+    # command. ``expose_value=False`` tells Click to parse the option (firing
+    # our callback with the value) but NOT pass it to the command callback
+    # as a kwarg. The merged value is still available via ctx.meta.
+    option_kwargs_with_cb = dict(option_kwargs)
+    option_kwargs_with_cb["callback"] = _merge_callback
+    option_kwargs_with_cb.setdefault("expose_value", False)
+
+    # Walk the command tree and install a FRESH click.Option on every level.
+    # WHY a fresh instance per level: click.Option objects are stateful
+    # (they're bound to a specific command's parameter list), so sharing a
+    # single instance across multiple commands causes subtle double-registration
+    # issues. Constructing per-level is cheap and keeps each command
+    # self-contained.
+    _install_on_group(cli, param_decls, option_kwargs_with_cb)
+
+
+def _derive_option_name(
+    param_decls: tuple[str, ...],
+    option_kwargs: dict[str, Any],
+) -> str:
+    """Derive the Python-identifier name Click would assign to this option.
+
+    Click's own ``Option.__init__`` runs this logic -- we construct a
+    throwaway instance and read its ``.name`` attribute. This is robust to
+    edge cases (short/long aliases, flag/slash syntax, explicit ``name=``
+    kwarg) that a hand-rolled implementation would likely miss.
+
+    Args:
+        param_decls: The param declaration tuple as passed to
+            ``add_global_option``.
+        option_kwargs: The option kwargs; specifically we strip ``callback=``
+            (unsupported by caller, but defensive) so construction doesn't
+            reject the probe.
+
+    Returns:
+        The Python identifier Click would use for this option (e.g.,
+        ``'foo_bar'`` for ``--foo-bar``).
+    """
+    # Strip any caller-unfriendly kwargs before the probe construction so
+    # this function is robust to misuse upstream (we raise for `callback`
+    # earlier, but `_derive_option_name` is a pure helper that shouldn't
+    # also validate).
+    probe_kwargs = {k: v for k, v in option_kwargs.items() if k != "callback"}
+    probe = click.Option(list(param_decls), **probe_kwargs)
+    # Option.name is set during __init__ by Click's own derivation rules.
+    # Cast to str because the attribute is typed as Optional[str] in Click's
+    # stubs, but in practice it's always populated for standard declarations.
+    assert probe.name is not None, (
+        f"Click failed to derive a name for option {param_decls!r}; "
+        "pass an explicit 'param_decls' that includes a long-form flag."
+    )
+    return probe.name
+
+
+def _install_on_group(
+    group: click.Group,
+    param_decls: tuple[str, ...],
+    option_kwargs: dict[str, Any],
+) -> None:
+    """Recursively install the option on a group, all its subgroups, and all leaves.
+
+    Walks ``group.commands`` and dispatches:
+      * Nested ``click.Group`` -> recurse into it AND attach the option to
+        the group itself (users can pass the flag between ``outer`` and
+        ``inner`` group names).
+      * Plain ``click.Command`` -> attach the option to that leaf command.
+
+    The root group itself also gets the option -- this enables the
+    ``myapp --json sub-cmd`` case where the flag precedes any subcommand.
+
+    Args:
+        group: The current group being processed. On the first call, this is
+            the CLI root; on recursive calls it's a nested group.
+        param_decls: Param declarations, forwarded unchanged to each new
+            ``click.Option`` instance.
+        option_kwargs: Option kwargs (already including our merge callback).
+    """
+    # Attach to the group itself FIRST so the flag is accepted at this level.
+    # Click stores params on the command's ``.params`` list; appending is the
+    # documented way to add options programmatically (same as what the
+    # @click.option() decorator does under the hood).
+    group.params.append(click.Option(list(param_decls), **option_kwargs))
+
+    # Then visit every registered subcommand. group.commands is a dict of
+    # {name: Command}; we ignore names and just dispatch on type.
+    for sub in group.commands.values():
+        if isinstance(sub, click.Group):
+            # Recurse: the subgroup (and everything under it) gets the option
+            # too. This handles arbitrarily-deep nesting.
+            _install_on_group(sub, param_decls, option_kwargs)
+        else:
+            # Leaf command: just attach the option.
+            sub.params.append(click.Option(list(param_decls), **option_kwargs))

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -51,6 +51,14 @@ from __future__ import annotations
 from typing import Any
 
 import click
+# NOTE on the click.core import: Click 8.3.2 (our minimum) defines
+# ParameterSource at ``click.core.ParameterSource`` and does NOT
+# re-export it to top-level. ``click.ParameterSource`` raises
+# AttributeError on this version (verified on the pinned installed
+# Click). The ``click.core`` module is publicly documented as part of
+# the Click API surface -- it isn't a private ``_core`` -- so importing
+# from there is the supported path for this feature. If / when Click
+# exposes ``click.ParameterSource`` at top level, we can switch.
 from click.core import ParameterSource
 
 

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -253,13 +253,30 @@ def add_global_option(
     option_kwargs_with_cb["callback"] = _merge_callback
     option_kwargs_with_cb["expose_value"] = False
 
+    # Compute the full set of flag strings this option will claim, using
+    # Click's OWN parsing of param_decls (via the probe constructed above)
+    # rather than string matching on the raw decls.
+    #
+    # WHY reuse the probe: a slash-flag like "--shout/--no-shout" is a
+    # single element in param_decls, but Click splits it into
+    # probe.opts=["--shout"] + probe.secondary_opts=["--no-shout"]. A
+    # naive string-match would leave "--shout/--no-shout" intact and
+    # miss a collision with an existing command that already declares
+    # just "--shout" or "--no-shout" separately. Collecting from the
+    # probe gives us the actual set of strings Click will register on
+    # each command, matching how ``existing.opts`` / ``secondary_opts``
+    # is populated on already-installed options.
+    new_flag_strings = set(getattr(probe, "opts", ())) | set(
+        getattr(probe, "secondary_opts", ())
+    )
+
     # Walk the command tree and install a FRESH click.Option on every level.
     # WHY a fresh instance per level: click.Option objects are stateful
     # (they're bound to a specific command's parameter list), so sharing a
     # single instance across multiple commands causes subtle double-registration
     # issues. Constructing per-level is cheap and keeps each command
     # self-contained.
-    _install_on_group(cli, param_decls, option_kwargs_with_cb, name)
+    _install_on_group(cli, param_decls, option_kwargs_with_cb, name, new_flag_strings)
 
 
 def _derive_option_name(
@@ -308,6 +325,7 @@ def _install_on_group(
     param_decls: tuple[str, ...],
     option_kwargs: dict[str, Any],
     name: str,
+    new_flag_strings: set[str],
 ) -> None:
     """Recursively install the option on a group, all its subgroups, and all leaves.
 
@@ -336,7 +354,7 @@ def _install_on_group(
             already declare the flag manually) would otherwise produce a
             confusing Click "option already registered" error at parse time.
     """
-    _install_on_command(group, param_decls, option_kwargs, name)
+    _install_on_command(group, param_decls, option_kwargs, name, new_flag_strings)
 
     # Then visit every registered subcommand. group.commands is a dict of
     # {name: Command}; we ignore names and just dispatch on type.
@@ -344,12 +362,12 @@ def _install_on_group(
         if isinstance(sub, click.Group):
             # Recurse: the subgroup (and everything under it) gets the option
             # too. This handles arbitrarily-deep nesting.
-            _install_on_group(sub, param_decls, option_kwargs, name)
+            _install_on_group(sub, param_decls, option_kwargs, name, new_flag_strings)
         else:
             # Leaf command: just attach the option via the conflict-checked
             # helper so callers get a clear error instead of a runtime
             # Click surprise when something already claimed the name.
-            _install_on_command(sub, param_decls, option_kwargs, name)
+            _install_on_command(sub, param_decls, option_kwargs, name, new_flag_strings)
 
 
 def _install_on_command(
@@ -357,6 +375,7 @@ def _install_on_command(
     param_decls: tuple[str, ...],
     option_kwargs: dict[str, Any],
     name: str,
+    new_flag_strings: set[str],
 ) -> None:
     """Attach a fresh click.Option to one command, rejecting name conflicts.
 
@@ -385,12 +404,16 @@ def _install_on_command(
     # "--json")`` has ``name == "output_json"`` but opts ``["--json"]``, so a
     # name-only check would miss the flag-string collision and the caller
     # would hit Click's own "option already registered" error later.
-    new_opts = {d for d in param_decls if d.startswith("-")}
+    #
+    # ``new_flag_strings`` was computed once in add_global_option() from a
+    # probe click.Option (so slash-flags like "--shout/--no-shout" are
+    # already split into {"--shout", "--no-shout"} instead of being a
+    # single unsplit string).
     for existing in command.params:
         existing_opts = set(getattr(existing, "opts", ()))
         # Collect secondary_opts too (the "--no-foo" side of a slash-flag).
         existing_opts.update(getattr(existing, "secondary_opts", ()))
-        flag_conflict = new_opts & existing_opts
+        flag_conflict = new_flag_strings & existing_opts
         name_conflict = getattr(existing, "name", None) == name
         if flag_conflict or name_conflict:
             # Help the caller find the conflict: command.name is Click's

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -140,9 +140,21 @@ def add_global_option(
     # have to reimplement it.
     name = _derive_option_name(param_decls, option_kwargs)
 
-    # Flags use OR, value options use innermost-wins. Capture this once; the
-    # merge callback branches on it.
-    is_flag = bool(option_kwargs.get("is_flag", False))
+    # Flags use OR, value options use innermost-wins. But slash-flags
+    # (``--foo/--no-foo``) have TWO user-facing forms: the "on" value and
+    # an explicit "off" value. OR'ing them across levels would prevent an
+    # inner ``--no-foo`` from overriding an outer ``--foo`` (False never
+    # wins an OR). Detect slash-flags via the probe's ``secondary_opts``
+    # and treat them as value-innermost instead, so users get the
+    # intuitive "inner level wins" semantics for both forms.
+    #
+    # Plain flags (single ``--foo`` declaration) keep OR semantics: there
+    # is no way for the user to say "off" at an inner level, so truthy-
+    # anywhere is the only sensible rule.
+    probe_kwargs = {k: v for k, v in option_kwargs.items() if k != "callback"}
+    probe = click.Option(list(param_decls), **probe_kwargs)
+    is_slash_flag = bool(getattr(probe, "secondary_opts", None))
+    is_flag = bool(option_kwargs.get("is_flag", False)) and not is_slash_flag
 
     def _merge_callback(
         ctx: click.Context,
@@ -207,6 +219,18 @@ def add_global_option(
 
         return value
 
+    # Guard: expose_value is owned by add_global_option just like callback.
+    # A caller-supplied ``expose_value=True`` would surface the option as a
+    # kwarg on every existing command callback, breaking those signatures
+    # at runtime. Reject explicitly rather than letting that silently break.
+    if option_kwargs.get("expose_value", False):
+        raise TypeError(
+            "add_global_option() forces expose_value=False so installed "
+            "options don't show up as kwargs on every command's callback. "
+            "If you need the value injected into a specific command, use "
+            "click.option() directly on that command instead."
+        )
+
     # Merge our callback into the kwargs we'll forward to click.Option below.
     # We've already rejected caller-supplied callbacks above, so this assign
     # is safe.
@@ -219,7 +243,7 @@ def add_global_option(
     # as a kwarg. The merged value is still available via ctx.meta.
     option_kwargs_with_cb = dict(option_kwargs)
     option_kwargs_with_cb["callback"] = _merge_callback
-    option_kwargs_with_cb.setdefault("expose_value", False)
+    option_kwargs_with_cb["expose_value"] = False
 
     # Walk the command tree and install a FRESH click.Option on every level.
     # WHY a fresh instance per level: click.Option objects are stateful
@@ -227,7 +251,7 @@ def add_global_option(
     # single instance across multiple commands causes subtle double-registration
     # issues. Constructing per-level is cheap and keeps each command
     # self-contained.
-    _install_on_group(cli, param_decls, option_kwargs_with_cb)
+    _install_on_group(cli, param_decls, option_kwargs_with_cb, name)
 
 
 def _derive_option_name(
@@ -259,12 +283,15 @@ def _derive_option_name(
     probe_kwargs = {k: v for k, v in option_kwargs.items() if k != "callback"}
     probe = click.Option(list(param_decls), **probe_kwargs)
     # Option.name is set during __init__ by Click's own derivation rules.
-    # Cast to str because the attribute is typed as Optional[str] in Click's
-    # stubs, but in practice it's always populated for standard declarations.
-    assert probe.name is not None, (
-        f"Click failed to derive a name for option {param_decls!r}; "
-        "pass an explicit 'param_decls' that includes a long-form flag."
-    )
+    # The attribute is typed as Optional[str] in Click's stubs, so we
+    # validate explicitly. (Using ``assert`` here would be stripped under
+    # ``python -O`` and let ``None`` silently propagate into ctx.meta
+    # writes, producing confusing errors far from the real cause.)
+    if probe.name is None:
+        raise ValueError(
+            f"Click failed to derive a name for option {param_decls!r}; "
+            "pass an explicit 'param_decls' that includes a long-form flag."
+        )
     return probe.name
 
 
@@ -272,6 +299,7 @@ def _install_on_group(
     group: click.Group,
     param_decls: tuple[str, ...],
     option_kwargs: dict[str, Any],
+    name: str,
 ) -> None:
     """Recursively install the option on a group, all its subgroups, and all leaves.
 
@@ -290,12 +318,17 @@ def _install_on_group(
         param_decls: Param declarations, forwarded unchanged to each new
             ``click.Option`` instance.
         option_kwargs: Option kwargs (already including our merge callback).
+        name: Click-derived Python name for the option (used to detect
+            conflicts with options already on a command).
+
+    Raises:
+        ValueError: If any command or group in the tree already defines
+            an option with the same Python name. Calling add_global_option()
+            twice with the same flag (or against a tree whose commands
+            already declare the flag manually) would otherwise produce a
+            confusing Click "option already registered" error at parse time.
     """
-    # Attach to the group itself FIRST so the flag is accepted at this level.
-    # Click stores params on the command's ``.params`` list; appending is the
-    # documented way to add options programmatically (same as what the
-    # @click.option() decorator does under the hood).
-    group.params.append(click.Option(list(param_decls), **option_kwargs))
+    _install_on_command(group, param_decls, option_kwargs, name)
 
     # Then visit every registered subcommand. group.commands is a dict of
     # {name: Command}; we ignore names and just dispatch on type.
@@ -303,7 +336,53 @@ def _install_on_group(
         if isinstance(sub, click.Group):
             # Recurse: the subgroup (and everything under it) gets the option
             # too. This handles arbitrarily-deep nesting.
-            _install_on_group(sub, param_decls, option_kwargs)
+            _install_on_group(sub, param_decls, option_kwargs, name)
         else:
-            # Leaf command: just attach the option.
-            sub.params.append(click.Option(list(param_decls), **option_kwargs))
+            # Leaf command: just attach the option via the conflict-checked
+            # helper so callers get a clear error instead of a runtime
+            # Click surprise when something already claimed the name.
+            _install_on_command(sub, param_decls, option_kwargs, name)
+
+
+def _install_on_command(
+    command: click.Command,
+    param_decls: tuple[str, ...],
+    option_kwargs: dict[str, Any],
+    name: str,
+) -> None:
+    """Attach a fresh click.Option to one command, rejecting name conflicts.
+
+    Checks ``command.params`` for an existing parameter whose Python name
+    matches -- this catches both (a) calling ``add_global_option()`` twice
+    with the same flag and (b) installing a flag onto a command tree where
+    some command already declared it manually. Either case would later
+    surface as a confusing Click error at parse/help time; raising here
+    points the caller directly at the conflict.
+
+    Args:
+        command: The Click command (or group) to install on. Click stores
+            params on the command's ``.params`` list; appending is the
+            documented way to add options programmatically.
+        param_decls: Option declarations (``"--json"`` etc.)
+        option_kwargs: Fully prepared kwargs (callback + expose_value set).
+        name: The Python name Click would derive; used for the conflict check.
+
+    Raises:
+        ValueError: If a parameter with the same name is already on the
+            command. Message identifies the command so the caller can
+            locate the conflict.
+    """
+    for existing in command.params:
+        if getattr(existing, "name", None) == name:
+            # Help the caller find the conflict: command.name is Click's
+            # own identifier for the command (set via @click.command(name=)
+            # or derived from the function name).
+            cmd_label = getattr(command, "name", None) or type(command).__name__
+            raise ValueError(
+                f"Cannot install global option {param_decls!r}: command "
+                f"{cmd_label!r} already has a parameter named {name!r}. "
+                "Either rename the conflicting option, remove the manual "
+                "declaration, or don't call add_global_option() twice for "
+                "the same flag."
+            )
+    command.params.append(click.Option(list(param_decls), **option_kwargs))

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -72,8 +72,12 @@ def add_global_option(
           at ANY level wins, so ``meta[name]`` is ``True`` if the user passed
           the flag at root OR group OR subcommand (or any combination).
         * Value options (strings, ints, enums, ...) use **innermost-wins**:
-          the deepest level that explicitly supplied the option on the
-          command line provides the final value. Levels that parsed only the
+          the deepest level that *explicitly* supplied the option provides
+          the final value. "Explicit" here means any Click
+          ``ParameterSource`` other than ``DEFAULT`` -- command line is
+          the common case, but environment variables and
+          ``default_map``-sourced values also count as explicit and can
+          override outer levels. Levels that parsed only the Click
           default do NOT overwrite an already-set value.
         * Not passed anywhere: ``meta[name]`` is ``False`` for flags and the
           Click-resolved default (usually ``None``) for value options.
@@ -376,17 +380,36 @@ def _install_on_command(
             command. Message identifies the command so the caller can
             locate the conflict.
     """
+    # We check for conflicts two ways because Click decouples a parameter's
+    # Python identifier from its flag strings. ``@click.option("output_json",
+    # "--json")`` has ``name == "output_json"`` but opts ``["--json"]``, so a
+    # name-only check would miss the flag-string collision and the caller
+    # would hit Click's own "option already registered" error later.
+    new_opts = {d for d in param_decls if d.startswith("-")}
     for existing in command.params:
-        if getattr(existing, "name", None) == name:
+        existing_opts = set(getattr(existing, "opts", ()))
+        # Collect secondary_opts too (the "--no-foo" side of a slash-flag).
+        existing_opts.update(getattr(existing, "secondary_opts", ()))
+        flag_conflict = new_opts & existing_opts
+        name_conflict = getattr(existing, "name", None) == name
+        if flag_conflict or name_conflict:
             # Help the caller find the conflict: command.name is Click's
             # own identifier for the command (set via @click.command(name=)
             # or derived from the function name).
             cmd_label = getattr(command, "name", None) or type(command).__name__
+            # Name the specific reason so the caller can locate the issue
+            # even when names and flag strings disagree.
+            if flag_conflict:
+                reason = (
+                    f"already uses flag string(s) {sorted(flag_conflict)!r} "
+                    f"on parameter {getattr(existing, 'name', '?')!r}"
+                )
+            else:
+                reason = f"already has a parameter named {name!r}"
             raise ValueError(
                 f"Cannot install global option {param_decls!r}: command "
-                f"{cmd_label!r} already has a parameter named {name!r}. "
-                "Either rename the conflicting option, remove the manual "
-                "declaration, or don't call add_global_option() twice for "
-                "the same flag."
+                f"{cmd_label!r} {reason}. Either rename the conflicting "
+                "option, remove the manual declaration, or don't call "
+                "add_global_option() twice for the same flag."
             )
     command.params.append(click.Option(list(param_decls), **option_kwargs))

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -106,6 +106,20 @@ def add_global_option(
             the callback slot to implement the merge semantics. Wrap the
             click.Option yourself and register it manually if you need a
             custom callback.
+        TypeError: If ``option_kwargs`` contains ``expose_value=True`` -- we
+            force ``expose_value=False`` so the installed option doesn't
+            appear as a kwarg on every command's callback signature. If
+            you need the value injected into a specific command's function,
+            use ``click.option()`` directly on that command instead.
+        ValueError: If Click cannot derive a Python name from
+            ``param_decls`` (typically because no long-form flag like
+            ``--foo`` was provided).
+        ValueError: If any command or group in the tree already has an
+            option with the same Python name or flag string -- catches
+            both "called ``add_global_option()`` twice with the same flag"
+            and "command has the option hand-declared already". The error
+            message names the specific command and conflict so the caller
+            can locate the issue immediately.
 
     Examples:
         Flag with OR semantics, read anywhere in your code::

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -133,17 +133,24 @@ def add_global_option(
             #   myapp sub-cmd --json
             #   myapp group --json sub-cmd
 
-        Value option with innermost-wins::
+        Value option with innermost-wins. Note this example uses
+        ``--region`` rather than ``--env``: ``create_cli`` already
+        installs ``--env`` at the root (alongside ``--verbose``,
+        ``--quiet``, ``--dry-run``, ``--yes``), so calling
+        ``add_global_option(cli, "--env", ...)`` against a
+        ``create_cli`` root would raise ``ValueError`` for a
+        flag-string collision. Pick a name that is not one of the
+        clickwork-reserved built-ins::
 
-            clickwork.add_global_option(cli, "--env", default=None,
-                                        help="Target environment.")
+            clickwork.add_global_option(cli, "--region", default=None,
+                                        help="Target region.")
 
-            # myapp --env=prod sub-cmd --env=staging
-            #   => ctx.find_root().meta['env'] == 'staging'   (inner wins)
-            # myapp --env=prod sub-cmd
-            #   => ctx.find_root().meta['env'] == 'prod'      (outer alone)
+            # myapp --region=us-east sub-cmd --region=eu-west
+            #   => ctx.find_root().meta['region'] == 'eu-west'   (inner wins)
+            # myapp --region=us-east sub-cmd
+            #   => ctx.find_root().meta['region'] == 'us-east'   (outer alone)
             # myapp sub-cmd
-            #   => ctx.find_root().meta['env'] is None        (Click default)
+            #   => ctx.find_root().meta['region'] is None        (Click default)
     """
     # Guard: we install our own callback to implement the merge. If the
     # caller supplies one, silently dropping it would lead to confusing bugs

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -79,8 +79,13 @@ def add_global_option(
           ``default_map``-sourced values also count as explicit and can
           override outer levels. Levels that parsed only the Click
           default do NOT overwrite an already-set value.
-        * Not passed anywhere: ``meta[name]`` is ``False`` for flags and the
-          Click-resolved default (usually ``None``) for value options.
+        * Not passed anywhere: ``meta[name]`` is the Click-resolved
+          default -- typically ``False`` for flags and ``None`` for
+          value options, but callers can change either with
+          ``default=...`` in ``option_kwargs``. If the caller declared
+          a flag with ``default=True``, ``meta[name]`` is ``True`` when
+          the user didn't pass the flag; the OR-merge semantics still
+          apply on top of whatever default Click resolves at each level.
 
     Snapshot behaviour:
         Registration is a **call-time snapshot** of ``cli``'s command tree.

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -60,8 +60,12 @@ def add_global_option(
     option's Python-identifier name (e.g., ``--foo-bar`` -> ``meta['foo_bar']``).
     Read it from command callbacks via::
 
+        # For add_global_option(cli, "--json", is_flag=True) the meta key
+        # is "json" (Click's standard param-decl-to-name derivation). Use
+        # whatever key your flag derives to -- ``--my-flag`` -> ``"my_flag"``,
+        # ``--api-url`` -> ``"api_url"``, etc.
         root_meta = click.get_current_context().find_root().meta
-        value = root_meta[name]
+        is_json = root_meta["json"]
 
     Merge semantics:
         * Flags (``is_flag=True``) use **OR across levels**: a truthy value

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -84,9 +84,20 @@ def add_global_option(
         is_json = root_meta["json"]
 
     Merge semantics:
-        * Flags (``is_flag=True``) use **OR across levels**: a truthy value
-          at ANY level wins, so ``meta[name]`` is ``True`` if the user passed
-          the flag at root OR group OR subcommand (or any combination).
+        * Plain flags (``is_flag=True`` with a single ``--foo`` declaration)
+          use **OR across levels**: a truthy value at ANY level wins, so
+          ``meta[name]`` is ``True`` if the user passed the flag at root
+          OR group OR subcommand (or any combination). OR is the only
+          sensible rule for plain flags: the user has no way to say "off"
+          at an inner level, so treating truthy-anywhere as wins is what
+          matches intuition.
+        * Slash-flags (``is_flag=True`` with a ``--foo/--no-foo``
+          declaration) are an **exception** to the OR rule. Because the
+          user CAN say "off" at an inner level via ``--no-foo``, we
+          switch to **innermost-wins** so an inner ``--no-foo`` can
+          override an outer ``--foo`` (and vice versa). If we OR'd these,
+          False would never win and the ``--no-foo`` form would be
+          useless at inner levels.
         * Value options (strings, ints, enums, ...) use **innermost-wins**:
           the deepest level that *explicitly* supplied the option provides
           the final value. "Explicit" here means any Click

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -106,6 +106,20 @@ def add_global_option(
         collision -- this is intentional: silent idempotent reinstalls
         would hide real "declared the same flag twice by mistake" bugs.
 
+    Lazy entry-point plugins:
+        The install-time flag-string conflict check is **best effort** for
+        entry-point plugins wrapped in ``LazyEntryPointCommand``. Those
+        proxies don't expose the plugin's own options until the plugin
+        module is actually loaded (that's the whole point of lazy
+        discovery), so ``add_global_option`` can't see an internal
+        ``--json`` declared by the plugin at install time. If the global
+        flag AND the plugin-internal option end up declaring the same
+        flag string, ``LazyEntryPointCommand.invoke`` catches the
+        collision at invocation time and raises ``click.UsageError``
+        with both sides named. Plugin authors who hit that error should
+        rename their internal option OR the CLI author should skip the
+        global install for that specific flag.
+
     Args:
         cli: The root Click group to install the option on. Walked recursively
             to discover nested groups and leaf commands.

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -51,14 +51,16 @@ from __future__ import annotations
 from typing import Any
 
 import click
-# NOTE on the click.core import: Click 8.3.2 (our minimum) defines
-# ParameterSource at ``click.core.ParameterSource`` and does NOT
-# re-export it to top-level. ``click.ParameterSource`` raises
-# AttributeError on this version (verified on the pinned installed
-# Click). The ``click.core`` module is publicly documented as part of
-# the Click API surface -- it isn't a private ``_core`` -- so importing
-# from there is the supported path for this feature. If / when Click
-# exposes ``click.ParameterSource`` at top level, we can switch.
+# NOTE on the click.core import: at the project's declared minimum
+# Click version (``click>=8.1`` per pyproject.toml) ``ParameterSource``
+# lives at ``click.core.ParameterSource`` and is NOT re-exported to
+# top-level. ``click.ParameterSource`` raises AttributeError on every
+# Click 8.x release currently shipping (verified on 8.3.2, which is
+# what the dev venv resolves to). ``click.core`` is documented as part
+# of Click's public API surface -- not a private ``_core`` module --
+# so importing from there is the supported path today. If a future
+# Click release promotes ParameterSource to top-level, this import
+# can be swapped.
 from click.core import ParameterSource
 
 

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -26,8 +26,14 @@ Design choices worth reading before changing this file:
    ``cli`` tree and we walk it immediately. Commands attached LATER don't get
    the option. This is intentional: a retroactive scheme would need to
    monkey-patch ``Group.add_command`` and would introduce surprising
-   lifecycle interactions with lazy plugin loading. If you need to cover
-   commands added later, call ``add_global_option`` again after adding them.
+   lifecycle interactions with lazy plugin loading. The correct workflow
+   is to invoke ``add_global_option`` ONCE, AFTER all commands (including
+   those loaded from ``discover_commands`` / entry points) are attached.
+   Re-invoking the function later with the same flag is **not** a
+   supported "catch up" mechanism -- the conflict-detection guard treats
+   an already-installed option as a collision and raises ``ValueError``.
+   That's deliberate: silent idempotent reinstalls would mask genuine
+   "declared the same flag twice by mistake" bugs.
 
 4. **Detecting "explicitly set".** For value options we must distinguish "the
    user passed ``--env=prod``" from "Click filled in the default of ``None``".
@@ -92,8 +98,13 @@ def add_global_option(
         Commands attached to ``cli`` AFTER ``add_global_option`` returns do
         NOT retroactively receive the option. This is deliberate: retroactive
         registration would require monkey-patching ``Group.add_command`` and
-        introduces lifecycle surprises. Call ``add_global_option`` again if
-        you need to cover later additions.
+        introduces lifecycle surprises. The correct workflow is to call
+        ``add_global_option`` ONCE, AFTER all commands (including those from
+        ``discover_commands`` / entry points) are attached. Re-invoking it
+        later with the same flag raises ``ValueError`` because the
+        conflict-detection guard treats the existing registration as a
+        collision -- this is intentional: silent idempotent reinstalls
+        would hide real "declared the same flag twice by mistake" bugs.
 
     Args:
         cli: The root Click group to install the option on. Walked recursively

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -514,6 +514,73 @@ class TestAddGlobalOptionEntryPointPropagation:
         assert "plugin-cmd" in result.output
         assert "--json" in result.output
 
+    def test_global_option_flag_collision_on_nested_subcommand_raises(
+        self, monkeypatch
+    ) -> None:
+        """Collision on a nested subcommand of a loaded group also raises.
+
+        WHY this test exists: the runtime check walks the LOADED command's
+        tree, not just its own ``.params``. If a plugin's entry-point
+        target is a ``click.Group`` and the collision lives on one of the
+        group's subcommands, an earlier "only check loaded.params" version
+        would MISS it -- Click's parser would still consume the flag at
+        the proxy level, so the subcommand would silently never see its
+        own option. This test builds that exact shape (a loaded group
+        ``plugin`` with a subcommand ``sub`` that declares ``--json``)
+        and asserts the runtime check fires with both ``sub`` and
+        ``--json`` named in the error.
+        """
+        import click
+        from click.testing import CliRunner
+        from clickwork.discovery import discover_commands_from_entrypoints
+
+        class FakeEntryPoint:
+            name = "plugin"
+
+            def load(self):
+                @click.group(name="plugin")
+                def plugin_grp() -> None: ...
+
+                # Collision lives on the SUBCOMMAND, not the group itself.
+                # A "check loaded.params only" walk would miss this.
+                @plugin_grp.command("sub")
+                @click.option("--json", is_flag=True)
+                def sub(json: bool) -> None: ...
+
+                return plugin_grp
+
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda group=None: [FakeEntryPoint()] if group == "clickwork.commands" else [],
+        )
+
+        @click.group()
+        def root() -> None: ...
+
+        commands = discover_commands_from_entrypoints()
+        for cmd_name, cmd in commands.items():
+            root.add_command(cmd, cmd_name)
+
+        add_global_option(root, "--json", is_flag=True)
+
+        runner = CliRunner()
+        # Repro from the user review on PR #26: invoke the nested
+        # subcommand with the colliding flag. Without the recursive walk,
+        # this returns exit 0 with root meta['json']=True but the
+        # subcommand sees json=False -- a silent wrong-behaviour. With
+        # the walk, we get UsageError (exit 2) up front.
+        result = runner.invoke(root, ["plugin", "sub", "--json"])
+
+        assert result.exit_code == 2, (
+            f"Expected UsageError (exit 2) on nested-subcommand flag collision; "
+            f"got exit={result.exit_code}, output={result.output!r}"
+        )
+        assert "sub" in result.output, (
+            f"Error message must name the colliding subcommand path; got "
+            f"output={result.output!r}"
+        )
+        assert "--json" in result.output
+
 
 class TestAddGlobalOptionIntegration:
     """End-to-end check that add_global_option composes with create_cli()."""

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -222,6 +222,112 @@ class TestAddGlobalOptionSnapshotSemantics:
         assert "no such option" in result.output.lower()
 
 
+class TestAddGlobalOptionGuards:
+    """add_global_option refuses caller configurations that would silently break.
+
+    These guards exist so misuse surfaces at add_global_option() call time
+    rather than later during parse or dispatch where the error message
+    would be from Click, buried, and hard to connect to the real cause.
+    """
+
+    def test_rejects_caller_supplied_expose_value_true(self) -> None:
+        """expose_value=True would inject the flag as a kwarg on every command.
+
+        That breaks existing command signatures (they weren't written to
+        receive the global option). We own expose_value=False as an API
+        invariant; raise if the caller tries to override.
+        """
+        import pytest
+
+        @click.group()
+        def root() -> None: ...
+
+        @root.command("sub-cmd")
+        def sub() -> None: ...
+
+        with pytest.raises(TypeError, match="expose_value"):
+            add_global_option(root, "--json", is_flag=True, expose_value=True)
+
+    def test_rejects_duplicate_install(self) -> None:
+        """Calling add_global_option twice with the same flag raises ValueError.
+
+        Click would otherwise fail at parse/help time with a confusing
+        "option already registered" error. Surfacing the conflict at the
+        second add_global_option call points the caller at the real cause.
+        """
+        import pytest
+
+        @click.group()
+        def root() -> None: ...
+
+        @root.command("sub-cmd")
+        def sub() -> None: ...
+
+        add_global_option(root, "--json", is_flag=True)
+
+        with pytest.raises(ValueError, match="already has a parameter"):
+            add_global_option(root, "--json", is_flag=True)
+
+    def test_rejects_conflict_with_existing_manual_option(self) -> None:
+        """If a command already has a matching option, installing raises.
+
+        Same cause as the duplicate-install case but surfaces when the
+        caller is mixing add_global_option with hand-declared options.
+        """
+        import pytest
+
+        @click.group()
+        def root() -> None: ...
+
+        @root.command("sub-cmd")
+        @click.option("--json", is_flag=True)
+        def sub(json: bool) -> None: ...
+
+        with pytest.raises(ValueError, match="already has a parameter"):
+            add_global_option(root, "--json", is_flag=True)
+
+    def test_slash_flag_uses_innermost_wins(self) -> None:
+        """--foo/--no-foo is a slash-flag and resolves innermost-wins.
+
+        For plain flags ("--foo" only) we OR across levels -- there's no
+        way to explicitly say "off" at an inner level. But slash-flags
+        give the user an explicit off-form ("--no-foo"), and the
+        intuitive semantic is "the level the user typed it at wins". An
+        inner --no-foo must be able to override an outer --foo, which
+        OR-merge can't produce (False never wins an OR).
+        """
+        captured: dict[str, object] = {}
+
+        @click.group()
+        def root() -> None: ...
+
+        @root.command("sub-cmd")
+        @click.pass_context
+        def sub(ctx: click.Context) -> None:
+            captured.update(ctx.find_root().meta)
+
+        add_global_option(root, "--shout/--no-shout", is_flag=True, default=False)
+
+        runner = CliRunner()
+
+        # Inner --no-shout should override outer --shout. With OR merge
+        # (the plain-flag rule) this would return True; with innermost-
+        # wins it correctly returns False.
+        captured.clear()
+        result = runner.invoke(root, ["--shout", "sub-cmd", "--no-shout"])
+        assert result.exit_code == 0, result.output
+        assert captured.get("shout") is False, (
+            "Inner --no-shout should override outer --shout (innermost-wins "
+            f"for slash-flags); got ctx.meta['shout']={captured.get('shout')!r}"
+        )
+
+        # Outer --shout alone still works.
+        captured.clear()
+        result = runner.invoke(root, ["--shout", "sub-cmd"])
+        assert result.exit_code == 0, result.output
+        assert captured.get("shout") is True
+
+
 class TestAddGlobalOptionIntegration:
     """End-to-end check that add_global_option composes with create_cli()."""
 

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -448,6 +448,72 @@ class TestAddGlobalOptionEntryPointPropagation:
             "LazyEntryPointCommand.invoke forwards parent=ctx.parent to loaded.main()."
         )
 
+    def test_global_option_flag_collision_with_plugin_raises(self, monkeypatch) -> None:
+        """If a plugin declares the same flag add_global_option installed, error.
+
+        WHY this test exists: add_global_option's conflict detection can't
+        see inside a LazyEntryPointCommand until the plugin is actually
+        loaded. So a plugin's private ``--json`` stays invisible to the
+        install-time guard. Without a runtime check in
+        LazyEntryPointCommand.invoke, Click would parse the flag at the
+        proxy level, consume the token, and the plugin would silently
+        never see its own option -- a nasty "it's ignored and I have no
+        idea why" debugging experience for plugin authors.
+
+        The runtime check in discovery.py compares the proxy's and the
+        loaded command's flag strings at invoke time and raises
+        click.UsageError on overlap. This test builds that exact collision
+        (plugin declares --json internally, CLI has add_global_option's
+        --json installed) and asserts the error fires with both sides
+        named so the caller can find the conflict quickly.
+        """
+        import click
+        from click.testing import CliRunner
+        from clickwork.discovery import discover_commands_from_entrypoints
+
+        class FakeEntryPoint:
+            name = "plugin-cmd"
+
+            def load(self):
+                # The plugin independently declares --json on its own
+                # command. This is the scenario add_global_option's
+                # install-time check can't detect because at install
+                # time the plugin hasn't been loaded yet.
+                @click.command(name="plugin-cmd")
+                @click.option("--json", is_flag=True)
+                def plugin_cmd(json: bool) -> None: ...
+
+                return plugin_cmd
+
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda group=None: [FakeEntryPoint()] if group == "clickwork.commands" else [],
+        )
+
+        @click.group()
+        def root() -> None: ...
+
+        commands = discover_commands_from_entrypoints()
+        for cmd_name, cmd in commands.items():
+            root.add_command(cmd, cmd_name)
+
+        # This succeeds because the proxy's params (at this point) are
+        # empty, so add_global_option sees no collision. The collision
+        # only materialises at invoke time when the plugin is loaded.
+        add_global_option(root, "--json", is_flag=True)
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["plugin-cmd"])
+
+        # UsageError exit code is 2; message must name both sides so the
+        # caller can figure out where to fix it.
+        assert result.exit_code == 2, (
+            f"Expected UsageError (exit 2) on plugin flag collision; "
+            f"got exit={result.exit_code}, output={result.output!r}"
+        )
+        assert "plugin-cmd" in result.output
+        assert "--json" in result.output
+
 
 class TestAddGlobalOptionIntegration:
     """End-to-end check that add_global_option composes with create_cli()."""

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -270,7 +270,7 @@ class TestAddGlobalOptionGuards:
 
         add_global_option(root, "--json", is_flag=True)
 
-        with pytest.raises(ValueError, match="already has a parameter"):
+        with pytest.raises(ValueError, match="Cannot install global option"):
             add_global_option(root, "--json", is_flag=True)
 
     def test_rejects_conflict_with_existing_manual_option(self) -> None:
@@ -288,7 +288,7 @@ class TestAddGlobalOptionGuards:
         @click.option("--json", is_flag=True)
         def sub(json: bool) -> None: ...
 
-        with pytest.raises(ValueError, match="already has a parameter"):
+        with pytest.raises(ValueError, match="Cannot install global option"):
             add_global_option(root, "--json", is_flag=True)
 
     def test_slash_flag_uses_innermost_wins(self) -> None:
@@ -331,6 +331,93 @@ class TestAddGlobalOptionGuards:
         result = runner.invoke(root, ["--shout", "sub-cmd"])
         assert result.exit_code == 0, result.output
         assert captured.get("shout") is True
+
+
+class TestAddGlobalOptionConflictDetection:
+    """The conflict check catches flag-string collisions too, not just name collisions."""
+
+    def test_rejects_conflict_by_flag_string_even_when_names_differ(self) -> None:
+        """A pre-existing @click.option('output_json', '--json') collides on '--json'.
+
+        The Python name 'output_json' does NOT match add_global_option's
+        derived 'json', so a name-only conflict check would miss this. The
+        flag-string check catches it.
+        """
+        import pytest
+
+        @click.group()
+        def root() -> None: ...
+
+        @root.command("sub-cmd")
+        @click.option("output_json", "--json", is_flag=True)
+        def sub(output_json: bool) -> None: ...
+
+        with pytest.raises(ValueError, match="already uses flag string"):
+            add_global_option(root, "--json", is_flag=True)
+
+
+class TestAddGlobalOptionEntryPointPropagation:
+    """ctx.meta values propagate into entry-point plugin commands.
+
+    LazyEntryPointCommand.invoke creates a fresh Click context for the
+    loaded plugin command; without parent= wiring, the plugin's
+    ctx.find_root() would return a detached root and miss values that
+    add_global_option wrote to the true root's meta. This test pins the
+    parent=ctx forwarding we added in discovery.py.
+    """
+
+    def test_global_option_value_reaches_entry_point_plugin(self, monkeypatch) -> None:
+        """A plugin command loaded via entry point sees ctx.find_root().meta['json']."""
+        import click
+        from click.testing import CliRunner
+        from clickwork.discovery import discover_commands_from_entrypoints
+
+        captured: dict = {}
+
+        class FakeEntryPoint:
+            """Imitates importlib.metadata.EntryPoint's name + load() interface."""
+
+            name = "plugin-cmd"
+
+            def load(self):
+                @click.command(name="plugin-cmd")
+                @click.pass_context
+                def plugin_cmd(ctx: click.Context) -> None:
+                    # The key assertion: the plugin's find_root() returns
+                    # the parent CLI's context, so meta values from
+                    # add_global_option are visible here.
+                    captured["json"] = ctx.find_root().meta.get("json")
+
+                return plugin_cmd
+
+        # Replace the real importlib.metadata.entry_points with our stub so
+        # discover_commands_from_entrypoints returns the fake above.
+        monkeypatch.setattr(
+            "importlib.metadata.entry_points",
+            lambda group=None: [FakeEntryPoint()] if group == "clickwork.commands" else [],
+        )
+
+        @click.group()
+        def root() -> None: ...
+
+        # Attach the lazy entry-point proxy to the root group. Normally
+        # create_cli() does this, but we build a minimal root here so the
+        # test stays focused on the meta-propagation invariant.
+        commands = discover_commands_from_entrypoints()
+        for cmd_name, cmd in commands.items():
+            root.add_command(cmd, cmd_name)
+
+        add_global_option(root, "--json", is_flag=True)
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["--json", "plugin-cmd"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("json") is True, (
+            "Global option value did not propagate into the entry-point "
+            f"plugin command; got captured={captured!r}. Check that "
+            "LazyEntryPointCommand.invoke forwards parent=ctx to loaded.main()."
+        )
 
 
 class TestAddGlobalOptionIntegration:

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -1,0 +1,262 @@
+"""Tests for clickwork.add_global_option.
+
+add_global_option() installs a single Click option at every level (root group,
+nested groups, and leaf subcommands) so users can pass it at any position on
+the command line. The resolved value is merged into the Click root context's
+``meta`` dict under the option's Python-identifier name.
+
+Resolution rules (exercised below):
+    - Flags (``is_flag=True``) OR across levels: truthy at ANY level wins.
+    - Value options (string, int, etc.) use innermost-wins semantics.
+    - Not passed anywhere => False for flags, None (or Click default) for values.
+
+These tests build minimal inline Click CLIs to keep each test focused on the
+parsing/merge behaviour of add_global_option itself. A single end-of-file
+integration test confirms it also works with ``clickwork.create_cli()``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from click.testing import CliRunner
+
+from clickwork import add_global_option
+from clickwork.cli import create_cli
+
+
+def _build_root_with_sub() -> tuple[click.Group, dict[str, object]]:
+    """Build a root group with a single leaf subcommand for flag/value tests.
+
+    The subcommand's callback writes ``ctx.meta`` into a shared dict so tests
+    can assert on the resolved values after invocation. We use a dict-capture
+    pattern because CliRunner can't directly return the Click context.
+
+    Returns:
+        A (root_group, captured) tuple. ``captured`` starts empty and is
+        populated with a copy of ``ctx.find_root().meta`` when the subcommand
+        runs.
+    """
+    captured: dict[str, object] = {}
+
+    @click.group()
+    def root() -> None:
+        """Root group for testing global options."""
+
+    @root.command("sub-cmd")
+    @click.pass_context
+    def sub_cmd(ctx: click.Context) -> None:
+        """Leaf subcommand that snapshots ctx.meta so tests can inspect it."""
+        # Copy from the ROOT meta because that's where add_global_option
+        # stores its resolved values (the invariant the feature promises).
+        captured.update(ctx.find_root().meta)
+
+    return root, captured
+
+
+class TestAddGlobalOptionFlag:
+    """Flag behaviour: --json is_flag=True, OR across levels, default False."""
+
+    def test_add_global_option_root_level_parses(self) -> None:
+        """``myapp --json sub-cmd`` sets ``ctx.meta['json']`` to True.
+
+        WHY this is the simplest case: the flag sits on the root group,
+        where Click would normally bind it. We just need to make sure our
+        callback writes through to the root context's meta.
+        """
+        root, captured = _build_root_with_sub()
+        add_global_option(root, "--json", is_flag=True, help="Emit JSON.")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["--json", "sub-cmd"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("json") is True
+
+    def test_add_global_option_subcommand_level_parses(self) -> None:
+        """``myapp sub-cmd --json`` sets ``ctx.meta['json']`` to True.
+
+        WHY this matters: users intuitively expect ``--json`` to work on the
+        subcommand they're calling, not only on the top-level binary. Our
+        callback on the subcommand's option has to walk up to root.meta.
+        """
+        root, captured = _build_root_with_sub()
+        add_global_option(root, "--json", is_flag=True, help="Emit JSON.")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["sub-cmd", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("json") is True
+
+    def test_add_global_option_group_level_parses(self) -> None:
+        """With a nested group, ``myapp group --json sub-cmd`` sets meta.
+
+        The nested group is a common pattern (``orbit-admin users list``).
+        add_global_option must recurse into nested groups so users can also
+        pass the flag at the middle level.
+        """
+        captured: dict[str, object] = {}
+
+        @click.group()
+        def root() -> None:
+            """Root group."""
+
+        @root.group("group")
+        def inner_group() -> None:
+            """Nested group under root."""
+
+        @inner_group.command("sub-cmd")
+        @click.pass_context
+        def sub_cmd(ctx: click.Context) -> None:
+            """Leaf under the nested group."""
+            captured.update(ctx.find_root().meta)
+
+        add_global_option(root, "--json", is_flag=True, help="Emit JSON.")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["group", "--json", "sub-cmd"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("json") is True
+
+    def test_add_global_option_flag_or_semantics_across_levels(self) -> None:
+        """OR semantics: flag at root OR subcommand OR both => True.
+
+        The OR rule means any single occurrence at any level flips the meta
+        value to True. Passing at two levels is still True (not a conflict).
+        """
+        root, captured = _build_root_with_sub()
+        add_global_option(root, "--json", is_flag=True, help="Emit JSON.")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["--json", "sub-cmd", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("json") is True
+
+    def test_add_global_option_not_passed_is_falsy_or_none(self) -> None:
+        """No --json anywhere => meta['json'] is False (flag default)."""
+        root, captured = _build_root_with_sub()
+        add_global_option(root, "--json", is_flag=True, help="Emit JSON.")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["sub-cmd"])
+
+        assert result.exit_code == 0, result.output
+        # False, not missing: even a default-only parse writes to meta so
+        # consumers can unconditionally read ctx.meta['json'] without
+        # .get()-with-default.
+        assert captured.get("json") is False
+
+
+class TestAddGlobalOptionValue:
+    """Value behaviour: --env is a string option, innermost-wins semantics."""
+
+    def test_value_innermost_wins_when_both_levels_set(self) -> None:
+        """``--env=prod sub-cmd --env=staging`` => meta['env'] == 'staging'.
+
+        Innermost wins because the subcommand level is closer to the action
+        being taken. This matches how most CLIs handle overrides (e.g.,
+        config-file env beats global env).
+        """
+        root, captured = _build_root_with_sub()
+        add_global_option(root, "--env", default=None, help="Environment.")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["--env=prod", "sub-cmd", "--env=staging"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("env") == "staging"
+
+    def test_value_root_only_propagates_to_meta(self) -> None:
+        """``--env=prod sub-cmd`` => meta['env'] == 'prod' (root wins alone)."""
+        root, captured = _build_root_with_sub()
+        add_global_option(root, "--env", default=None, help="Environment.")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["--env=prod", "sub-cmd"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("env") == "prod"
+
+    def test_value_not_passed_is_none(self) -> None:
+        """No --env anywhere => meta['env'] is None (the Click default)."""
+        root, captured = _build_root_with_sub()
+        add_global_option(root, "--env", default=None, help="Environment.")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["sub-cmd"])
+
+        assert result.exit_code == 0, result.output
+        assert captured.get("env") is None
+
+
+class TestAddGlobalOptionSnapshotSemantics:
+    """add_global_option is a call-time snapshot, NOT retroactive."""
+
+    def test_added_subcommands_do_not_inherit_option_retroactively(self) -> None:
+        """Subcommands attached AFTER add_global_option() don't get the option.
+
+        WHY snapshot: retroactive registration would require monkey-patching
+        Group.add_command and introduces lifecycle surprises (e.g., options
+        appearing on commands imported from third-party plugins). The
+        snapshot rule keeps the behaviour predictable and testable.
+        """
+        root, _ = _build_root_with_sub()
+        add_global_option(root, "--json", is_flag=True, help="Emit JSON.")
+
+        # Attach a fresh command AFTER the snapshot. It must NOT know about
+        # --json, so invoking ``fresh --json`` should error as an unknown
+        # option (Click's UsageError, exit code 2).
+        @root.command("fresh")
+        def fresh() -> None:
+            """A command added after add_global_option() ran."""
+            click.echo("fresh ran")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["fresh", "--json"])
+
+        assert result.exit_code != 0
+        # Click's canonical phrasing for unknown options is "no such option".
+        assert "no such option" in result.output.lower()
+
+
+class TestAddGlobalOptionIntegration:
+    """End-to-end check that add_global_option composes with create_cli()."""
+
+    def test_works_with_create_cli_harness(self, tmp_path: Path) -> None:
+        """A CLI built via create_cli() accepts add_global_option flags.
+
+        This confirms we don't depend on any clickwork-specific wiring
+        besides Click's own ctx.meta: the feature works whether the root
+        group was built by hand or by the clickwork harness.
+        """
+        cmd_dir = tmp_path / "commands"
+        cmd_dir.mkdir()
+        # A command file that snapshots ctx.find_root().meta into a file so
+        # we can assert on it after CliRunner invokes the CLI. We can't
+        # capture via a shared dict here because discover_commands() imports
+        # the module fresh -- references from the test module aren't visible.
+        snapshot_path = tmp_path / "snapshot.txt"
+        (cmd_dir / "echo_json.py").write_text(
+            "import click\n"
+            f"SNAPSHOT = {str(snapshot_path)!r}\n"
+            "\n"
+            "@click.command('echo-json')\n"
+            "@click.pass_context\n"
+            "def cli(ctx):\n"
+            "    root_meta = ctx.find_root().meta\n"
+            "    # Write 'json=True' (or False) so the test can read it back.\n"
+            "    with open(SNAPSHOT, 'w') as fh:\n"
+            "        fh.write(f\"json={root_meta.get('json')!r}\")\n"
+        )
+
+        cli = create_cli(name="test-cli", commands_dir=cmd_dir)
+        add_global_option(cli, "--json", is_flag=True, help="Emit JSON.")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["echo-json", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert snapshot_path.read_text() == "json=True"

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -355,6 +355,30 @@ class TestAddGlobalOptionConflictDetection:
         with pytest.raises(ValueError, match="already uses flag string"):
             add_global_option(root, "--json", is_flag=True)
 
+    def test_rejects_slash_flag_conflict(self) -> None:
+        """A slash-flag param_decl must match against existing --foo/--no-foo.
+
+        '--shout/--no-shout' is a *single* string in param_decls but Click
+        splits it into two flag strings (opts=['--shout'] +
+        secondary_opts=['--no-shout']). Early drafts of the conflict
+        check filtered param_decls with .startswith('-'), which for slash-
+        flags left the unsplit '--shout/--no-shout' string -- intersection
+        with {'--shout','--no-shout'} is empty and the collision slips
+        through. This test pins the probe-based derivation that splits
+        the slash-flag correctly.
+        """
+        import pytest
+
+        @click.group()
+        def root() -> None: ...
+
+        @root.command("sub-cmd")
+        @click.option("--shout/--no-shout", is_flag=True, default=False)
+        def sub(shout: bool) -> None: ...
+
+        with pytest.raises(ValueError, match="already uses flag string"):
+            add_global_option(root, "--shout/--no-shout", is_flag=True, default=False)
+
 
 class TestAddGlobalOptionEntryPointPropagation:
     """ctx.meta values propagate into entry-point plugin commands.

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -217,7 +217,12 @@ class TestAddGlobalOptionSnapshotSemantics:
         runner = CliRunner()
         result = runner.invoke(root, ["fresh", "--json"])
 
-        assert result.exit_code != 0
+        # Click uses exit code 2 specifically for UsageError (its standard
+        # classification for "bad CLI invocation"). Tighten from `!= 0` to
+        # `== 2` so we catch a regression where some unrelated exit code
+        # (e.g. 1 from a thrown exception in a callback) would otherwise
+        # let this test silently pass.
+        assert result.exit_code == 2
         # Click's canonical phrasing for unknown options is "no such option".
         assert "no such option" in result.output.lower()
 

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -8,7 +8,9 @@ the command line. The resolved value is merged into the Click root context's
 Resolution rules (exercised below):
     - Flags (``is_flag=True``) OR across levels: truthy at ANY level wins.
     - Value options (string, int, etc.) use innermost-wins semantics.
-    - Not passed anywhere => False for flags, None (or Click default) for values.
+    - Not passed anywhere => Click-resolved default (typically False for
+      flags and None for value options, but the caller can override either
+      via ``default=...`` in the option_kwargs).
 
 These tests build minimal inline Click CLIs to keep each test focused on the
 parsing/merge behaviour of add_global_option itself. A single end-of-file
@@ -387,7 +389,10 @@ class TestAddGlobalOptionEntryPointPropagation:
     loaded plugin command; without parent= wiring, the plugin's
     ctx.find_root() would return a detached root and miss values that
     add_global_option wrote to the true root's meta. This test pins the
-    parent=ctx forwarding we added in discovery.py.
+    parent=ctx.parent forwarding we added in discovery.py (it has to be
+    ctx.parent, not ctx itself, to avoid Click double-counting the
+    plugin-cmd segment in the loaded command's command_path -- the proxy
+    ctx already represents that level in the chain).
     """
 
     def test_global_option_value_reaches_entry_point_plugin(self, monkeypatch) -> None:
@@ -440,7 +445,7 @@ class TestAddGlobalOptionEntryPointPropagation:
         assert captured.get("json") is True, (
             "Global option value did not propagate into the entry-point "
             f"plugin command; got captured={captured!r}. Check that "
-            "LazyEntryPointCommand.invoke forwards parent=ctx to loaded.main()."
+            "LazyEntryPointCommand.invoke forwards parent=ctx.parent to loaded.main()."
         )
 
 

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -6,7 +6,12 @@ the command line. The resolved value is merged into the Click root context's
 ``meta`` dict under the option's Python-identifier name.
 
 Resolution rules (exercised below):
-    - Flags (``is_flag=True``) OR across levels: truthy at ANY level wins.
+    - Plain flags (single ``--foo`` with ``is_flag=True``) OR across levels:
+      truthy at ANY level wins.
+    - Slash-flags (``--foo/--no-foo`` with ``is_flag=True``) are an
+      exception -- they use innermost-wins so an inner ``--no-foo`` can
+      override an outer ``--foo`` (OR would never let False win, rendering
+      the off-form useless at inner levels).
     - Value options (string, int, etc.) use innermost-wins semantics.
     - Not passed anywhere => Click-resolved default (typically False for
       flags and None for value options, but the caller can override either


### PR DESCRIPTION
## Summary
``clickwork.add_global_option(cli, *decls, **opt_kwargs)`` walks the root group + every subgroup + every subcommand currently attached and installs the option on each. User can then pass the flag at **any** level and it resolves into ``ctx.find_root().meta[name]``.

**Resolution semantics:**
- **Flags** (``is_flag=True``): OR across levels — truthy at any level wins.
- **Value options**: innermost wins, via ``click.ParameterSource.DEFAULT`` check to distinguish explicit user input from defaults (handles options whose valid user value is ``None`` or whose default is non-``None`` without sentinel hacks).

**Implementation:** Click option callbacks with ``expose_value=False``. Click's parsing fires group callbacks before subcommand callbacks, so "outer first, inner later" parse order produces innermost-wins naturally when combined with the ``ParameterSource`` check. ``expose_value=False`` means existing command function signatures don't need to change — the option is invisible to callers except via ``ctx.meta``.

**Snapshot semantics:** registration is a call-time snapshot. Commands added *after* ``add_global_option()`` do NOT retroactively get the option. Deliberate design choice — documented in the docstring.

New module ``src/clickwork/global_options.py`` (distinct concern from ``cli.py``). Re-exported as ``clickwork.add_global_option``.

Fixes #14.

## Test plan
- [x] Flag OR semantics: root-only, sub-only, group-level, both levels, not-passed
- [x] Value innermost-wins: both levels set, root-only, not-passed
- [x] Snapshot semantics: command added after ``add_global_option()`` rejects the option
- [x] Integration: full ``create_cli()`` harness with disk-based discovery
- [x] Full suite: 149 passed (139 baseline + 10 new), zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)