### PR TITLE
docs: Wave 4 plan for issues #16, #17

### DIFF
--- a/docs/plans/2026-04-17-wave-4-docs.md
+++ b/docs/plans/2026-04-17-wave-4-docs.md
@@ -2,7 +2,9 @@
 
 **Date:** 2026-04-17
 **Roadmap:** [docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md](../superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md)
-**Scope:** Issues #16 (`clickwork.testing` helper + `mix_stderr` docs) and #17 (Common Footguns section in LLM_REFERENCE). Parallel — the two PRs touch DIFFERENT sections of `LLM_REFERENCE.md` (testing one-liner vs top-level "Common Footguns"), so they can merge without conflicts as long as agents write to their assigned section only. #17's entries reference the `clickwork.testing` helpers from #16 by their locked-in name (`clickwork.testing.run_cli`, `clickwork.testing.make_test_cli`) — that's fine because the names are pinned by this plan.
+**Scope:** Issues #16 (`clickwork.testing` helper + `mix_stderr` docs) and #17 (Common Footguns section in LLM_REFERENCE). Parallel **development**, serial **merge**: the two PRs touch DIFFERENT sections of `LLM_REFERENCE.md` (testing one-liner vs top-level "Common Footguns"), so they develop without conflicts as long as agents write to their assigned section only.
+
+**Merge order: #16 before #17.** #17's footgun entries reference the `clickwork.testing.run_cli` / `clickwork.testing.make_test_cli` helpers by name. The names are pinned by this plan, so agents can write #17 before #16 lands. But if #17 merges first, `main` briefly documents APIs that don't exist yet — which is a bad state to leave `main` in even for a few minutes. Always merge #16 first, then #17, to keep `main` always self-consistent.
 **Depends on:** Waves 1–3 merged. Wave 3's `run_with_secrets` and `clickwork.http` land in the footguns doc as "use the new helper."
 
 ## API shape decisions

--- a/docs/plans/2026-04-17-wave-4-docs.md
+++ b/docs/plans/2026-04-17-wave-4-docs.md
@@ -9,7 +9,7 @@
 
 ### #16 — `clickwork.testing` + CliRunner-output docs
 
-**Important correction from an earlier draft:** the original plan framed the docs around `CliRunner`'s `mix_stderr=True` default ("`result.stderr` is always empty unless you pass `mix_stderr=False`"). That was true on older Click versions but **is no longer accurate on Click 8.3.x** (our installed/minimum-tested version): `CliRunner.__init__` no longer exposes a `mix_stderr` parameter, and a real invocation populates all three of `result.output` (mixed stdout + stderr), `result.stdout`, and `result.stderr` separately. The footgun is therefore **not** "stderr is empty", it's "`result.output` interleaves streams". Plan updated accordingly.
+**Important correction from an earlier draft:** the original plan framed the docs around `CliRunner`'s `mix_stderr=True` default ("`result.stderr` is always empty unless you pass `mix_stderr=False`"). That was true on older Click versions but **is no longer accurate on the Click version this repo is currently pinned to** (Click 8.3.2 via `uv.lock`; `pyproject.toml` declares `click>=8.1` but we don't have CI exercising the 8.1 floor): `CliRunner.__init__` no longer exposes a `mix_stderr` parameter, and a real invocation populates all three of `result.output` (mixed stdout + stderr), `result.stdout`, and `result.stderr` separately. The footgun is therefore **not** "stderr is empty", it's "`result.output` interleaves streams". Plan updated accordingly. *(Follow-up to file: add a CI job that exercises the declared minimum Click version so "minimum-supported" claims can be verified programmatically.)*
 
 | Decision | Choice |
 |----------|--------|

--- a/docs/plans/2026-04-17-wave-4-docs.md
+++ b/docs/plans/2026-04-17-wave-4-docs.md
@@ -1,0 +1,127 @@
+# Wave 4 plan — docs
+
+**Date:** 2026-04-17
+**Roadmap:** [docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md](../superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md)
+**Scope:** Issues #16 (`clickwork.testing` helper + `mix_stderr` docs) and #17 (Common Footguns section in LLM_REFERENCE). Serial — #16 first, then #17.
+**Depends on:** Waves 1–3 merged. Wave 3's `run_with_secrets` and `clickwork.http` land in the footguns doc as "use the new helper."
+
+## API shape decisions
+
+### #16 — `clickwork.testing` + `mix_stderr` docs
+
+| Decision | Choice |
+|----------|--------|
+| Module surface | Option B: `run_cli()` + `make_test_cli()`. NOT shipping `mock_run()` / `mock_capture()` in this PR — they'd hide Click testing internals that test authors benefit from understanding, and we can add them later without API churn. |
+| `mix_stderr` docs location | **Both** GUIDE.md and LLM_REFERENCE.md. Different audiences (humans vs LLMs), same invariant. GUIDE.md gets a "Testing commands" subsection; LLM_REFERENCE.md gets a one-liner under testing with a cross-ref to the GUIDE section. |
+| `make_test_cli` signature | `make_test_cli(*, commands_dir: Path \| None = None, **create_cli_kwargs) -> click.Group`. Wraps `create_cli()` with a sensible default name (`"test-cli"`) and optionally a temp-dir commands directory. Tests that just want a CLI to call `runner.invoke` against don't have to repeat the `create_cli(name=...)` boilerplate. |
+| `run_cli` signature | `run_cli(cli: click.Group, args: list[str], **runner_kwargs) -> click.testing.Result`. Wraps `CliRunner().invoke()` with `catch_exceptions=False` by default (so test failures surface real tracebacks instead of Click's swallowed-exception path). Returns Click's native `Result` — we deliberately don't invent a new `TestResult` type because most test authors already know Click's. |
+| `mock_require` helper | **Not shipping.** Wave 1's #8 made `patch("clickwork.prereqs.require")` work directly, so a dedicated helper is no longer needed. |
+
+### #17 — Common Footguns in LLM_REFERENCE.md
+
+| Decision | Choice |
+|----------|--------|
+| Structure | Option A: single top-level "Common Footguns" section in LLM_REFERENCE.md. Short entries with cross-references to GUIDE.md / module docstrings for deeper reading. One place for grep-ability when something goes wrong. |
+| Companion entry in tutorials | TBD follow-up (not in scope). If GUIDE.md has a "Tutorials" section later, it can cross-link into this footguns section for specific scenarios. |
+| Entries to include | ALL items from the issue, with post-Wave-1/2/3 fixes flipped from "here's the workaround" to "here's the helper." |
+| Entry format | Each entry: a **Pitfall:** one-liner describing the footgun, an **Instead:** one-liner with the canonical fix (or helper name), and a **Why:** one-liner with the historical context so readers understand whether the guidance still applies. Short by design — if a reader needs depth they click through to the helper's docstring. |
+
+## Branch + worktree layout
+
+| Issue | Branch | Worktree path |
+|-------|--------|---------------|
+| #16 | `docs/testing-module-16` | `/home/qbrd/qbrd-orbit-widener/worktrees/clickwork-testing-16` |
+| #17 | `docs/footguns-17` | `/home/qbrd/qbrd-orbit-widener/worktrees/clickwork-footguns-17` |
+
+*(Already prepped from current main during Wave 3 Copilot waits. Rebase onto post-Wave-3 main before dispatching agents.)*
+
+## Per-issue tasks
+
+### #16 — `clickwork.testing` module + `mix_stderr` docs
+
+**Files:**
+- new `src/clickwork/testing.py` (public module accessible as `clickwork.testing`)
+- new `tests/unit/test_testing.py` (meta: tests FOR the testing helpers)
+- `docs/GUIDE.md` — add "Testing commands" subsection covering `CliRunner` `mix_stderr=True` default and the new helpers
+- `docs/LLM_REFERENCE.md` — add one-liner in the testing area pointing at GUIDE
+
+**TDD:**
+
+1. **Red.** Add tests in `tests/unit/test_testing.py`:
+   - `test_run_cli_invokes_command_and_returns_click_result` — basic smoke: `run_cli(cli, ["--help"])` returns a `click.testing.Result` with `exit_code == 0`.
+   - `test_run_cli_catch_exceptions_false_by_default` — a command that raises a real exception should propagate through `run_cli` (not be swallowed by Click's `standalone_mode`). Pass `catch_exceptions=True` explicitly and confirm that form suppresses instead.
+   - `test_make_test_cli_returns_click_group` — asserts type.
+   - `test_make_test_cli_accepts_commands_dir` — creates a tmp dir, passes it, asserts commands discovered.
+   - `test_make_test_cli_forwards_create_cli_kwargs` — e.g. `description="test"` reaches the returned group's help text.
+   - `test_make_test_cli_default_name` — when no `name=` kwarg passed, the returned group has a sensible default (document what it is: `"test-cli"`).
+
+2. **Green.** Implement `clickwork/testing.py`:
+   - Import `CliRunner` lazily inside `run_cli` to avoid importing `click.testing` at module import time.
+   - `run_cli(cli, args, **kwargs)`: `kwargs.setdefault("catch_exceptions", False)`; delegate to `CliRunner().invoke(cli, args, **kwargs)`.
+   - `make_test_cli(*, commands_dir=None, **create_cli_kwargs)`: `create_cli_kwargs.setdefault("name", "test-cli")`; forward `commands_dir=commands_dir` if set; return the resulting `click.Group`.
+
+3. **Refactor.** Module docstring explaining:
+   - Why these helpers exist (reduce boilerplate in plugin test suites)
+   - `catch_exceptions=False` rationale: surfaces real tracebacks
+   - `mix_stderr` note: `CliRunner` defaults to `mix_stderr=True`, so assertions on stderr-only output should use `result.output` unless the caller explicitly passed `mix_stderr=False`. Link to GUIDE.md.
+   - A canonical copy-pasteable example
+
+**GUIDE.md additions** — new "Testing commands" section:
+- Introduces `clickwork.testing` helpers
+- Documents the `mix_stderr=True` gotcha explicitly (agents keep hitting this, humans do too)
+- Shows a canonical test example using `run_cli` + `make_test_cli`
+
+**LLM_REFERENCE.md addition** — one-liner in testing section pointing at GUIDE.md's "mix_stderr gotcha" subsection.
+
+**Constraints:**
+- **Must close issue #16.** `Fixes #16`.
+- Do NOT ship `mock_run` / `mock_capture` in this PR — captured as follow-up.
+- Do NOT ship `patch_require` helper — Wave 1 #8 made it unnecessary.
+- Strong typing.
+- Zero warnings.
+- Teaching-style comments.
+
+### #17 — Common Footguns in LLM_REFERENCE.md
+
+**Files:**
+- `docs/LLM_REFERENCE.md` — add top-level "Common Footguns" section
+
+**Entries (each Pitfall / Instead / Why):**
+
+1. **Patching `ctx.require`** — Pitfall: patching `clickwork.cli._require` (old workaround). Instead: `patch("clickwork.prereqs.require")`. Why: Wave 1 #8 made the public symbol patchable; the internal alias was removed.
+2. **Signalling user errors** — Pitfall: `sys.exit(1)` with manual `click.echo`. Instead: `raise click.ClickException("message")`. Why: Wave 1 #5 made `ClickException` route correctly; ad-hoc exits bypass that.
+3. **CliRunner `mix_stderr`** — Pitfall: asserting on `result.stderr`. Instead: assert on `result.output`. Why: default `mix_stderr=True` merges stderr into stdout; `result.stderr` is always empty under defaults. Cross-ref GUIDE.md.
+4. **URL-encoding query params** — Pitfall: string-concatenating user values into URL query strings. Instead: build params as a dict and use `urllib.parse.urlencode`. Why: spaces, `&`, `#` in user values silently break URLs or enable injection.
+5. **Secrets in argv** — Pitfall: `ctx.run(["wrangler", "secret", "put", name, Secret(token)])`. Instead: `ctx.run_with_secrets(...)` (Wave 3 #11). Why: argv is world-readable in `ps`; the helper enforces this and routes via env/stdin.
+6. **Shell-sourceable config files** — Pitfall: hand-rolling a `.env` parser. Instead: `clickwork.config.load_env_file(path)` (Wave 2 #9). Why: parser gotchas are solved once; the helper also enforces owner-only permissions.
+7. **Platform dispatch** — Pitfall: repeating `if sys.platform == "linux": ... elif "win32": ...`. Instead: `@clickwork.platform_dispatch(linux=..., windows=..., macos=...)` (Wave 2 #12). Why: the helper handles "unsupported platform" errors consistently.
+8. **HTTP calls** — Pitfall: building a `urllib.request` helper in each command, or adding `requests`. Instead: `clickwork.http.get/post/put/delete` (Wave 3 #13). Why: stdlib-only helper with URL allowlist, JSON auto-parse, structured `HttpError`.
+9. **Missing `import sys`** — Pitfall: calling `sys.exit()` or `sys.stdin` without importing. Instead: explicit `import sys`. Why: easy to forget; `sys` is not a builtin.
+10. **`bash -c`** — Pitfall: `ctx.run(["bash", "-c", "command $VAR"])`. Instead: use Python stdlib directly, or `ctx.run(["command"], env={...})`. Why: `bash -c` opens a shell-injection vector if any part of the command string is user-influenced, and creates a cross-platform dependency on `bash`.
+11. **`Secret.get()` at module scope** — Pitfall: `TOKEN = Secret(...).get()` at module import. Instead: call `.get()` at the call site when you actually need the value. Why: module-scope unwrap defeats the "value stays wrapped until used" invariant.
+
+**Each entry is 3 lines max.** Link out to helper docstrings / GUIDE sections for depth.
+
+**Constraints:**
+- **Must close issue #17.** `Fixes #17`.
+- Keep entries short — readers scanning for "why is my thing broken" want a quick hit, not prose.
+- Every "Instead:" pointing at a Wave 1-3 helper uses the helper's actual module path (no typos).
+
+## Per-wave execution checklist
+
+- [ ] Wave 3 PRs (#28, #29) merged
+- [ ] This plan merged
+- [ ] Wave 4 worktrees rebased onto post-Wave-3 main
+- [ ] Two parallel subagents dispatched (docs can parallelize cleanly — no shared files)
+- [ ] Diffs reviewed in main session
+- [ ] Commit + push + PRs with `Fixes #N`
+- [ ] Copilot review loop per PR
+- [ ] Merges
+- [ ] Worktrees + local branches cleaned up
+
+## Out of scope for Wave 4 (follow-ups to file)
+
+- `mock_run()` / `mock_capture()` context managers — hides Click internals; revisit if real demand surfaces
+- `patch_require()` helper — made unnecessary by Wave 1 #8
+- Tutorial-style GUIDE.md expansion — this wave is reference-level docs only
+- Future pagination / auto-parse / retry entries in footguns — add when those features exist

--- a/docs/plans/2026-04-17-wave-4-docs.md
+++ b/docs/plans/2026-04-17-wave-4-docs.md
@@ -51,7 +51,7 @@
 
 1. **Red.** Add tests in `tests/unit/test_testing.py`:
    - `test_run_cli_invokes_command_and_returns_click_result` — basic smoke: `run_cli(cli, ["--help"])` returns a `click.testing.Result` with `exit_code == 0`.
-   - `test_run_cli_catch_exceptions_false_by_default` — a command that raises a real exception should propagate through `run_cli` (not be swallowed by Click's `standalone_mode`). Pass `catch_exceptions=True` explicitly and confirm that form suppresses instead.
+   - `test_run_cli_catch_exceptions_false_by_default` — a command that raises a real exception should propagate through `run_cli` (because the helper pins `CliRunner.invoke(..., catch_exceptions=False)` by default). Pass `catch_exceptions=True` explicitly and confirm that form suppresses the exception and surfaces it as `result.exception` instead.
    - `test_make_test_cli_returns_click_group` — asserts type.
    - `test_make_test_cli_accepts_commands_dir` — creates a tmp dir, passes it, asserts commands discovered.
    - `test_make_test_cli_forwards_create_cli_kwargs` — e.g. `description="test"` reaches the returned group's help text.
@@ -96,7 +96,7 @@
 4. **URL-encoding query params** — Pitfall: string-concatenating user values into URL query strings. Instead: build params as a dict and use `urllib.parse.urlencode`. Why: spaces, `&`, `#` in user values silently break URLs or enable injection.
 5. **Secrets in argv** — Pitfall: `ctx.run(["wrangler", "secret", "put", name, Secret(token)])`. Instead: `ctx.run_with_secrets(...)` (Wave 3 #11). Why: argv is world-readable in `ps`; the helper enforces this and routes via env/stdin.
 6. **Shell-sourceable config files** — Pitfall: hand-rolling a `.env` parser. Instead: `clickwork.config.load_env_file(path)` (Wave 2 #9). Why: parser gotchas are solved once; the helper also enforces owner-only permissions.
-7. **Platform dispatch** — Pitfall: repeating `if sys.platform == "linux": ... elif "win32": ...`. Instead: `@clickwork.platform_dispatch(linux=..., windows=..., macos=...)` (Wave 2 #12). Why: the helper handles "unsupported platform" errors consistently.
+7. **Platform dispatch** — Pitfall: repeating `if sys.platform == "linux": ... elif sys.platform == "win32": ...`. Instead: `@clickwork.platform_dispatch(linux=..., windows=..., macos=...)` (Wave 2 #12). Why: the helper handles "unsupported platform" errors consistently.
 8. **HTTP calls** — Pitfall: building a `urllib.request` helper in each command, or adding `requests`. Instead: `clickwork.http.get/post/put/delete` (Wave 3 #13). Why: stdlib-only helper with URL allowlist, JSON auto-parse, structured `HttpError`.
 9. **Missing `import sys`** — Pitfall: calling `sys.exit()` or `sys.stdin` without importing. Instead: explicit `import sys`. Why: easy to forget; `sys` is not a builtin.
 10. **`bash -c`** — Pitfall: `ctx.run(["bash", "-c", "command $VAR"])`. Instead: use Python stdlib directly, or `ctx.run(["command"], env={...})`. Why: `bash -c` opens a shell-injection vector if any part of the command string is user-influenced, and creates a cross-platform dependency on `bash`.

--- a/docs/plans/2026-04-17-wave-4-docs.md
+++ b/docs/plans/2026-04-17-wave-4-docs.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-17
 **Roadmap:** [docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md](../superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md)
-**Scope:** Issues #16 (`clickwork.testing` helper + `mix_stderr` docs) and #17 (Common Footguns section in LLM_REFERENCE). Serial — #16 first, then #17.
+**Scope:** Issues #16 (`clickwork.testing` helper + `mix_stderr` docs) and #17 (Common Footguns section in LLM_REFERENCE). Parallel — the two PRs touch DIFFERENT sections of `LLM_REFERENCE.md` (testing one-liner vs top-level "Common Footguns"), so they can merge without conflicts as long as agents write to their assigned section only. #17's entries reference the `clickwork.testing` helpers from #16 by their locked-in name (`clickwork.testing.run_cli`, `clickwork.testing.make_test_cli`) — that's fine because the names are pinned by this plan.
 **Depends on:** Waves 1–3 merged. Wave 3's `run_with_secrets` and `clickwork.http` land in the footguns doc as "use the new helper."
 
 ## API shape decisions

--- a/docs/plans/2026-04-17-wave-4-docs.md
+++ b/docs/plans/2026-04-17-wave-4-docs.md
@@ -7,12 +7,14 @@
 
 ## API shape decisions
 
-### #16 — `clickwork.testing` + `mix_stderr` docs
+### #16 — `clickwork.testing` + CliRunner-output docs
+
+**Important correction from an earlier draft:** the original plan framed the docs around `CliRunner`'s `mix_stderr=True` default ("`result.stderr` is always empty unless you pass `mix_stderr=False`"). That was true on older Click versions but **is no longer accurate on Click 8.3.x** (our installed/minimum-tested version): `CliRunner.__init__` no longer exposes a `mix_stderr` parameter, and a real invocation populates all three of `result.output` (mixed stdout + stderr), `result.stdout`, and `result.stderr` separately. The footgun is therefore **not** "stderr is empty", it's "`result.output` interleaves streams". Plan updated accordingly.
 
 | Decision | Choice |
 |----------|--------|
 | Module surface | Option B: `run_cli()` + `make_test_cli()`. NOT shipping `mock_run()` / `mock_capture()` in this PR — they'd hide Click testing internals that test authors benefit from understanding, and we can add them later without API churn. |
-| `mix_stderr` docs location | **Both** GUIDE.md and LLM_REFERENCE.md. Different audiences (humans vs LLMs), same invariant. GUIDE.md gets a "Testing commands" subsection; LLM_REFERENCE.md gets a one-liner under testing with a cross-ref to the GUIDE section. |
+| CliRunner-output docs location | **Both** GUIDE.md and LLM_REFERENCE.md. Different audiences (humans vs LLMs), same invariant: `result.output` is stdout + stderr interleaved; use `result.stdout` / `result.stderr` explicitly if you need to distinguish. GUIDE.md gets a "Testing commands" subsection; LLM_REFERENCE.md gets a one-liner under testing with a cross-ref to GUIDE. |
 | `make_test_cli` signature | `make_test_cli(*, commands_dir: Path \| None = None, **create_cli_kwargs) -> click.Group`. Wraps `create_cli()` with a sensible default name (`"test-cli"`) and optionally a temp-dir commands directory. Tests that just want a CLI to call `runner.invoke` against don't have to repeat the `create_cli(name=...)` boilerplate. |
 | `run_cli` signature | `run_cli(cli: click.Group, args: list[str], **runner_kwargs) -> click.testing.Result`. Wraps `CliRunner().invoke()` with `catch_exceptions=False` by default (so test failures surface real tracebacks instead of Click's swallowed-exception path). Returns Click's native `Result` — we deliberately don't invent a new `TestResult` type because most test authors already know Click's. |
 | `mock_require` helper | **Not shipping.** Wave 1's #8 made `patch("clickwork.prereqs.require")` work directly, so a dedicated helper is no longer needed. |
@@ -37,12 +39,12 @@
 
 ## Per-issue tasks
 
-### #16 — `clickwork.testing` module + `mix_stderr` docs
+### #16 — `clickwork.testing` module + CliRunner-output docs
 
 **Files:**
 - new `src/clickwork/testing.py` (public module accessible as `clickwork.testing`)
 - new `tests/unit/test_testing.py` (meta: tests FOR the testing helpers)
-- `docs/GUIDE.md` — add "Testing commands" subsection covering `CliRunner` `mix_stderr=True` default and the new helpers
+- `docs/GUIDE.md` — add "Testing commands" subsection covering how `CliRunner.Result.output` / `.stdout` / `.stderr` relate (Click 8.3.x behaviour) and the new helpers
 - `docs/LLM_REFERENCE.md` — add one-liner in the testing area pointing at GUIDE
 
 **TDD:**
@@ -63,15 +65,15 @@
 3. **Refactor.** Module docstring explaining:
    - Why these helpers exist (reduce boilerplate in plugin test suites)
    - `catch_exceptions=False` rationale: surfaces real tracebacks
-   - `mix_stderr` note: `CliRunner` defaults to `mix_stderr=True`, so assertions on stderr-only output should use `result.output` unless the caller explicitly passed `mix_stderr=False`. Link to GUIDE.md.
+   - CliRunner-output note: on Click 8.3.x, `result.output` contains stdout AND stderr interleaved (stream-of-user-output order); `result.stdout` is stdout only; `result.stderr` is stderr only. A test asserting "the error message was printed to stderr" should assert on `result.stderr` directly. Link to GUIDE.md. (Note: older Click versions exposed a `mix_stderr` kwarg; it was removed — don't write tests that assume it still exists.)
    - A canonical copy-pasteable example
 
 **GUIDE.md additions** — new "Testing commands" section:
 - Introduces `clickwork.testing` helpers
-- Documents the `mix_stderr=True` gotcha explicitly (agents keep hitting this, humans do too)
+- Documents the `result.output` mixed-streams behaviour and when to prefer `result.stdout` / `result.stderr` separately
 - Shows a canonical test example using `run_cli` + `make_test_cli`
 
-**LLM_REFERENCE.md addition** — one-liner in testing section pointing at GUIDE.md's "mix_stderr gotcha" subsection.
+**LLM_REFERENCE.md addition** — one-liner in testing section pointing at GUIDE.md's CliRunner-output subsection.
 
 **Constraints:**
 - **Must close issue #16.** `Fixes #16`.
@@ -90,7 +92,7 @@
 
 1. **Patching `ctx.require`** — Pitfall: patching `clickwork.cli._require` (old workaround). Instead: `patch("clickwork.prereqs.require")`. Why: Wave 1 #8 made the public symbol patchable; the internal alias was removed.
 2. **Signalling user errors** — Pitfall: `sys.exit(1)` with manual `click.echo`. Instead: `raise click.ClickException("message")`. Why: Wave 1 #5 made `ClickException` route correctly; ad-hoc exits bypass that.
-3. **CliRunner `mix_stderr`** — Pitfall: asserting on `result.stderr`. Instead: assert on `result.output`. Why: default `mix_stderr=True` merges stderr into stdout; `result.stderr` is always empty under defaults. Cross-ref GUIDE.md.
+3. **CliRunner mixed output** — Pitfall: asserting on `result.output` when you specifically want stdout-only or stderr-only content (`result.output` interleaves BOTH streams). Instead: assert on `result.stdout` or `result.stderr` directly. Why: on Click 8.3.x `output` is stdout+stderr combined; the older `mix_stderr` kwarg that some online snippets reference has been removed. Cross-ref GUIDE.md.
 4. **URL-encoding query params** — Pitfall: string-concatenating user values into URL query strings. Instead: build params as a dict and use `urllib.parse.urlencode`. Why: spaces, `&`, `#` in user values silently break URLs or enable injection.
 5. **Secrets in argv** — Pitfall: `ctx.run(["wrangler", "secret", "put", name, Secret(token)])`. Instead: `ctx.run_with_secrets(...)` (Wave 3 #11). Why: argv is world-readable in `ps`; the helper enforces this and routes via env/stdin.
 6. **Shell-sourceable config files** — Pitfall: hand-rolling a `.env` parser. Instead: `clickwork.config.load_env_file(path)` (Wave 2 #9). Why: parser gotchas are solved once; the helper also enforces owner-only permissions.

--- a/docs/plans/2026-04-17-wave-4-docs.md
+++ b/docs/plans/2026-04-17-wave-4-docs.md
@@ -114,7 +114,7 @@
 - [ ] Wave 3 PRs (#28, #29) merged
 - [ ] This plan merged
 - [ ] Wave 4 worktrees rebased onto post-Wave-3 main
-- [ ] Two parallel subagents dispatched (docs can parallelize cleanly — no shared files)
+- [ ] Two parallel subagents dispatched. Both edit ``docs/LLM_REFERENCE.md`` but in DIFFERENT sections (#16 edits the testing section's one-liner; #17 adds the new top-level "Common Footguns" section). Agents must touch only their assigned section — if edit regions land near each other, serialize instead to avoid a textual merge conflict. No source file overlap either way (#16 owns ``src/clickwork/testing.py`` + tests; #17 is docs-only).
 - [ ] Diffs reviewed in main session
 - [ ] Commit + push + PRs with `Fixes #N`
 - [ ] Copilot review loop per PR


### PR DESCRIPTION
## Summary
Locked-in decisions for Wave 4 of the 0.2.0 roadmap (docs + testing helper).

**#16 — ``clickwork.testing`` module + CliRunner-output docs**
- Ship ``run_cli()`` + ``make_test_cli()`` (option B from the brainstorm)
- Document ``CliRunner``'s **actual Click 8.3.x behaviour** (mix_stderr kwarg was removed; ``result.output`` is stdout+stderr interleaved; ``result.stdout`` / ``result.stderr`` are available separately) in **both** GUIDE.md and LLM_REFERENCE.md
- NOT shipping ``mock_run`` / ``mock_capture`` this wave — follow-up if demand surfaces
- NOT shipping ``patch_require`` — Wave 1 #8 made it unnecessary

**#17 — Common Footguns in LLM_REFERENCE.md**
- Single top-level section (option A), 11 entries, Pitfall / Instead / Why format (3 lines max each)
- Post-Wave fixes flipped from "here's the workaround" to "here's the helper": uses ``run_with_secrets``, ``load_env_file``, ``platform_dispatch``, ``clickwork.http`` etc.
- Still-applicable pitfalls (CliRunner mixed output, URL-encode query params, ``import sys``, ``bash -c``, Secret at call site) stay as warnings

**Important revision during review:** the original draft of the plan framed the testing docs around Click's old ``mix_stderr=True`` default. User empirically verified and flagged that on the currently-pinned Click 8.3.x, ``mix_stderr`` is gone as a parameter and ``result.stderr`` IS populated. Plan has been reframed throughout to match actual behaviour. See the "Important correction" note at the top of the #16 decisions section.

Roadmap: [docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md](../blob/main/docs/superpowers/specs/2026-04-17-clickwork-0.2.0-roadmap.md)

## Test plan
- [ ] Plan merged
- [ ] Wave 4 worktrees rebased onto post-Wave-3 main
- [ ] Two parallel subagents dispatched (docs parallelize cleanly — different sections of LLM_REFERENCE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)