### PR TITLE
feat: ctx.run_with_secrets for safe subprocess secret delivery (Fixes #11)

### DIFF
--- a/src/clickwork/_types.py
+++ b/src/clickwork/_types.py
@@ -372,3 +372,17 @@ class CliContext:
         default=None, repr=False, compare=False,
     )
     """Confirm then run: wraps confirm() + run() in a single call."""
+
+    run_with_secrets: Callable[..., subprocess.CompletedProcess | None] | None = field(
+        default=None, repr=False, compare=False,
+    )
+    """Run a subprocess with secrets delivered via env (and optionally stdin).
+
+    The helper rejects ``Secret`` instances appearing directly in ``cmd``
+    (argv is visible in ``ps``), places each entry of ``secrets`` into the
+    subprocess's environment, and -- when ``stdin_secret="NAME"`` is set
+    -- additionally pipes ``secrets["NAME"].get()`` through the child's
+    stdin (Wave 1's ``stdin_text=`` path). Log lines show env-var NAMES
+    but redact VALUES. See :func:`clickwork.process.run_with_secrets` for
+    the full contract and examples.
+    """

--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -27,7 +27,12 @@ from clickwork._logging import setup_logging
 from clickwork._types import CliContext, CliProcessError, PrerequisiteError, normalize_prefix
 from clickwork.config import ConfigError, load_config
 from clickwork.discovery import discover_commands
-from clickwork.process import capture as _capture, run as _run, run_with_confirm as _run_with_confirm
+from clickwork.process import (
+    capture as _capture,
+    run as _run,
+    run_with_confirm as _run_with_confirm,
+    run_with_secrets as _run_with_secrets,
+)
 from clickwork.prompts import confirm as _confirm, confirm_destructive as _confirm_destructive
 
 
@@ -439,6 +444,20 @@ def create_cli(
             env=env,
             stdin_text=stdin_text,
             stdin_bytes=stdin_bytes,
+        )
+
+        # run_with_secrets: safety-focused wrapper for subprocesses that
+        # need sensitive input. The forwarding lambda captures cli_ctx.dry_run
+        # (so --dry-run at the CLI level short-circuits secret delivery too)
+        # and accepts ``env=`` as a non-secret passthrough, matching the shape
+        # of the other bindings above. secrets / stdin_secret are keyword-only
+        # at the helper level; we mirror that here.
+        cli_ctx.run_with_secrets = lambda cmd, *, secrets, stdin_secret=None, env=None: _run_with_secrets(
+            cmd,
+            secrets=secrets,
+            stdin_secret=stdin_secret,
+            dry_run=cli_ctx.dry_run,
+            env=env,
         )
 
         # Attach the CliContext to Click's ctx.obj so all subcommands can

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -739,7 +739,21 @@ def run_with_secrets(
                 "Secret(...) before passing them into run_with_secrets."
             )
 
-    # 5. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
+    # 5. stdin_secret must be a str (or None) before we use it in a
+    # dict-membership test. Without this check a caller who passes
+    # a list/dict (common typo: ``stdin_secret=["TOKEN"]`` when they
+    # meant the string) would crash on the ``in secrets`` check below
+    # with an opaque ``TypeError: unhashable type: 'list'`` far from
+    # the real cause. Validate the type up front with an actionable
+    # message.
+    if stdin_secret is not None and not isinstance(stdin_secret, str):
+        raise TypeError(
+            f"stdin_secret must be a str (or None); got "
+            f"{type(stdin_secret).__name__}. Pass the KEY name from "
+            "your ``secrets={}`` dict, e.g. stdin_secret=\"TOKEN\"."
+        )
+
+    # 7. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
     # we touch Secret.get() for any reason, so a typo surfaces as a
     # clear ValueError with no secret material in flight.
     if stdin_secret is not None and stdin_secret not in secrets:
@@ -760,7 +774,7 @@ def run_with_secrets(
         f"<redacted:{stdin_secret}>" if stdin_secret is not None else "<none>"
     )
 
-    # 6. Dry-run short-circuit. Docstring promises dry_run does not
+    # 8. Dry-run short-circuit. Docstring promises dry_run does not
     # pull secret values into memory. Honouring that means bailing out
     # BEFORE Secret.get() on any entry of ``secrets`` -- only the
     # caller-supplied ``env`` (which is already plain strings) and the
@@ -782,7 +796,7 @@ def run_with_secrets(
         )
         return None
 
-    # 7. Build the full env for the subprocess. Caller's env goes first
+    # 9. Build the full env for the subprocess. Caller's env goes first
     # so secrets win on key conflict -- the helper's job is to deliver
     # the secret, and a stale override from ``env`` would silently break
     # that contract. Each Secret.get() is called EXACTLY ONCE and the
@@ -796,14 +810,14 @@ def run_with_secrets(
     # label so operators can tell them apart. Neither leaks the value.
     secret_keys = set(secret_env.keys())
 
-    # 8. Resolve the stdin payload from the ALREADY-unwrapped secret_env
+    # 10. Resolve the stdin payload from the ALREADY-unwrapped secret_env
     # dict rather than calling Secret.get() a second time -- one unwrap
     # per secret keeps the "minimal touch" contract explicit.
     stdin_payload: str | None = None
     if stdin_secret is not None:
         stdin_payload = secret_env[stdin_secret]
 
-    # 9. Emit the helper's own log line. This is the SINGLE place where
+    # 11. Emit the helper's own log line. This is the SINGLE place where
     # the "secrets-in-play" subprocess launch is recorded. We log
     # BEFORE delegating to run() so:
     #   - the argv (already validated Secret-free and all-str) appears
@@ -818,7 +832,7 @@ def run_with_secrets(
         stdin_display,
     )
 
-    # 10. Delegate. run() handles signal forwarding and stdin piping --
+    # 12. Delegate. run() handles signal forwarding and stdin piping --
     # we reuse all of it instead of reinventing the wheel (and instead
     # of teaching run() about Secret). dry_run was already handled
     # above so we pass False here to make that explicit.

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -24,7 +24,7 @@ import shlex
 import signal
 import subprocess
 
-from clickwork._types import CliProcessError
+from clickwork._types import CliProcessError, Secret
 from clickwork.prompts import confirm as _prompt_confirm
 
 logger = logging.getLogger("clickwork")
@@ -500,4 +500,241 @@ def run_with_confirm(
         env=env,
         stdin_text=stdin_text,
         stdin_bytes=stdin_bytes,
+    )
+
+
+def _validate_no_secret_in_argv(cmd: list[str | Secret]) -> None:
+    """Reject any ``Secret`` instance that appears as an argv element.
+
+    WHY an explicit-instance check and NOT a deep value scan:
+    argv is world-readable via ``ps`` / ``/proc/*/cmdline`` on most
+    POSIX systems. The goal of this guard is to catch the common
+    footgun -- a caller writing ``run_with_secrets(["curl", "-H",
+    f"Authorization: Bearer {tok}"], ...)`` where ``tok`` is a
+    ``Secret`` -- and surface it loudly before the subprocess starts.
+
+    We deliberately do NOT scan string elements for values that
+    happen to match some ``Secret.get()``. That would either require
+    the caller to declare every secret in advance (defeating the
+    ``secrets=`` signature) or scan every string against every known
+    Secret globally (brittle, performance-hostile, and prone to
+    false positives on short secrets). The explicit-Secret check
+    catches the realistic mistake without the deep-scan pitfalls.
+
+    The error message names the offending arg's POSITION (its index
+    in ``cmd``), never its value. Leaking ``.get()`` in our own
+    rejection path would undermine the whole point of the helper.
+
+    Args:
+        cmd: Argv list whose elements may be ``str`` or ``Secret``.
+
+    Raises:
+        ValueError: If any element is a ``Secret`` instance. The
+            message names the first offending position.
+    """
+    for idx, arg in enumerate(cmd):
+        if isinstance(arg, Secret):
+            # NOTE: no str(arg) here -- Secret.__str__ returns "***"
+            # which is safe, but we also don't want the error message
+            # to hint at the arg beyond its position. Position alone
+            # is enough for the caller to fix the call site.
+            raise ValueError(
+                f"cmd[{idx}] is a Secret instance. Do not place secrets "
+                "in argv (visible in `ps` output). Pass them via "
+                "`secrets={...}` (env) or `stdin_secret=\"NAME\"` (stdin) instead."
+            )
+
+
+def _format_env_redacted(
+    env: dict[str, str] | None,
+    secret_keys: set[str],
+) -> str:
+    """Render an env dict for logging, redacting secret-sourced values.
+
+    Keys that came from ``secrets={}`` are rendered as ``NAME=<redacted>``;
+    all other keys keep their value. Env-var NAMES stay visible so
+    operators debugging a subprocess launch can confirm what the child
+    sees (missing keys, typos). Only values are hidden.
+
+    Args:
+        env: The full env dict that will be passed to the subprocess,
+            or ``None`` if no extra env was built.
+        secret_keys: The set of keys whose values came from ``secrets``
+            and therefore must be redacted.
+
+    Returns:
+        A single-line string representation suitable for a log message.
+    """
+    if env is None:
+        return "{}"
+    parts: list[str] = []
+    for name, value in env.items():
+        if name in secret_keys:
+            parts.append(f"{name}=<redacted>")
+        else:
+            parts.append(f"{name}={value}")
+    return "{" + ", ".join(parts) + "}"
+
+
+def run_with_secrets(
+    cmd: list[str | Secret],
+    *,
+    secrets: dict[str, Secret],
+    stdin_secret: str | None = None,
+    dry_run: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess | None:
+    """Execute a command with secrets delivered via env and/or stdin, never argv.
+
+    This is a safety-focused wrapper over :func:`run` for subprocesses that
+    need sensitive data. It centralises two guardrails that are easy to
+    forget at individual call sites:
+
+    1. **Explicit-Secret rejection in argv.** Any ``Secret`` instance that
+       appears directly in ``cmd`` raises :class:`ValueError` before the
+       subprocess starts. Argv is world-readable via ``ps`` and
+       ``/proc/*/cmdline`` on most POSIX systems, so putting a secret
+       there leaks it to any local user. The check is intentionally
+       shallow: we reject *explicit Secret instances only*, not string
+       arguments whose value happens to match some ``Secret.get()``. The
+       rationale -- and why a deep scan is NOT the right choice here --
+       is spelled out on :func:`_validate_no_secret_in_argv`.
+    2. **Redacted logging.** The helper emits its own log line BEFORE
+       delegating to :func:`run`, with every secret-sourced env-var
+       rendered as ``NAME=<redacted>``. Env-var names stay visible so
+       operators can see what environment the subprocess sees; values
+       are hidden. ``run()`` itself has no knowledge of Secret semantics
+       and emits no env-echoing logs during normal execution, so no
+       redaction is needed there.
+
+    Delivery:
+
+    - **Env (always).** Every key in ``secrets`` is placed in the
+      subprocess's environment with its unwrapped value. Caller-supplied
+      ``env`` is merged underneath; on key conflict, ``secrets`` wins.
+    - **Stdin (optional).** If ``stdin_secret="NAME"`` is set, the value
+      of ``secrets["NAME"]`` is ALSO piped to the child's stdin (via
+      Wave 1's ``stdin_text=`` helper on :func:`run`). The same value
+      is in env -- some tools prefer one channel, some the other.
+
+    Args:
+        cmd: Argv list. Elements are typed as ``str | Secret`` so the
+            Secret-in-argv check is meaningful at the type level, but
+            after validation argv is guaranteed to be plain strings.
+        secrets: Keyword-only. Mapping of env-var names to ``Secret``
+            instances. Passing an empty dict is legal (no secrets
+            delivered) but in that case you probably want :func:`run`
+            directly -- using this helper when there are no secrets
+            just adds ceremony with no safety benefit.
+        stdin_secret: Keyword-only. If set, the name of the key in
+            ``secrets`` whose value should ALSO be piped through stdin.
+            Must be a key in ``secrets`` -- otherwise raises
+            :class:`ValueError` without leaking any secret value.
+        dry_run: Keyword-only. If True, log what would happen and return
+            ``None`` without spawning a subprocess or reading any
+            secret value into a child's env / stdin. Matches the
+            :func:`run` dry-run semantics.
+        env: Keyword-only. Additional (non-secret) env vars to pass
+            through to the subprocess. Merged UNDER ``secrets`` so the
+            secret value always wins on key conflict.
+
+    Returns:
+        :class:`subprocess.CompletedProcess` on success, or ``None`` in
+        dry-run mode.
+
+    Raises:
+        ValueError: If any ``Secret`` appears in ``cmd``, or if
+            ``stdin_secret`` names a key that isn't in ``secrets``.
+        CliProcessError: Propagated from :func:`run` if the child
+            exits non-zero.
+
+    Example -- ``wrangler secret put`` reads the secret from stdin so
+    it never appears in argv::
+
+        ctx.run_with_secrets(
+            ["wrangler", "secret", "put", "API_TOKEN"],
+            secrets={"CLOUDFLARE_API_TOKEN": Secret(token)},
+            stdin_secret="CLOUDFLARE_API_TOKEN",
+        )
+
+    Example -- ``docker login --password-stdin`` uses the same pattern::
+
+        ctx.run_with_secrets(
+            ["docker", "login", "-u", username, "--password-stdin",
+             "registry.example.com"],
+            secrets={"DOCKER_REG_PASSWORD": Secret(password)},
+            stdin_secret="DOCKER_REG_PASSWORD",
+        )
+
+    Follow-up (deliberately out of scope here):
+        A global ``--log-insecure-secrets`` flag / env var would let
+        operators opt in to unredacted logging during local debugging.
+        That's tracked as a separate issue; this helper always redacts.
+    """
+    # 1. Argv guardrail. Run this BEFORE any logging / env building so
+    # the rejection happens as early as possible and can't accidentally
+    # surface the secret through a pre-check log line.
+    _validate_no_secret_in_argv(cmd)
+
+    # 2. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
+    # we touch Secret.get() for any reason, so a typo surfaces as a
+    # clear ValueError with no secret material in flight.
+    if stdin_secret is not None and stdin_secret not in secrets:
+        # Include the requested key name (safe -- the caller typed it)
+        # but NEVER iterate the secrets dict values into the message.
+        raise ValueError(
+            f"stdin_secret={stdin_secret!r} is not a key in secrets={{...}}. "
+            "The name must match one of the keys you pass in `secrets`."
+        )
+
+    # 3. Build the full env for the subprocess. Caller's env goes first
+    # so secrets win on key conflict -- the helper's job is to deliver
+    # the secret, and a stale override from ``env`` would silently break
+    # that contract.
+    base_env: dict[str, str] = dict(env) if env is not None else {}
+    secret_env = {name: s.get() for name, s in secrets.items()}
+    full_env: dict[str, str] = {**base_env, **secret_env}
+    # Track which keys came from secrets so the log line redacts only
+    # those values -- non-secret env vars stay plainly visible.
+    secret_keys = set(secret_env.keys())
+
+    # 4. Resolve stdin payload (if requested) BEFORE logging so that if
+    # anything goes wrong we never emit a half-formed log line. Read
+    # via Secret.get() exactly once here; the value stays in this local
+    # and is passed by reference into run().
+    stdin_payload: str | None = None
+    if stdin_secret is not None:
+        stdin_payload = secrets[stdin_secret].get()
+
+    # 5. Emit the helper's own log line. This is the SINGLE place where
+    # the "secrets-in-play" subprocess launch is recorded. We log
+    # BEFORE delegating to run() so:
+    #   - the argv (already validated Secret-free) appears once, here,
+    #     with full context (env + stdin redacted);
+    #   - run()'s own logging stays unchanged -- it never sees Secret
+    #     objects, only plain strings, and during normal (non-dry-run)
+    #     execution it doesn't log env at all (see process.run()).
+    # cast to list[str] for the formatter -- after _validate_no_secret_in_argv
+    # we know every element is a str, but the annotation is still
+    # list[str | Secret]; _format_cmd doesn't care about the nominal
+    # type, only that each element is str-compatible.
+    plain_cmd: list[str] = [a for a in cmd if isinstance(a, str)]
+    stdin_display = (
+        f"<redacted:{stdin_secret}>" if stdin_secret is not None else "<none>"
+    )
+    logger.info(
+        "run_with_secrets: cmd=%s env=%s stdin=%s",
+        _format_cmd(plain_cmd),
+        _format_env_redacted(full_env, secret_keys),
+        stdin_display,
+    )
+
+    # 6. Delegate. run() handles dry-run, signal forwarding, and stdin
+    # piping -- we deliberately reuse all of it instead of reinventing
+    # the wheel (and instead of teaching run() about Secret).
+    return run(
+        plain_cmd,
+        dry_run=dry_run,
+        env=full_env,
+        stdin_text=stdin_payload,
     )

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -722,16 +722,25 @@ def run_with_secrets(
                 "str(path), ints with str(n), etc."
             )
 
-    # 4. Validate every value in ``secrets`` is a Secret instance. If
-    # a caller accidentally passes a plain string (or any other type),
-    # .get() below would raise AttributeError mid-execution -- which
-    # clickwork.cli's wrapped_invoke classifies as a framework bug
-    # (exit 2, "Internal error: ...") rather than the user error it
-    # actually is. Catching this up front gives a clear TypeError
-    # naming the offending key + type, and the error message
-    # deliberately does NOT include the value (which might itself be
-    # sensitive even in its unwrapped form).
+    # 4. Validate every KEY in ``secrets`` is a str and every VALUE is
+    # a Secret instance. Two distinct failure modes this prevents:
+    #   a) Non-str keys (e.g. ``secrets={1: Secret("x")}``) would
+    #      become env-var names and later fail mid-subprocess launch
+    #      with ``TypeError: expected str, bytes or os.PathLike
+    #      object, not int``. By that point we've already unwrapped
+    #      the Secret into memory -- too late for a clean recovery.
+    #   b) Non-Secret values (e.g. ``secrets={"T": "raw string"}``)
+    #      would crash on ``.get()`` below, misclassified as a
+    #      framework bug through clickwork.cli's wrapped_invoke.
+    # Error messages name the offending key/type but never the
+    # VALUE (which might be sensitive even in its unwrapped form).
     for sname, sval in secrets.items():
+        if not isinstance(sname, str):
+            raise TypeError(
+                f"secrets keys must be str (env-var names); got key of "
+                f"type {type(sname).__name__}. Every entry in the "
+                "secrets dict maps an env-var NAME (str) to a Secret."
+            )
         if not isinstance(sval, Secret):
             raise TypeError(
                 f"secrets[{sname!r}] must be a Secret instance; got "
@@ -753,7 +762,7 @@ def run_with_secrets(
             "your ``secrets={}`` dict, e.g. stdin_secret=\"TOKEN\"."
         )
 
-    # 7. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
+    # 6. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
     # we touch Secret.get() for any reason, so a typo surfaces as a
     # clear ValueError with no secret material in flight.
     if stdin_secret is not None and stdin_secret not in secrets:
@@ -774,7 +783,7 @@ def run_with_secrets(
         f"<redacted:{stdin_secret}>" if stdin_secret is not None else "<none>"
     )
 
-    # 8. Dry-run short-circuit. Docstring promises dry_run does not
+    # 7. Dry-run short-circuit. Docstring promises dry_run does not
     # pull secret values into memory. Honouring that means bailing out
     # BEFORE Secret.get() on any entry of ``secrets`` -- only the
     # caller-supplied ``env`` (which is already plain strings) and the
@@ -796,7 +805,7 @@ def run_with_secrets(
         )
         return None
 
-    # 9. Build the full env for the subprocess. Caller's env goes first
+    # 8. Build the full env for the subprocess. Caller's env goes first
     # so secrets win on key conflict -- the helper's job is to deliver
     # the secret, and a stale override from ``env`` would silently break
     # that contract. Each Secret.get() is called EXACTLY ONCE and the
@@ -810,14 +819,14 @@ def run_with_secrets(
     # label so operators can tell them apart. Neither leaks the value.
     secret_keys = set(secret_env.keys())
 
-    # 10. Resolve the stdin payload from the ALREADY-unwrapped secret_env
+    # 9. Resolve the stdin payload from the ALREADY-unwrapped secret_env
     # dict rather than calling Secret.get() a second time -- one unwrap
     # per secret keeps the "minimal touch" contract explicit.
     stdin_payload: str | None = None
     if stdin_secret is not None:
         stdin_payload = secret_env[stdin_secret]
 
-    # 11. Emit the helper's own log line. This is the SINGLE place where
+    # 10. Emit the helper's own log line. This is the SINGLE place where
     # the "secrets-in-play" subprocess launch is recorded. We log
     # BEFORE delegating to run() so:
     #   - the argv (already validated Secret-free and all-str) appears
@@ -832,7 +841,7 @@ def run_with_secrets(
         stdin_display,
     )
 
-    # 12. Delegate. run() handles signal forwarding and stdin piping --
+    # 11. Delegate. run() handles signal forwarding and stdin piping --
     # we reuse all of it instead of reinventing the wheel (and instead
     # of teaching run() about Secret). dry_run was already handled
     # above so we pass False here to make that explicit.

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -549,18 +549,32 @@ def _format_env_redacted(
     env: dict[str, str] | None,
     secret_keys: set[str],
 ) -> str:
-    """Render an env dict for logging, redacting secret-sourced values.
+    """Render an env dict for logging with ALL values redacted.
 
-    Keys that came from ``secrets={}`` are rendered as ``NAME=<redacted>``;
-    all other keys keep their value. Env-var NAMES stay visible so
-    operators debugging a subprocess launch can confirm what the child
-    sees (missing keys, typos). Only values are hidden.
+    Keys that came from ``secrets={}`` are tagged ``<redacted>``; keys
+    that came from the caller's own ``env`` dict are tagged ``<set>``.
+    Either way, no value content reaches the log.
+
+    WHY we redact non-secret values too (tightened after Copilot review
+    on PR #28): even env vars the caller didn't explicitly wrap in
+    ``Secret`` may be sensitive -- a caller might forget to wrap an
+    ``API_TOKEN`` before dropping it into ``env=``, and printing that
+    to a log would compound the mistake. ``run_with_secrets`` is by
+    definition the "secrets in play" path; treating every env var on
+    that codepath as potentially-sensitive is the safer default.
+    Operators who need to see non-secret env values for debugging can
+    use ``ctx.run`` directly, which doesn't log env at all.
+
+    Names stay visible so operators can confirm WHICH env was set
+    (detect missing / mistyped keys) without seeing the values.
 
     Args:
         env: The full env dict that will be passed to the subprocess,
             or ``None`` if no extra env was built.
-        secret_keys: The set of keys whose values came from ``secrets``
-            and therefore must be redacted.
+        secret_keys: The set of keys whose values came from ``secrets``.
+            Used to tag those keys as ``<redacted>`` vs ``<set>`` for
+            caller-supplied env, so the log clearly shows which keys
+            were secret-sourced.
 
     Returns:
         A single-line string representation suitable for a log message.
@@ -568,11 +582,13 @@ def _format_env_redacted(
     if env is None:
         return "{}"
     parts: list[str] = []
-    for name, value in env.items():
+    for name in env:
         if name in secret_keys:
             parts.append(f"{name}=<redacted>")
         else:
-            parts.append(f"{name}={value}")
+            # Still hide the value (see WHY above) but tag it so the
+            # log distinguishes "secret-sourced" from "caller env".
+            parts.append(f"{name}=<set>")
     return "{" + ", ".join(parts) + "}"
 
 

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -748,6 +748,31 @@ def run_with_secrets(
                 "Secret(...) before passing them into run_with_secrets."
             )
 
+    # 4b. Same discipline for caller-supplied ``env``: if it contains a
+    # non-str key or non-str value, subprocess.Popen raises TypeError
+    # AFTER we'd already unwrapped every Secret into memory -- a wasted
+    # .get() that contradicts the "minimal touch" / safe-failure promise
+    # this function makes elsewhere. Validate env types now so a bad
+    # env dict never triggers a Secret unwrap. Error names the offending
+    # key/type but never any value (a caller's env might itself contain
+    # something sensitive they forgot to wrap; same policy as the
+    # run_with_secrets log redaction).
+    if env is not None:
+        for ekey, eval_ in env.items():
+            if not isinstance(ekey, str):
+                raise TypeError(
+                    f"env keys must be str; got key of type "
+                    f"{type(ekey).__name__}. Every entry in the env "
+                    "dict maps an env-var NAME (str) to its string value."
+                )
+            if not isinstance(eval_, str):
+                raise TypeError(
+                    f"env[{ekey!r}] must be str; got "
+                    f"{type(eval_).__name__}. subprocess.Popen rejects "
+                    "non-str env values -- convert ints/paths with "
+                    "str(...) before passing."
+                )
+
     # 5. stdin_secret must be a str (or None) before we use it in a
     # dict-membership test. Without this check a caller who passes
     # a list/dict (common typo: ``stdin_secret=["TOKEN"]`` when they

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -671,12 +671,34 @@ def run_with_secrets(
         operators opt in to unredacted logging during local debugging.
         That's tracked as a separate issue; this helper always redacts.
     """
-    # 1. Argv guardrail. Run this BEFORE any logging / env building so
+    # 1. Same list-not-string guardrail as run() / capture() /
+    # run_with_confirm. Callers who pass a tuple or a raw string would
+    # otherwise slip past the argv iteration below and bypass the
+    # shell-injection contract the other helpers enforce. _validate_cmd
+    # only checks isinstance(cmd, list), so our declared
+    # list[str | Secret] element typing still goes through it cleanly.
+    _validate_cmd(cmd)
+
+    # 2. Argv guardrail. Run this BEFORE any logging / env building so
     # the rejection happens as early as possible and can't accidentally
     # surface the secret through a pre-check log line.
     _validate_no_secret_in_argv(cmd)
 
-    # 2. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
+    # 3. After the Secret check, every element must be a plain str. A
+    # PathLike, bytes, or int sneaking through would otherwise get
+    # silently dropped by the old filter-comprehension, changing the
+    # command the child sees. Fail loudly with the offending index so
+    # the caller knows exactly what to fix.
+    for idx, arg in enumerate(cmd):
+        if not isinstance(arg, str):
+            raise TypeError(
+                f"cmd[{idx}] must be a str; got {type(arg).__name__}. "
+                "run_with_secrets only accepts str (and Secret, which is "
+                "rejected separately as a guardrail). Convert paths with "
+                "str(path), ints with str(n), etc."
+            )
+
+    # 4. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
     # we touch Secret.get() for any reason, so a typo surfaces as a
     # clear ValueError with no secret material in flight.
     if stdin_secret is not None and stdin_secret not in secrets:
@@ -687,10 +709,43 @@ def run_with_secrets(
             "The name must match one of the keys you pass in `secrets`."
         )
 
-    # 3. Build the full env for the subprocess. Caller's env goes first
+    # After validation, every cmd element is a plain str -- the element
+    # typing is list[str | Secret] at the API boundary, but the runtime
+    # is guaranteed narrower. Cast via list() so downstream helpers
+    # (run, _format_cmd) get the concrete list[str] they expect.
+    plain_cmd: list[str] = list(cmd)  # type: ignore[arg-type]
+
+    stdin_display = (
+        f"<redacted:{stdin_secret}>" if stdin_secret is not None else "<none>"
+    )
+
+    # 5. Dry-run short-circuit. Docstring promises dry_run does not
+    # pull secret values into memory. Honouring that means bailing out
+    # BEFORE Secret.get() on any entry of ``secrets`` -- only the
+    # caller-supplied ``env`` (which is already plain strings) and the
+    # secret KEYS (not values) appear in the dry-run log.
+    if dry_run:
+        base_env_for_log: dict[str, str] = dict(env) if env is not None else {}
+        # Show the secret keys as NAME=<redacted> in the dry-run log so
+        # an operator inspecting a dry-run can see the full env shape
+        # without any values having been read off the Secret objects.
+        redacted_secret_env = {name: "<redacted>" for name in secrets}
+        display_env = {**base_env_for_log, **redacted_secret_env}
+        logger.info(
+            "run_with_secrets [dry-run]: cmd=%s env=%s stdin=%s",
+            _format_cmd(plain_cmd),
+            # secret_keys = names we'd redact; in dry-run every secret
+            # is redacted regardless because we haven't unwrapped them.
+            _format_env_redacted(display_env, set(secrets)),
+            stdin_display,
+        )
+        return None
+
+    # 6. Build the full env for the subprocess. Caller's env goes first
     # so secrets win on key conflict -- the helper's job is to deliver
     # the secret, and a stale override from ``env`` would silently break
-    # that contract.
+    # that contract. Each Secret.get() is called EXACTLY ONCE and the
+    # result reused below for stdin delivery if needed.
     base_env: dict[str, str] = dict(env) if env is not None else {}
     secret_env = {name: s.get() for name, s in secrets.items()}
     full_env: dict[str, str] = {**base_env, **secret_env}
@@ -698,30 +753,21 @@ def run_with_secrets(
     # those values -- non-secret env vars stay plainly visible.
     secret_keys = set(secret_env.keys())
 
-    # 4. Resolve stdin payload (if requested) BEFORE logging so that if
-    # anything goes wrong we never emit a half-formed log line. Read
-    # via Secret.get() exactly once here; the value stays in this local
-    # and is passed by reference into run().
+    # 7. Resolve the stdin payload from the ALREADY-unwrapped secret_env
+    # dict rather than calling Secret.get() a second time -- one unwrap
+    # per secret keeps the "minimal touch" contract explicit.
     stdin_payload: str | None = None
     if stdin_secret is not None:
-        stdin_payload = secrets[stdin_secret].get()
+        stdin_payload = secret_env[stdin_secret]
 
-    # 5. Emit the helper's own log line. This is the SINGLE place where
+    # 8. Emit the helper's own log line. This is the SINGLE place where
     # the "secrets-in-play" subprocess launch is recorded. We log
     # BEFORE delegating to run() so:
-    #   - the argv (already validated Secret-free) appears once, here,
-    #     with full context (env + stdin redacted);
+    #   - the argv (already validated Secret-free and all-str) appears
+    #     once, here, with full context (env + stdin redacted);
     #   - run()'s own logging stays unchanged -- it never sees Secret
     #     objects, only plain strings, and during normal (non-dry-run)
     #     execution it doesn't log env at all (see process.run()).
-    # cast to list[str] for the formatter -- after _validate_no_secret_in_argv
-    # we know every element is a str, but the annotation is still
-    # list[str | Secret]; _format_cmd doesn't care about the nominal
-    # type, only that each element is str-compatible.
-    plain_cmd: list[str] = [a for a in cmd if isinstance(a, str)]
-    stdin_display = (
-        f"<redacted:{stdin_secret}>" if stdin_secret is not None else "<none>"
-    )
     logger.info(
         "run_with_secrets: cmd=%s env=%s stdin=%s",
         _format_cmd(plain_cmd),
@@ -729,12 +775,13 @@ def run_with_secrets(
         stdin_display,
     )
 
-    # 6. Delegate. run() handles dry-run, signal forwarding, and stdin
-    # piping -- we deliberately reuse all of it instead of reinventing
-    # the wheel (and instead of teaching run() about Secret).
+    # 9. Delegate. run() handles signal forwarding and stdin piping --
+    # we reuse all of it instead of reinventing the wheel (and instead
+    # of teaching run() about Secret). dry_run was already handled
+    # above so we pass False here to make that explicit.
     return run(
         plain_cmd,
-        dry_run=dry_run,
+        dry_run=False,
         env=full_env,
         stdin_text=stdin_payload,
     )

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -569,8 +569,11 @@ def _format_env_redacted(
     (detect missing / mistyped keys) without seeing the values.
 
     Args:
-        env: The full env dict that will be passed to the subprocess,
-            or ``None`` if no extra env was built.
+        env: The extra / override env dict that ``_build_env()`` will
+            merge into the inherited ``os.environ`` for the subprocess
+            (NOT the full inherited environment -- this helper only
+            sees and formats the entries the caller / secrets dict
+            explicitly supplied). ``None`` if no extra env was built.
         secret_keys: The set of keys whose values came from ``secrets``.
             Used to tag those keys as ``<redacted>`` vs ``<set>`` for
             caller-supplied env, so the log clearly shows which keys
@@ -616,10 +619,15 @@ def run_with_secrets(
        rationale -- and why a deep scan is NOT the right choice here --
        is spelled out on :func:`_validate_no_secret_in_argv`.
     2. **Redacted logging.** The helper emits its own log line BEFORE
-       delegating to :func:`run`, with every secret-sourced env-var
-       rendered as ``NAME=<redacted>``. Env-var names stay visible so
-       operators can see what environment the subprocess sees; values
-       are hidden. ``run()`` itself has no knowledge of Secret semantics
+       delegating to :func:`run`, with EVERY env-var value redacted.
+       Secret-sourced entries render as ``NAME=<redacted>``; caller-
+       supplied ``env`` entries render as ``NAME=<set>``. Env-var names
+       stay visible so operators can see what environment the
+       subprocess sees (missing / mistyped keys); values are uniformly
+       hidden because on this codepath any non-secret value might ALSO
+       be sensitive (a caller could forget to wrap a token in Secret
+       and drop it into ``env=``; printing that would compound the
+       mistake). ``run()`` itself has no knowledge of Secret semantics
        and emits no env-echoing logs during normal execution, so no
        redaction is needed there.
 
@@ -765,8 +773,10 @@ def run_with_secrets(
     base_env: dict[str, str] = dict(env) if env is not None else {}
     secret_env = {name: s.get() for name, s in secrets.items()}
     full_env: dict[str, str] = {**base_env, **secret_env}
-    # Track which keys came from secrets so the log line redacts only
-    # those values -- non-secret env vars stay plainly visible.
+    # Track which keys came from secrets so the log line tags them as
+    # ``<redacted>``. Non-secret (caller-supplied) env keys are tagged
+    # ``<set>`` by ``_format_env_redacted`` -- same redaction, different
+    # label so operators can tell them apart. Neither leaks the value.
     secret_keys = set(secret_env.keys())
 
     # 7. Resolve the stdin payload from the ALREADY-unwrapped secret_env

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -722,7 +722,24 @@ def run_with_secrets(
                 "str(path), ints with str(n), etc."
             )
 
-    # 4. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
+    # 4. Validate every value in ``secrets`` is a Secret instance. If
+    # a caller accidentally passes a plain string (or any other type),
+    # .get() below would raise AttributeError mid-execution -- which
+    # clickwork.cli's wrapped_invoke classifies as a framework bug
+    # (exit 2, "Internal error: ...") rather than the user error it
+    # actually is. Catching this up front gives a clear TypeError
+    # naming the offending key + type, and the error message
+    # deliberately does NOT include the value (which might itself be
+    # sensitive even in its unwrapped form).
+    for sname, sval in secrets.items():
+        if not isinstance(sval, Secret):
+            raise TypeError(
+                f"secrets[{sname!r}] must be a Secret instance; got "
+                f"{type(sval).__name__}. Wrap sensitive values as "
+                "Secret(...) before passing them into run_with_secrets."
+            )
+
+    # 5. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
     # we touch Secret.get() for any reason, so a typo surfaces as a
     # clear ValueError with no secret material in flight.
     if stdin_secret is not None and stdin_secret not in secrets:
@@ -743,7 +760,7 @@ def run_with_secrets(
         f"<redacted:{stdin_secret}>" if stdin_secret is not None else "<none>"
     )
 
-    # 5. Dry-run short-circuit. Docstring promises dry_run does not
+    # 6. Dry-run short-circuit. Docstring promises dry_run does not
     # pull secret values into memory. Honouring that means bailing out
     # BEFORE Secret.get() on any entry of ``secrets`` -- only the
     # caller-supplied ``env`` (which is already plain strings) and the
@@ -765,7 +782,7 @@ def run_with_secrets(
         )
         return None
 
-    # 6. Build the full env for the subprocess. Caller's env goes first
+    # 7. Build the full env for the subprocess. Caller's env goes first
     # so secrets win on key conflict -- the helper's job is to deliver
     # the secret, and a stale override from ``env`` would silently break
     # that contract. Each Secret.get() is called EXACTLY ONCE and the
@@ -779,14 +796,14 @@ def run_with_secrets(
     # label so operators can tell them apart. Neither leaks the value.
     secret_keys = set(secret_env.keys())
 
-    # 7. Resolve the stdin payload from the ALREADY-unwrapped secret_env
+    # 8. Resolve the stdin payload from the ALREADY-unwrapped secret_env
     # dict rather than calling Secret.get() a second time -- one unwrap
     # per secret keeps the "minimal touch" contract explicit.
     stdin_payload: str | None = None
     if stdin_secret is not None:
         stdin_payload = secret_env[stdin_secret]
 
-    # 8. Emit the helper's own log line. This is the SINGLE place where
+    # 9. Emit the helper's own log line. This is the SINGLE place where
     # the "secrets-in-play" subprocess launch is recorded. We log
     # BEFORE delegating to run() so:
     #   - the argv (already validated Secret-free and all-str) appears
@@ -801,7 +818,7 @@ def run_with_secrets(
         stdin_display,
     )
 
-    # 9. Delegate. run() handles signal forwarding and stdin piping --
+    # 10. Delegate. run() handles signal forwarding and stdin piping --
     # we reuse all of it instead of reinventing the wheel (and instead
     # of teaching run() about Secret). dry_run was already handled
     # above so we pass False here to make that explicit.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -604,6 +604,51 @@ class TestConvenienceMethods:
         captured = capfd.readouterr()
         assert captured.out == "confirm-token"
 
+    def test_ctx_run_with_secrets_forwards_stdin_secret(self, tmp_path: Path, capfd):
+        """ctx.run_with_secrets(stdin_secret=...) must round-trip through the ctx binding.
+
+        WHY this test exists (in addition to the process-level tests in
+        test_process.py): the ctx.run_with_secrets binding in create_cli()
+        is a forwarding lambda; if a future refactor silently drops
+        ``stdin_secret`` from its signature, process-level tests would
+        still pass but the CLI surface would break. This test pins the
+        ctx-level forwarding shape, mirroring the symmetry of
+        test_ctx_run_forwards_stdin_text / test_ctx_run_with_confirm_forwards_stdin_text.
+        """
+        from clickwork.cli import create_cli
+        from clickwork._types import Secret
+
+        received = {}
+
+        @click.command()
+        @click.pass_obj
+        def echo_stdin_secret(ctx):
+            # Round-trip a secret through the child's stdin via ctx.run_with_secrets.
+            # The secret is ALSO placed in env under "PW" (dual-channel
+            # delivery), but for this test we only assert the stdin side.
+            result = ctx.run_with_secrets(
+                [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())"],
+                secrets={"PW": Secret("ctx-secret-via-stdin")},
+                stdin_secret="PW",
+            )
+            received["returncode"] = result.returncode if result is not None else None
+
+        cmd_dir = tmp_path / "commands"
+        cmd_dir.mkdir()
+
+        cli = create_cli(name="test-cli", commands_dir=cmd_dir)
+        cli.add_command(echo_stdin_secret)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["echo-stdin-secret"])
+        assert result.exit_code == 0, f"CLI failed: {result.output!r}"
+        assert received["returncode"] == 0
+        captured = capfd.readouterr()
+        assert captured.out == "ctx-secret-via-stdin", (
+            f"Expected stdin payload to round-trip through ctx.run_with_secrets; "
+            f"got {captured.out!r}"
+        )
+
     def test_ctx_run_respects_dry_run(self, tmp_path: Path):
         """ctx.run() in dry-run mode should not execute the command (returns None).
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -686,6 +686,33 @@ class TestRunWithSecrets:
         # Mention the type so the fix (str(path)) is obvious.
         assert "PosixPath" in str(exc_info.value) or "WindowsPath" in str(exc_info.value) or "Path" in str(exc_info.value)
 
+    def test_run_with_secrets_rejects_non_Secret_value_in_secrets_dict(self):
+        """secrets={"K": "plain-string"} fails with a clear TypeError.
+
+        WHY: if the caller forgets to wrap a value in Secret, .get()
+        would raise AttributeError mid-execution. Through clickwork's
+        wrapped_invoke that surfaces as exit 2 "Internal error:
+        'str' object has no attribute 'get'" -- classified as a
+        framework bug when it's really a user-side wrapping miss.
+        The up-front TypeError keeps the error close to the cause and
+        doesn't echo the value (which might be sensitive even
+        unwrapped).
+        """
+        from clickwork.process import run_with_secrets
+
+        with pytest.raises(TypeError) as exc_info:
+            run_with_secrets(
+                [sys.executable, "-c", "pass"],
+                secrets={"TOKEN": "plain-string-not-wrapped"},  # type: ignore[dict-item]
+            )
+        # Must name the offending key AND its type so the fix is
+        # obvious, but NEVER the value (a caller who passed a token
+        # un-Secret-wrapped shouldn't see it echoed in the error
+        # message -- same redaction discipline as everywhere else).
+        assert "TOKEN" in str(exc_info.value)
+        assert "str" in str(exc_info.value)  # type name, not value
+        assert "plain-string-not-wrapped" not in str(exc_info.value)
+
     def test_run_with_secrets_rejects_non_list_cmd(self):
         """cmd must be a list, not a tuple/str/other iterable.
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -524,6 +524,49 @@ class TestRunWithSecrets:
             f"Secret value leaked into log: {all_log_text!r}"
         )
 
+    def test_run_with_secrets_does_not_leak_non_secret_env_values(self, caplog):
+        """Non-secret env values ALSO redacted (tightened after Copilot PR #28).
+
+        WHY: a caller can pass ``env={"REGION": "us-east-1", "API_KEY":
+        "accidentally-not-wrapped"}`` -- we can't tell which of those
+        the caller considers sensitive. The helper's contract is "this
+        invocation carries secrets", so treating the whole env as
+        potentially-sensitive is the safer default. Non-secret values
+        render as ``<set>`` so the log still shows which keys were set
+        (useful for debugging missing/mistyped keys) without exposing
+        the values.
+
+        This test pins the behaviour: pass a non-secret env value that
+        would be embarrassing to leak, assert it NEVER appears in the
+        log output.
+        """
+        import logging
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        accidental_plaintext = "ghp_totallyNotWrappedInSecret_12345"
+
+        with caplog.at_level(logging.INFO, logger="clickwork"):
+            run_with_secrets(
+                [sys.executable, "-c", "pass"],
+                secrets={"REAL_TOKEN": Secret("also-hidden")},
+                env={"BAD_TOKEN": accidental_plaintext, "REGION": "us-east-1"},
+            )
+
+        all_log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert accidental_plaintext not in all_log_text, (
+            f"Non-secret env value leaked into log: {all_log_text!r}"
+        )
+        # Non-secret VALUES also hidden: "us-east-1" must not appear either.
+        assert "us-east-1" not in all_log_text
+        # But the NAMES must still be visible so operators can see shape.
+        assert "BAD_TOKEN" in all_log_text
+        assert "REGION" in all_log_text
+        assert "REAL_TOKEN" in all_log_text
+        # And the tags differ so the operator can tell WHICH were secret-sourced.
+        assert "REAL_TOKEN=<redacted>" in all_log_text
+        assert "BAD_TOKEN=<set>" in all_log_text
+
     def test_run_with_secrets_stdin_secret_must_be_in_secrets_dict(self):
         """stdin_secret must name a key that exists in secrets={}.
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -357,3 +357,247 @@ class TestRunWithConfirm:
                 stdin_text="hello",
                 stdin_bytes=b"world",
             )
+
+
+class TestRunWithSecrets:
+    """run_with_secrets() delivers secrets via env (always) and stdin (optional).
+
+    The helper is a thin, safety-focused wrapper around run(). It exists to
+    make the "subprocess needs a secret" contract explicit at every call
+    site, and to centralise two guardrails:
+      - reject any ``Secret`` instance that appears directly in ``cmd``
+        (argv is world-readable in ``ps``);
+      - redact secret-sourced env vars in the log line this helper emits
+        before delegating to ``run()``.
+
+    Child processes running under this helper always see ``secrets`` in
+    their env; optionally, one of those secrets can ALSO be piped through
+    stdin (for tools like ``wrangler secret put --env-stdin`` or
+    ``docker login --password-stdin``). The dual-channel delivery is
+    deliberate: some tools prefer env, some prefer stdin, and this helper
+    lets the caller support both without re-plumbing secret handling.
+    """
+
+    def test_run_with_secrets_rejects_Secret_in_argv(self):
+        """A Secret instance appearing in cmd is a footgun; reject it loudly.
+
+        WHY: argv is visible via ``ps`` / ``/proc/*/cmdline`` to other
+        processes on the same host. If a caller accidentally writes
+        ``run_with_secrets(["curl", "-H", f"Authorization: Bearer {tok}",
+        ...])`` where ``tok`` is a Secret, the token lands in argv and
+        leaks. Rejecting the explicit Secret-in-argv case catches the
+        most common mistake.
+
+        The error message must name the offending arg by **position**
+        (its index in cmd), NOT by value -- the whole point is to avoid
+        leaking the secret, and an error message that echoes .get() back
+        would undermine that.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        secret = Secret("supersecret-leaky")
+        with pytest.raises(ValueError) as exc_info:
+            run_with_secrets(["cmd", secret], secrets={})
+
+        # Error message must reference the position (index 1) so the
+        # caller knows which arg to fix.
+        assert "1" in str(exc_info.value), (
+            f"Expected error to name the offending position, got: {exc_info.value!r}"
+        )
+        # The raw secret value must NOT appear anywhere in the error -- a
+        # regression here would mean our "don't leak secrets" helper leaks
+        # secrets in its own rejection path.
+        assert "supersecret-leaky" not in str(exc_info.value)
+
+    def test_run_with_secrets_routes_via_env(self):
+        """Secrets are delivered to the child subprocess via environment variables.
+
+        WHY env-as-default: tools like ``CLOUDFLARE_API_TOKEN`` expect
+        credentials in env; forcing every caller to build an env dict
+        themselves is error-prone. Giving ``secrets=`` its own channel
+        makes the "this is sensitive" signal visible at each call site.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        # Child reads the env var we claim to have set and echoes it to
+        # stdout, so we can assert the delivery worked end-to-end.
+        result = run_with_secrets(
+            [
+                sys.executable,
+                "-c",
+                "import os, sys; sys.stdout.write(os.environ['TOKEN'])",
+            ],
+            secrets={"TOKEN": Secret("supersecret")},
+        )
+        # Capture via subprocess.run-style assertion: rerun capturing.
+        # We use capture directly here for clarity, mirroring how the
+        # existing stdin_text test uses capfd.
+        # But since run_with_secrets delegates to run() (which inherits
+        # stdio), we need capfd-style capture. Use capsys via the capfd
+        # fixture form when this is called -- see the fixture-based test
+        # below. This positive path just asserts the return code.
+        assert result is not None
+        assert result.returncode == 0
+
+    def test_run_with_secrets_env_value_reaches_child(self, capfd):
+        """Second form of the env-delivery test using capfd to verify payload.
+
+        WHY a second test: the first asserts the happy path without
+        capturing. This one pins the exact value the child sees,
+        guaranteeing Secret.get() was called and the value was placed
+        into env under the right key.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        run_with_secrets(
+            [
+                sys.executable,
+                "-c",
+                "import os, sys; sys.stdout.write(os.environ['TOKEN'])",
+            ],
+            secrets={"TOKEN": Secret("supersecret")},
+        )
+        captured = capfd.readouterr()
+        assert captured.out == "supersecret"
+
+    def test_run_with_secrets_routes_via_stdin_when_stdin_secret_set(self, capfd):
+        """stdin_secret="NAME" routes secrets[NAME].get() through the child's stdin.
+
+        WHY dual-channel: tools like ``wrangler secret put --env-stdin``
+        and ``docker login --password-stdin`` want the secret on stdin
+        (keeping it out of argv AND out of env, where a child process
+        inspection might surface it). The same value is ALSO placed in
+        env -- that's intentional; some tools read from one channel, some
+        from the other, and the caller shouldn't have to pick.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        run_with_secrets(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.write(sys.stdin.read())",
+            ],
+            secrets={"PW": Secret("hunter2")},
+            stdin_secret="PW",
+        )
+        captured = capfd.readouterr()
+        assert captured.out == "hunter2"
+
+    def test_run_with_secrets_logs_redacted(self, caplog):
+        """The helper's log line shows env-var NAMES but never VALUES.
+
+        WHY: operators debugging a subprocess launch need to see WHICH
+        environment variables were set (to spot misspellings, missing
+        keys, etc.) but must never see the values. The redaction token
+        ``<redacted>`` is the canonical placeholder.
+        """
+        import logging
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        # caplog captures records from the clickwork logger. INFO level
+        # so the helper's own info-level message is retained.
+        with caplog.at_level(logging.INFO, logger="clickwork"):
+            run_with_secrets(
+                [sys.executable, "-c", "pass"],
+                secrets={"K": Secret("v")},
+            )
+
+        # Flatten all captured log messages for substring checks.
+        all_log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "<redacted>" in all_log_text, (
+            f"Expected '<redacted>' marker in log output, got: {all_log_text!r}"
+        )
+        # The env-var NAME stays visible so operators can see which keys
+        # were set.
+        assert "K" in all_log_text
+        # The value must NOT appear anywhere in the captured log output.
+        # (A one-character value like "v" might false-match in other log
+        # text, so we check it appears only as part of "<redacted>" --
+        # which has no 'v' -- or inside words like "secrets" / "env" /
+        # "delegate". For safety, grep for "=v" which would be the shape
+        # of a leaked "K=v" pair.)
+        assert "=v" not in all_log_text, (
+            f"Secret value leaked into log: {all_log_text!r}"
+        )
+
+    def test_run_with_secrets_stdin_secret_must_be_in_secrets_dict(self):
+        """stdin_secret must name a key that exists in secrets={}.
+
+        WHY: if the caller typos the key name, silently routing None or
+        empty through stdin would produce a confusing failure from the
+        child process. Raising early with a ValueError makes the mistake
+        obvious. The error message must NOT leak any secret value.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        # Case 1: secrets dict is empty.
+        with pytest.raises(ValueError) as exc_info:
+            run_with_secrets(
+                ["cmd"],
+                secrets={},
+                stdin_secret="MISSING",
+            )
+        # Name the missing key so the caller knows what to fix.
+        assert "MISSING" in str(exc_info.value)
+
+        # Case 2: secrets present but none matching. Ensure existing
+        # Secret values don't leak into the rejection message.
+        with pytest.raises(ValueError) as exc_info:
+            run_with_secrets(
+                ["cmd"],
+                secrets={"OTHER": Secret("do-not-leak-me")},
+                stdin_secret="MISSING",
+            )
+        assert "do-not-leak-me" not in str(exc_info.value)
+
+    def test_run_with_secrets_respects_dry_run(self):
+        """dry_run=True must short-circuit before any subprocess starts.
+
+        WHY: same policy as run(stdin_text=..., dry_run=True) -- dry-run
+        is a safety net, and spawning a child just to throw away its
+        output would defeat the purpose (and could leak the secret to
+        the child even if we never read its output).
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        with patch("subprocess.Popen") as mock_popen:
+            result = run_with_secrets(
+                [sys.executable, "-c", "import sys; sys.exit(1)"],
+                secrets={"TOKEN": Secret("v")},
+                dry_run=True,
+            )
+
+        assert result is None
+        mock_popen.assert_not_called()
+
+    def test_run_with_secrets_merges_caller_env(self, capfd):
+        """Caller-supplied env is merged with secrets; secrets win on key conflict.
+
+        WHY: callers often want to set non-secret env vars (region,
+        config path) alongside secrets. The helper should layer them,
+        and secrets should win if a caller foolishly passes the same
+        key in both env and secrets -- the secrets value is what the
+        call was set up to deliver.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        run_with_secrets(
+            [
+                sys.executable,
+                "-c",
+                "import os, sys; sys.stdout.write(os.environ['REGION'] + ':' + os.environ['TOKEN'])",
+            ],
+            secrets={"TOKEN": Secret("t")},
+            env={"REGION": "us-east-1"},
+        )
+        captured = capfd.readouterr()
+        assert captured.out == "us-east-1:t"

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -421,8 +421,13 @@ class TestRunWithSecrets:
         from clickwork.process import run_with_secrets
         from clickwork._types import Secret
 
-        # Child reads the env var we claim to have set and echoes it to
-        # stdout, so we can assert the delivery worked end-to-end.
+        # Child reads the env var we claim to have set and exits 0 iff
+        # the value matches -- we assert exit code here. The companion
+        # test below (``..._env_value_reaches_child``) pins the exact
+        # child stdout via ``capfd``; this one only verifies the
+        # successful-exit path so a regression where the env var never
+        # reaches the child still fails loudly (the child would exit
+        # non-zero with KeyError before ever writing to stdout).
         result = run_with_secrets(
             [
                 sys.executable,
@@ -431,13 +436,6 @@ class TestRunWithSecrets:
             ],
             secrets={"TOKEN": Secret("supersecret")},
         )
-        # Capture via subprocess.run-style assertion: rerun capturing.
-        # We use capture directly here for clarity, mirroring how the
-        # existing stdin_text test uses capfd.
-        # But since run_with_secrets delegates to run() (which inherits
-        # stdio), we need capfd-style capture. Use capsys via the capfd
-        # fixture form when this is called -- see the fixture-based test
-        # below. This positive path just asserts the return code.
         assert result is not None
         assert result.returncode == 0
 
@@ -577,6 +575,93 @@ class TestRunWithSecrets:
 
         assert result is None
         mock_popen.assert_not_called()
+
+    def test_run_with_secrets_dry_run_does_not_unwrap_secrets(self):
+        """dry_run=True must not call Secret.get() on any secret.
+
+        WHY: dry-run is "nothing happens" -- no subprocess, no file
+        writes, and (this test) no secret values pulled into memory.
+        A Secret whose .get() would otherwise raise (e.g. one backed by
+        a lazy source that errors during dry-run) must pass cleanly
+        through dry-run. We pin this by wrapping a Secret in a spy that
+        tracks every .get() call; the assertion is that it was called
+        ZERO times.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        unwrap_count = {"count": 0}
+
+        class _SpySecret(Secret):
+            """Secret that records every .get() invocation.
+
+            Inherits Secret so isinstance checks still fire; overrides
+            .get to increment the counter. We do NOT want the counter
+            touched during dry-run.
+            """
+
+            def get(self) -> str:
+                unwrap_count["count"] += 1
+                return super().get()
+
+        result = run_with_secrets(
+            [sys.executable, "-c", "print('never runs')"],
+            secrets={"TOKEN": _SpySecret("the-secret-value")},
+            stdin_secret="TOKEN",
+            dry_run=True,
+        )
+        assert result is None
+        assert unwrap_count["count"] == 0, (
+            f"dry_run=True must not unwrap any Secret; got "
+            f"{unwrap_count['count']} .get() call(s). A regression here "
+            "would mean dry-run is pulling secret values into process "
+            "memory, contradicting the docstring contract."
+        )
+
+    def test_run_with_secrets_rejects_non_str_non_secret_argv(self):
+        """cmd elements that aren't str and aren't Secret raise TypeError.
+
+        WHY: an earlier implementation silently dropped non-str elements
+        from cmd via an isinstance-filter, which could change the
+        command the child sees (if a PathLike, bytes, or int sneaked
+        through). The new guard validates every element is str after
+        the Secret-rejection step so the caller gets a loud error at
+        the offending index instead of a mysterious "command did the
+        wrong thing" bug at runtime.
+        """
+        from clickwork.process import run_with_secrets
+        from pathlib import Path
+
+        with pytest.raises(TypeError) as exc_info:
+            run_with_secrets(
+                ["echo", Path("/tmp/nope")],
+                secrets={},
+            )
+        # The error must name the offending index so the caller can
+        # locate the bad arg without a traceback hunt.
+        assert "cmd[1]" in str(exc_info.value)
+        # Mention the type so the fix (str(path)) is obvious.
+        assert "PosixPath" in str(exc_info.value) or "WindowsPath" in str(exc_info.value) or "Path" in str(exc_info.value)
+
+    def test_run_with_secrets_rejects_non_list_cmd(self):
+        """cmd must be a list, not a tuple/str/other iterable.
+
+        WHY: matches the _validate_cmd guard run()/capture() already
+        enforce. A tuple would iterate fine in plain Python but
+        signals the caller is treating argv as something other than a
+        mutable list -- often a sign they came from a string.format
+        chain that should have been a list[str] to begin with. The
+        same list-only rule catches raw string commands (which is the
+        shell-injection footgun _validate_cmd was originally written
+        to prevent).
+        """
+        from clickwork.process import run_with_secrets
+
+        with pytest.raises(TypeError, match="cmd must be a list"):
+            run_with_secrets(
+                "echo hello",  # type: ignore[arg-type] -- the point of the test
+                secrets={},
+            )
 
     def test_run_with_secrets_merges_caller_env(self, capfd):
         """Caller-supplied env is merged with secrets; secrets win on key conflict.

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -686,6 +686,59 @@ class TestRunWithSecrets:
         # Mention the type so the fix (str(path)) is obvious.
         assert "PosixPath" in str(exc_info.value) or "WindowsPath" in str(exc_info.value) or "Path" in str(exc_info.value)
 
+    def test_run_with_secrets_rejects_non_str_env_value_before_unwrap(self):
+        """Non-str env values must raise BEFORE any Secret.get() runs.
+
+        WHY: if caller's ``env={"X": 1}`` or ``env={1: "x"}`` reaches
+        subprocess.Popen, it raises TypeError -- but by that point
+        every Secret in ``secrets`` has already been unwrapped into
+        memory. Validating env types up front keeps the "minimal
+        touch" promise: no Secret ever gets unwrapped on a call that
+        was doomed anyway. The Spy-Secret counter pins that.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        unwrap_count = {"count": 0}
+
+        class _SpySecret(Secret):
+            def get(self) -> str:
+                unwrap_count["count"] += 1
+                return super().get()
+
+        with pytest.raises(TypeError) as exc_info:
+            run_with_secrets(
+                [sys.executable, "-c", "pass"],
+                secrets={"TOKEN": _SpySecret("must-not-leak")},
+                env={"REGION": 42},  # type: ignore[dict-item]
+            )
+
+        assert "REGION" in str(exc_info.value)
+        assert "int" in str(exc_info.value)
+        # Most important assertion: no Secret.get() happened. Earlier
+        # flow would have unwrapped TOKEN into full_env, then crashed
+        # on Popen's env validation. We want to catch this before any
+        # secret material leaves the wrapper.
+        assert unwrap_count["count"] == 0, (
+            f"Expected zero Secret.get() calls before the env validation "
+            f"fires; got {unwrap_count['count']}. A regression here would "
+            "mean env-type failures unwrap secrets unnecessarily."
+        )
+        # Secret value must also not appear in the error text.
+        assert "must-not-leak" not in str(exc_info.value)
+
+    def test_run_with_secrets_rejects_non_str_env_key(self):
+        """Non-str env keys also rejected up front (same rationale)."""
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        with pytest.raises(TypeError, match="env keys must be str"):
+            run_with_secrets(
+                [sys.executable, "-c", "pass"],
+                secrets={"TOKEN": Secret("v")},
+                env={42: "value"},  # type: ignore[dict-item]
+            )
+
     def test_run_with_secrets_rejects_non_str_key_in_secrets_dict(self):
         """secrets keys must be str (env-var names), not int / tuple / etc.
 

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -686,6 +686,28 @@ class TestRunWithSecrets:
         # Mention the type so the fix (str(path)) is obvious.
         assert "PosixPath" in str(exc_info.value) or "WindowsPath" in str(exc_info.value) or "Path" in str(exc_info.value)
 
+    def test_run_with_secrets_rejects_non_str_key_in_secrets_dict(self):
+        """secrets keys must be str (env-var names), not int / tuple / etc.
+
+        WHY: an earlier draft only validated the values. A caller passing
+        ``secrets={1: Secret("x")}`` would then unwrap the Secret (pulling
+        it into memory!) and fail mid-subprocess launch with a confusing
+        ``TypeError: expected str, bytes or os.PathLike object, not int``
+        far from the real cause. Validate key types up front so the
+        Secret.get() never happens on the bad call.
+        """
+        from clickwork.process import run_with_secrets
+        from clickwork._types import Secret
+
+        with pytest.raises(TypeError) as exc_info:
+            run_with_secrets(
+                [sys.executable, "-c", "pass"],
+                secrets={1: Secret("value-must-not-leak")},  # type: ignore[dict-item]
+            )
+        # Error names the offending type but NEVER the value.
+        assert "int" in str(exc_info.value)
+        assert "value-must-not-leak" not in str(exc_info.value)
+
     def test_run_with_secrets_rejects_non_Secret_value_in_secrets_dict(self):
         """secrets={"K": "plain-string"} fails with a clear TypeError.
 


### PR DESCRIPTION
## Summary
Standalone helper that makes "secrets-in-play" explicit at every call site and enforces the never-in-argv guardrail for Secret values.

- ``cmd: list[str | Secret]`` — any Secret in argv raises ``ValueError`` with position-only error (never the value)
- ``secrets={"NAME": Secret(...)}`` delivered via env; ``stdin_secret="NAME"`` additionally pipes that entry through stdin_text (reuses Wave 1's #10)
- One-line log redaction: argv visible, env-var names visible, secret values shown as ``<redacted>``, stdin-routed secret as ``<redacted:NAME>``
- Bound on ``CliContext`` via forwarding lambda next to ``ctx.run`` / ``ctx.run_with_confirm``

Fixes #11. ``--log-insecure-secrets`` opt-in is a deliberate follow-up, not here.

## Test plan
- [x] 8 process-level tests (argv rejection with position-only error, env delivery, stdin routing, log redaction, invalid stdin_secret, dry-run short-circuit, caller env merge)
- [x] 1 ctx-level ``CliRunner`` forwarding test
- [x] Full suite: 197 passed (188 baseline + 9 new), zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)