### PR TITLE
feat: clickwork.testing helpers + CliRunner-output docs (Fixes #16)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -455,10 +455,90 @@ directly. The framework discovers commands from entry points -- no
 
 ## Testing Your Commands
 
+### Testing commands with `clickwork.testing`
+
+The `clickwork.testing` module ships two thin helpers that collapse the
+boilerplate of constructing a test CLI and invoking it through Click's
+`CliRunner`:
+
+```python
+from clickwork.testing import make_test_cli, run_cli
+
+def test_greet_says_hello(tmp_path):
+    (tmp_path / "greet.py").write_text(
+        "import click\n"
+        "@click.command()\n"
+        "def greet():\n"
+        "    click.echo('hello')\n"
+        "cli = greet\n"
+    )
+
+    cli = make_test_cli(commands_dir=tmp_path)
+    result = run_cli(cli, ["greet"])
+
+    assert result.exit_code == 0
+    assert "hello" in result.stdout
+```
+
+What the helpers do:
+
+- `make_test_cli(*, commands_dir=None, **kwargs)` wraps
+  `create_cli()` with a default `name="test-cli"`. Every other kwarg
+  forwards unchanged, so you still get `description=`, `config_schema=`,
+  etc. when you need them.
+- `run_cli(cli, args, **kwargs)` wraps `CliRunner().invoke()` with
+  `catch_exceptions=False` pinned by default. This means a bug in your
+  command surfaces as a real traceback in pytest output instead of being
+  quietly captured into `result.exception`. Pass `catch_exceptions=True`
+  explicitly when you want Click's default swallow-and-report behaviour.
+
+`run_cli` returns Click's native `click.testing.Result` -- the helpers
+deliberately do not invent a new result type, so any idiom you already
+know from Click docs keeps working.
+
+### `result.output` vs `result.stdout` vs `result.stderr`
+
+Click's `Result` exposes three stream attributes and they are **not
+interchangeable**:
+
+| Attribute | Contents |
+|-----------|----------|
+| `result.output` | stdout **and** stderr interleaved in the order the command produced them |
+| `result.stdout` | stdout only |
+| `result.stderr` | stderr only |
+
+The rule of thumb: if a test says "the error message was printed to
+stderr", it should assert on `result.stderr` -- asserting on
+`result.output` would pass even if the command wrote the error to
+stdout by mistake, because `output` contains both streams.
+
+```python
+@click.command()
+def noisy():
+    click.echo("normal line")
+    click.echo("error line", err=True)
+
+result = run_cli(noisy, [])
+assert "normal line" in result.stdout        # yes
+assert "error line" in result.stderr          # yes
+assert "error line" in result.output          # ALSO yes (interleaved)
+assert "normal line" in result.stderr         # NO -- would fail
+```
+
+> **Footgun:** old Click releases exposed a `mix_stderr` kwarg on
+> `CliRunner.__init__` that toggled whether stderr was folded into
+> `output`. That kwarg has been **removed** in current Click (8.2+).
+> Both streams are always available separately via `result.stdout` /
+> `result.stderr`, with `result.output` continuing to provide the
+> interleaved form for backwards compatibility. Do not copy snippets
+> from older docs that still reference `CliRunner(mix_stderr=False)` --
+> they will fail with `TypeError`.
+
 ### Unit Testing with CliRunner
 
-Click's `CliRunner` invokes your CLI in-process without spawning a
-subprocess:
+If you need finer control than `run_cli` gives -- custom `CliRunner`
+configuration, isolated filesystems via `runner.isolated_filesystem()`,
+and so on -- reach for Click's `CliRunner` directly:
 
 ```python
 from click.testing import CliRunner

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -530,11 +530,10 @@ assert "normal line" in result.stderr         # NO -- would fail
 > into `output`. Post-removal, `result.stdout` / `result.stderr` are
 > populated independently and `result.output` keeps providing the
 > interleaved form. clickwork declares `click>=8.1`, so in principle
-> a consumer could be on 8.1 where the kwarg still works -- the
-> pinned environment (`uv.lock`) tracks 8.2+. If you are reading an
-> older snippet that uses `CliRunner(mix_stderr=False)`, check the
-> Click version in your test environment: 8.2+ will raise
-> `TypeError`, older releases still accept it.
+> a consumer could still be on 8.1 where the kwarg works. If you
+> are reading an older snippet that uses `CliRunner(mix_stderr=False)`,
+> check the Click version in your test environment: 8.2+ will raise
+> `TypeError`; older releases still accept it.
 
 ### Unit Testing with CliRunner
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -525,14 +525,16 @@ assert "error line" in result.output          # ALSO yes (interleaved)
 assert "normal line" in result.stderr         # NO -- would fail
 ```
 
-> **Footgun:** old Click releases exposed a `mix_stderr` kwarg on
-> `CliRunner.__init__` that toggled whether stderr was folded into
-> `output`. That kwarg has been **removed** in current Click (8.2+).
-> Both streams are always available separately via `result.stdout` /
-> `result.stderr`, with `result.output` continuing to provide the
-> interleaved form for backwards compatibility. Do not copy snippets
-> from older docs that still reference `CliRunner(mix_stderr=False)` --
-> they will fail with `TypeError`.
+> **Footgun:** Click 8.2 removed the `mix_stderr` kwarg on
+> `CliRunner.__init__` that used to toggle whether stderr was folded
+> into `output`. Post-removal, `result.stdout` / `result.stderr` are
+> populated independently and `result.output` keeps providing the
+> interleaved form. clickwork declares `click>=8.1`, so in principle
+> a consumer could be on 8.1 where the kwarg still works -- the
+> pinned environment (`uv.lock`) tracks 8.2+. If you are reading an
+> older snippet that uses `CliRunner(mix_stderr=False)`, check the
+> Click version in your test environment: 8.2+ will raise
+> `TypeError`, older releases still accept it.
 
 ### Unit Testing with CliRunner
 
@@ -557,7 +559,11 @@ def test_deploy_dry_run(tmp_path):
     )
 
     cli = create_cli(name="test-cli", commands_dir=cmd_dir)
-    result = CliRunner().invoke(cli, ["--dry-run", "deploy"])
+    # Pass ``catch_exceptions=False`` here for the same reason
+    # ``run_cli`` pins it above: without it, a bug inside the command
+    # surfaces only as ``result.exception`` with a generic exit code,
+    # and the real traceback is swallowed.
+    result = CliRunner().invoke(cli, ["--dry-run", "deploy"], catch_exceptions=False)
 
     assert result.exit_code == 0
     assert "dry_run=True" in result.output

--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -147,16 +147,12 @@ when asserting on a specific stream. See
 [GUIDE.md "Testing commands with `clickwork.testing`"](GUIDE.md#testing-commands-with-clickworktesting).
 
 ```python
-from click.testing import CliRunner
-from clickwork import create_cli
+from clickwork.testing import make_test_cli, run_cli
 
 def test_deploy_dry_run(tmp_path):
-    cmd_dir = tmp_path / "commands"
-    cmd_dir.mkdir()
-    (cmd_dir / "deploy.py").write_text(...)
-
-    cli = create_cli(name="test-cli", commands_dir=cmd_dir)
-    result = CliRunner().invoke(cli, ["--dry-run", "deploy"])
+    (tmp_path / "deploy.py").write_text(...)
+    cli = make_test_cli(commands_dir=tmp_path)
+    result = run_cli(cli, ["--dry-run", "deploy"])
     assert result.exit_code == 0
 ```
 

--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -139,6 +139,13 @@ if __name__ == "__main__":
 
 ## Testing Commands
 
+Prefer `clickwork.testing.run_cli` / `clickwork.testing.make_test_cli` for new
+test code -- they pin `catch_exceptions=False` and default `name="test-cli"`
+so real tracebacks surface in pytest output. Note that `result.output`
+contains stdout AND stderr interleaved; use `result.stdout` / `result.stderr`
+when asserting on a specific stream. See
+[GUIDE.md "Testing commands with `clickwork.testing`"](GUIDE.md#testing-commands-with-clickworktesting).
+
 ```python
 from click.testing import CliRunner
 from clickwork import create_cli

--- a/src/clickwork/__init__.py
+++ b/src/clickwork/__init__.py
@@ -18,11 +18,18 @@ Public API:
     platform_dispatch - Decorator that routes a command to a per-OS impl
     platform          - Submodule exposing dispatch(), is_linux/macos/windows
     http              - Submodule exposing get/post/put/delete + HttpError
+    testing           - Submodule exposing run_cli() + make_test_cli() helpers
 """
 
 __version__ = "0.1.0"
 
-from clickwork import http, platform
+# WHY ``testing`` is imported here alongside ``http`` / ``platform``: all
+# three are advertised as importable both as ``clickwork.<name>`` and as
+# ``from clickwork import <name>``. The top-level import makes the
+# attribute-on-package form work without relying on implicit submodule
+# resolution (which doesn't fire until the user imports the submodule
+# explicitly somewhere else first).
+from clickwork import http, platform, testing
 from clickwork._types import CliContext, CliProcessError, PrerequisiteError, Secret, normalize_prefix
 from clickwork.cli import create_cli, pass_cli_context
 from clickwork.config import ConfigError, load_config
@@ -49,4 +56,5 @@ __all__ = [
     "post",
     "put",
     "delete",
+    "testing",
 ]

--- a/src/clickwork/testing.py
+++ b/src/clickwork/testing.py
@@ -1,0 +1,192 @@
+"""Test helpers for clickwork-built CLIs.
+
+This module provides two thin wrappers over Click's own testing toolkit so
+plugin test suites can stop re-typing the same 4-line setup. It ships on
+purpose with a minimal surface -- ``run_cli`` and ``make_test_cli`` only --
+because most test authors benefit from keeping the rest of Click's testing
+API visible. If you want to stub out subprocess calls, build your own mocks;
+we deliberately do not ship ``mock_run`` / ``mock_capture`` context managers.
+
+Why these helpers exist
+-----------------------
+
+Before this module existed, every plugin test that exercised a full CLI
+looked like::
+
+    from click.testing import CliRunner
+    from clickwork import create_cli
+
+    def test_greet(tmp_path):
+        (tmp_path / "greet.py").write_text(...)
+        cli = create_cli(name="test-cli", commands_dir=tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["greet"], catch_exceptions=False)
+        assert result.exit_code == 0
+
+Two pieces of boilerplate appeared in every file: constructing the CLI with
+a throwaway name, and remembering to pass ``catch_exceptions=False`` so real
+tracebacks surface in test output. This module collapses both.
+
+Canonical usage
+---------------
+
+::
+
+    from clickwork.testing import make_test_cli, run_cli
+
+    def test_greet_says_hello(tmp_path):
+        (tmp_path / "greet.py").write_text(
+            "import click\\n"
+            "@click.command()\\n"
+            "def greet():\\n"
+            "    click.echo('hello')\\n"
+            "cli = greet\\n"
+        )
+
+        cli = make_test_cli(commands_dir=tmp_path)
+        result = run_cli(cli, ["greet"])
+
+        assert result.exit_code == 0
+        assert "hello" in result.stdout
+
+CliRunner output attributes -- pick the right one
+-------------------------------------------------
+
+Click's :class:`click.testing.Result` exposes three stream attributes that
+look similar but differ in subtle ways that matter for assertion tests:
+
+* ``result.output`` -- stdout AND stderr **interleaved** in the order the
+  command produced them. Convenient for "did the command say X at all"
+  smoke checks. Misleading for "did the error go to stderr" tests,
+  because the answer is always "yes, and also it's in ``output``".
+* ``result.stdout`` -- stdout only. Assert on this when the contract you
+  care about is specifically "this goes to the normal output channel".
+* ``result.stderr`` -- stderr only. Assert on this when the contract is
+  "this is an error / diagnostic / progress line on a side channel".
+
+A test that says "the error message was printed to stderr" should assert
+on ``result.stderr``, not ``result.output``. See the GUIDE.md "Testing
+commands" section for a worked example.
+
+Historical note: older Click versions exposed a ``mix_stderr`` kwarg on
+``CliRunner.__init__``. That kwarg was **removed**; current Click
+(8.2+) always populates all three stream attributes separately, with
+``output`` containing the interleaved form for free. Do not copy
+snippets from old docs that reference ``CliRunner(mix_stderr=False)`` --
+they will fail with ``TypeError``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import click
+
+from clickwork.cli import create_cli
+
+if TYPE_CHECKING:
+    # click.testing is only pulled in for type-checker annotations so the
+    # runtime import cost stays opt-in: a project that imports
+    # ``clickwork.testing`` for ``make_test_cli`` but never calls
+    # ``run_cli`` never loads click.testing's ~dozen-KB module graph.
+    from click.testing import Result
+
+
+def run_cli(
+    cli: click.BaseCommand,
+    args: list[str],
+    **kwargs: Any,
+) -> Result:
+    """Invoke a Click CLI under CliRunner with test-friendly defaults.
+
+    Equivalent to ``click.testing.CliRunner().invoke(cli, args, **kwargs)``
+    with one change: ``catch_exceptions`` defaults to ``False`` so bugs in
+    the command surface as real tracebacks in pytest output instead of
+    being swallowed into ``result.exception``. Pass ``catch_exceptions=True``
+    explicitly if you want to assert on the caught exception.
+
+    Args:
+        cli: The Click command or group to invoke. Accepts any
+            ``click.BaseCommand`` subclass so tests can pass a raw
+            ``@click.command``-decorated function or a group built with
+            :func:`clickwork.create_cli`.
+        args: The command-line arguments to pass, as you would write them
+            after the CLI name (e.g. ``["deploy", "--env", "staging"]``).
+        **kwargs: Forwarded verbatim to ``CliRunner.invoke``. Useful
+            overrides: ``input=`` to feed stdin, ``env=`` to set
+            environment variables, ``catch_exceptions=True`` to restore
+            Click's default exception-swallowing behaviour.
+
+    Returns:
+        Click's native :class:`click.testing.Result`. We deliberately do
+        not wrap this -- plugin authors already know its shape.
+
+    Example::
+
+        result = run_cli(cli, ["deploy", "--dry-run"])
+        assert result.exit_code == 0
+        assert "would deploy" in result.stdout
+    """
+    # WHY we import CliRunner inside the function rather than at module
+    # top level: click.testing pulls in additional streams/runner
+    # machinery that a plugin's production code path never needs. Doing
+    # the import here keeps ``import clickwork.testing`` itself cheap --
+    # test-only consumers (conftest.py, test modules) pay the cost once
+    # the first time ``run_cli`` is called.
+    from click.testing import CliRunner
+
+    # WHY setdefault instead of popping + re-adding: setdefault only
+    # writes the key when it's absent, so a caller that passes
+    # ``catch_exceptions=True`` keeps their override intact. Explicit
+    # ``kwargs["catch_exceptions"] = False`` would clobber it.
+    kwargs.setdefault("catch_exceptions", False)
+
+    runner = CliRunner()
+    return runner.invoke(cli, args, **kwargs)
+
+
+def make_test_cli(
+    *,
+    commands_dir: Path | None = None,
+    **create_cli_kwargs: Any,
+) -> click.Group:
+    """Build a clickwork CLI with sensible test-suite defaults.
+
+    Thin convenience wrapper over :func:`clickwork.create_cli`. Fills in a
+    default ``name`` (``"test-cli"``) so tests that don't care about the
+    CLI name don't have to repeat that argument, and forwards every other
+    kwarg through unchanged.
+
+    Args:
+        commands_dir: Directory containing command ``.py`` files to
+            discover, typically ``tmp_path`` in a pytest test. Optional;
+            omit to test the global-flags layer without registering any
+            commands.
+        **create_cli_kwargs: Forwarded verbatim to ``create_cli``.
+            Commonly overridden: ``name=`` to pin the CLI name for help-
+            text assertions, ``description=`` to test custom help text,
+            ``config_schema=`` to exercise config validation.
+
+    Returns:
+        A :class:`click.Group` ready to feed into :func:`run_cli`.
+
+    Example::
+
+        cli = make_test_cli(commands_dir=tmp_path, description="deploy helpers")
+        result = run_cli(cli, ["--help"])
+        assert "deploy helpers" in result.stdout
+    """
+    # WHY setdefault for ``name``: callers that DO pass name= (e.g.,
+    # "custom-cli") must keep it. setdefault is the one-liner that
+    # preserves both behaviours -- provide a sensible default while
+    # staying transparent to explicit overrides.
+    create_cli_kwargs.setdefault("name", "test-cli")
+
+    # Forward commands_dir as a dedicated keyword rather than folding it
+    # into ``create_cli_kwargs`` in the signature. This makes the helper's
+    # intent ("opt-in commands directory, everything else passes through")
+    # readable at a glance, and prevents a caller from accidentally
+    # passing ``commands_dir=`` as both a positional-looking kwarg AND
+    # inside ``**create_cli_kwargs`` -- Python would raise TypeError on
+    # the duplicate.
+    return create_cli(commands_dir=commands_dir, **create_cli_kwargs)

--- a/src/clickwork/testing.py
+++ b/src/clickwork/testing.py
@@ -74,7 +74,7 @@ attributes on ``Result`` are populated separately (``output`` is the
 interleaved form; ``stdout`` and ``stderr`` are kept independent).
 clickwork declares ``click>=8.1`` so in principle a consumer could be
 running on 8.1 where ``mix_stderr`` still exists -- the pinned
-environment (see ``uv.lock``) tracks a 8.2+ release. If you are
+environment (see ``uv.lock``) tracks an 8.2+ release. If you are
 looking at an older snippet that uses ``CliRunner(mix_stderr=False)``,
 check the Click version in your test environment rather than
 assuming the 8.2+ API: 8.2+ will raise ``TypeError``, older releases

--- a/src/clickwork/testing.py
+++ b/src/clickwork/testing.py
@@ -82,6 +82,7 @@ still accept the kwarg.
 """
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -99,7 +100,7 @@ if TYPE_CHECKING:
 
 def run_cli(
     cli: click.BaseCommand,
-    args: list[str],
+    args: str | Sequence[str] | None = None,
     **kwargs: Any,
 ) -> Result:
     """Invoke a Click CLI under CliRunner with test-friendly defaults.
@@ -116,7 +117,12 @@ def run_cli(
             ``@click.command``-decorated function or a group built with
             :func:`clickwork.create_cli`.
         args: The command-line arguments to pass, as you would write them
-            after the CLI name (e.g. ``["deploy", "--env", "staging"]``).
+            after the CLI name. The preferred form is a list/tuple of
+            already-tokenised strings (``["deploy", "--env", "staging"]``);
+            a single string gets shell-tokenised by Click, which matches
+            Click's ``CliRunner.invoke`` signature but is error-prone on
+            values containing spaces or quotes. ``None`` means "no
+            arguments," equivalent to invoking the CLI with no positionals.
         **kwargs: Forwarded verbatim to ``CliRunner.invoke``. Useful
             overrides: ``input=`` to feed stdin, ``env=`` to set
             environment variables, ``catch_exceptions=True`` to restore

--- a/src/clickwork/testing.py
+++ b/src/clickwork/testing.py
@@ -68,12 +68,17 @@ A test that says "the error message was printed to stderr" should assert
 on ``result.stderr``, not ``result.output``. See the GUIDE.md "Testing
 commands" section for a worked example.
 
-Historical note: older Click versions exposed a ``mix_stderr`` kwarg on
-``CliRunner.__init__``. That kwarg was **removed**; current Click
-(8.2+) always populates all three stream attributes separately, with
-``output`` containing the interleaved form for free. Do not copy
-snippets from old docs that reference ``CliRunner(mix_stderr=False)`` --
-they will fail with ``TypeError``.
+Historical note: Click 8.2 removed the ``mix_stderr`` kwarg that
+``CliRunner.__init__`` used to accept. Post-removal, all three stream
+attributes on ``Result`` are populated separately (``output`` is the
+interleaved form; ``stdout`` and ``stderr`` are kept independent).
+clickwork declares ``click>=8.1`` so in principle a consumer could be
+running on 8.1 where ``mix_stderr`` still exists -- the pinned
+environment (see ``uv.lock``) tracks a 8.2+ release. If you are
+looking at an older snippet that uses ``CliRunner(mix_stderr=False)``,
+check the Click version in your test environment rather than
+assuming the 8.2+ API: 8.2+ will raise ``TypeError``, older releases
+still accept the kwarg.
 """
 from __future__ import annotations
 

--- a/src/clickwork/testing.py
+++ b/src/clickwork/testing.py
@@ -73,12 +73,11 @@ Historical note: Click 8.2 removed the ``mix_stderr`` kwarg that
 attributes on ``Result`` are populated separately (``output`` is the
 interleaved form; ``stdout`` and ``stderr`` are kept independent).
 clickwork declares ``click>=8.1`` so in principle a consumer could be
-running on 8.1 where ``mix_stderr`` still exists -- the pinned
-environment (see ``uv.lock``) tracks an 8.2+ release. If you are
-looking at an older snippet that uses ``CliRunner(mix_stderr=False)``,
-check the Click version in your test environment rather than
-assuming the 8.2+ API: 8.2+ will raise ``TypeError``, older releases
-still accept the kwarg.
+running on 8.1 where ``mix_stderr`` still exists. If you are looking
+at an older snippet that uses ``CliRunner(mix_stderr=False)``, check
+the Click version in your test environment rather than assuming the
+8.2+ API: 8.2+ will raise ``TypeError``; older releases still accept
+the kwarg.
 """
 from __future__ import annotations
 
@@ -95,14 +94,24 @@ if TYPE_CHECKING:
     # runtime import cost stays opt-in: a project that imports
     # ``clickwork.testing`` for ``make_test_cli`` but never calls
     # ``run_cli`` never loads click.testing's ~dozen-KB module graph.
-    from click.testing import Result
+    from click.testing import Result as _ClickResult
+else:
+    # At runtime the alias resolves to ``Any`` so ``typing.get_type_hints``
+    # (used by IDEs, FastAPI, pydantic, etc.) can still introspect the
+    # signature without ``Result`` actually existing in module globals.
+    # Without this fallback ``get_type_hints(run_cli)`` would raise
+    # ``NameError: name '_ClickResult' is not defined`` -- the forward-
+    # reference string ``-> _ClickResult`` can't resolve because
+    # TYPE_CHECKING is False at runtime. The real type is still visible
+    # to type-checkers thanks to the TYPE_CHECKING branch above.
+    _ClickResult = Any
 
 
 def run_cli(
     cli: click.BaseCommand,
     args: str | Sequence[str] | None = None,
     **kwargs: Any,
-) -> Result:
+) -> _ClickResult:
     """Invoke a Click CLI under CliRunner with test-friendly defaults.
 
     Equivalent to ``click.testing.CliRunner().invoke(cli, args, **kwargs)``

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,0 +1,199 @@
+"""Tests for the clickwork.testing helper module.
+
+These tests are themselves meta: they exercise the helpers that future test
+suites will use to drive clickwork-built CLIs. Each test corresponds to one of
+the acceptance criteria in the Wave 4 plan for issue #16.
+
+WHY we keep these tests minimal: the two public helpers (``run_cli`` and
+``make_test_cli``) are thin adapters. Their value is in *convention* (pinned
+defaults and forwarded kwargs), not logic -- so each test asserts ONE
+convention in isolation. That way a future refactor of the helpers produces a
+single focused failure, instead of a wall of broken assertions that all
+collapse into the same root cause.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import Result
+
+
+class TestRunCli:
+    """run_cli() wraps CliRunner().invoke() with pinned defaults."""
+
+    def test_run_cli_invokes_command_and_returns_click_result(self) -> None:
+        """run_cli() returns Click's native Result object (exit_code == 0 on --help).
+
+        WHY we assert on the native Result type: plugin authors already know
+        Click's testing idioms, so we deliberately DO NOT invent a new result
+        type. Anything returned here must be drop-in compatible with
+        ``CliRunner.invoke()``'s return value so snippets copy-pasted from
+        Click docs keep working.
+        """
+        from clickwork.testing import run_cli
+
+        @click.command()
+        def greet() -> None:
+            """Say hi."""
+            click.echo("hi")
+
+        result = run_cli(greet, ["--help"])
+
+        # Click's native Result type -- we deliberately don't wrap it.
+        assert isinstance(result, Result)
+        assert result.exit_code == 0
+        # --help text always mentions the "Usage" banner; cheap smoke check
+        # that we actually invoked the command rather than, say, returning a
+        # stubbed Result.
+        assert "Usage" in result.output
+
+    def test_run_cli_catch_exceptions_false_by_default(self) -> None:
+        """Unhandled exceptions propagate unless catch_exceptions=True is passed.
+
+        WHY this is the default: with ``catch_exceptions=True`` (Click's own
+        default), a bug inside a command surfaces only as ``result.exception``
+        and ``result.exit_code == 1`` -- the real traceback is swallowed,
+        which routinely hides test failures behind a generic assertion on
+        exit code. We flip the default so the traceback lands directly on
+        the pytest output and the author sees the exact line that broke.
+        Passing ``catch_exceptions=True`` explicitly restores Click's
+        original behaviour for tests that WANT to assert on
+        ``result.exception``.
+        """
+        from clickwork.testing import run_cli
+
+        @click.command()
+        def boom() -> None:
+            raise RuntimeError("explode")
+
+        # Default: catch_exceptions=False, so RuntimeError propagates.
+        with pytest.raises(RuntimeError, match="explode"):
+            run_cli(boom, [])
+
+        # Explicit catch_exceptions=True overrides and suppresses.
+        result = run_cli(boom, [], catch_exceptions=True)
+        assert isinstance(result.exception, RuntimeError)
+        assert str(result.exception) == "explode"
+        assert result.exit_code == 1
+
+
+class TestMakeTestCli:
+    """make_test_cli() wraps create_cli() with test-friendly defaults."""
+
+    def test_make_test_cli_returns_click_group(self, tmp_path: Path) -> None:
+        """make_test_cli() returns a click.Group instance.
+
+        WHY we assert on the type: tests downstream rely on methods that only
+        Groups expose (``.commands``, ``.add_command``, etc.), so if a future
+        refactor accidentally returns a bare ``click.Command`` the failure
+        should surface here rather than as a confusing ``AttributeError`` in
+        the caller.
+        """
+        from clickwork.testing import make_test_cli
+
+        cli = make_test_cli(commands_dir=tmp_path)
+
+        assert isinstance(cli, click.Group)
+
+    def test_make_test_cli_accepts_commands_dir(self, tmp_path: Path) -> None:
+        """Commands dropped in commands_dir are discovered by the returned CLI.
+
+        WHY we exercise discovery end-to-end: commands_dir is the forward
+        path that every other clickwork test will use to scaffold realistic
+        CLIs, so a regression that breaks discovery from make_test_cli
+        (e.g., forgetting to forward the kwarg) would silently cascade into
+        every plugin test suite. Cheaper to catch it here.
+        """
+        from clickwork.testing import make_test_cli, run_cli
+
+        # Minimal conventional command file: exports `cli` as a Click command.
+        (tmp_path / "ping.py").write_text(
+            "import click\n"
+            "@click.command()\n"
+            "def ping():\n"
+            "    '''Respond with pong.'''\n"
+            "    click.echo('pong')\n"
+            "cli = ping\n"
+        )
+
+        cli = make_test_cli(commands_dir=tmp_path)
+        result = run_cli(cli, ["ping"])
+
+        assert result.exit_code == 0
+        assert "pong" in result.output
+
+    def test_make_test_cli_forwards_create_cli_kwargs(self, tmp_path: Path) -> None:
+        """Extra kwargs (e.g. description=) reach the underlying create_cli call.
+
+        WHY we test forwarding: **kwargs is easy to forget to pass through
+        when refactoring. A failure here means a plugin test that sets
+        ``description="..."`` to verify custom help-text behaviour would
+        silently drop the argument and produce a Click default.
+        """
+        from clickwork.testing import make_test_cli, run_cli
+
+        cli = make_test_cli(commands_dir=tmp_path, description="smoke-test description")
+        result = run_cli(cli, ["--help"])
+
+        assert result.exit_code == 0
+        # create_cli passes description through to Click's help= parameter,
+        # which renders it near the top of --help output.
+        assert "smoke-test description" in result.output
+
+    def test_make_test_cli_default_name(self, tmp_path: Path) -> None:
+        """Without an explicit name= kwarg, the CLI is named 'test-cli'.
+
+        WHY this default is pinned in tests: downstream test authors will
+        grep logs and help output for the CLI name when debugging; making
+        the default predictable (rather than, say, a random uuid) keeps
+        those greps trivial. If someone changes the default, this test
+        forces the change to be intentional.
+        """
+        from clickwork.testing import make_test_cli
+
+        cli = make_test_cli(commands_dir=tmp_path)
+
+        assert cli.name == "test-cli"
+
+    def test_make_test_cli_respects_explicit_name(self, tmp_path: Path) -> None:
+        """Passing name= overrides the 'test-cli' default.
+
+        WHY this complements test_make_test_cli_default_name: asserting the
+        default is pinned isn't enough -- we also need to know a caller can
+        still override it. A setdefault("name", ...) bug that silently
+        clobbered an explicit name would pass the "default is test-cli"
+        test while breaking this one.
+        """
+        from clickwork.testing import make_test_cli
+
+        cli = make_test_cli(commands_dir=tmp_path, name="custom-name")
+
+        assert cli.name == "custom-name"
+
+
+class TestModuleSurface:
+    """clickwork.testing is importable via both module and attribute paths."""
+
+    def test_module_importable_as_clickwork_testing(self) -> None:
+        """``import clickwork.testing`` resolves the submodule.
+
+        WHY both import forms are tested: we advertise the module in docs
+        with ``from clickwork.testing import run_cli`` AND as
+        ``clickwork.testing.run_cli`` (attribute access on the package).
+        Both must work; a missing re-export in ``clickwork/__init__.py``
+        would silently break the second form and users would not discover
+        it until a copy-pasted snippet failed.
+        """
+        import clickwork.testing as testing_module
+
+        assert callable(testing_module.run_cli)
+        assert callable(testing_module.make_test_cli)
+
+    def test_testing_attribute_on_clickwork_package(self) -> None:
+        """``from clickwork import testing`` works thanks to the re-export."""
+        from clickwork import testing
+
+        assert callable(testing.run_cli)
+        assert callable(testing.make_test_cli)


### PR DESCRIPTION
## Summary

Adds the public `clickwork.testing` module promised in the Wave 4 plan. Two thin wrappers so plugin test suites can stop re-typing the same 4-line CliRunner setup:

- **`run_cli(cli, args, **kwargs)`** — wraps `CliRunner().invoke()` with `catch_exceptions=False` pinned by default so bugs inside commands surface as real pytest tracebacks instead of being swallowed into `result.exception`.
- **`make_test_cli(*, commands_dir=None, **create_cli_kwargs)`** — wraps `create_cli()` with a default `name="test-cli"`. Every other kwarg forwards unchanged.

Both return Click's native types (`click.testing.Result` / `click.Group`) so copy-pasted Click idioms keep working. `click.testing` is imported lazily inside `run_cli`.

## Docs

- **GUIDE.md**: new "Testing commands with `clickwork.testing`" subsection with a stream-attribute comparison table and a callout about the removed `CliRunner(mix_stderr=False)` kwarg.
- **LLM_REFERENCE.md**: short paragraph in the existing Testing Commands section pointing at the helpers and GUIDE.
- **`src/clickwork/__init__.py`**: re-exports `testing` alongside `http` / `platform`.

## Out of scope (follow-ups per plan)

`mock_run` / `mock_capture` / `patch_require` helpers. Captured in the plan.

## Test plan

- [x] 9 new tests in `tests/unit/test_testing.py` covering the 6 plan criteria + 3 surface tests (explicit name override, both import paths)
- [x] 257 total pass, zero warnings under `filterwarnings = ["error"]`
- [x] Red-first confirmed (9 failing → 9 passing after implementation)

Refs plan: \`docs/plans/2026-04-17-wave-4-docs.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)