### PR TITLE
docs: Common Footguns section in LLM_REFERENCE (Fixes #17)

### DIFF
--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -185,9 +185,9 @@ Why. Link out to helper docstrings or [GUIDE.md](GUIDE.md) for depth.
 
 ### 1. Patching `ctx.require`
 
-**Pitfall:** patching `clickwork.cli._require` (old workaround).
+**Pitfall:** patching a private `clickwork.cli` helper to fake out prereq checks.
 **Instead:** `patch("clickwork.prereqs.require")`.
-**Why:** Wave 1 #8 made the public symbol patchable; the internal alias was removed.
+**Why:** `CliContext.require` routes through `clickwork.cli._require_via_prereqs`, which dispatches to `clickwork.prereqs.require` at call time. Patch the public prereqs function so your mock intercepts the actual lookup, not a stale internal alias.
 
 ### 2. Signalling user errors
 
@@ -199,7 +199,7 @@ Why. Link out to helper docstrings or [GUIDE.md](GUIDE.md) for depth.
 
 **Pitfall:** asserting on `result.output` when you specifically want stdout-only or stderr-only content (`result.output` interleaves BOTH streams).
 **Instead:** assert on `result.stdout` or `result.stderr` directly.
-**Why:** on current Click (8.2+) `output` is stdout+stderr combined; the older `mix_stderr` kwarg that some online snippets reference has been removed. See [GUIDE.md](GUIDE.md#testing-commands-with-clickworktesting) (anchor resolves once #16 merges first -- see plan's merge-order note).
+**Why:** on current Click (8.2+) `result.output` is stdout+stderr combined while `result.stdout` and `result.stderr` are populated independently; the older `CliRunner(mix_stderr=False)` kwarg referenced in some online snippets has been removed. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`" (lands on main via #16).
 
 ### 4. URL-encoding query params
 
@@ -209,7 +209,7 @@ Why. Link out to helper docstrings or [GUIDE.md](GUIDE.md) for depth.
 
 ### 5. Secrets in argv
 
-**Pitfall:** `ctx.run(["wrangler", "secret", "put", name, Secret(token)])`.
+**Pitfall:** `ctx.run(["wrangler", "secret", "put", name, token.get()])`.
 **Instead:** `ctx.run_with_secrets(...)` (Wave 3 #11).
 **Why:** argv is world-readable in `ps`; the helper enforces this and routes via env/stdin.
 

--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -199,7 +199,7 @@ Why. Link out to helper docstrings or [GUIDE.md](GUIDE.md) for depth.
 
 **Pitfall:** asserting on `result.output` when you specifically want stdout-only or stderr-only content (`result.output` interleaves BOTH streams).
 **Instead:** assert on `result.stdout` or `result.stderr` directly.
-**Why:** on current Click (8.2+) `result.output` is stdout+stderr combined while `result.stdout` and `result.stderr` are populated independently; the older `CliRunner(mix_stderr=False)` kwarg referenced in some online snippets has been removed. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`" (lands on main via #16).
+**Why:** clickwork declares `click>=8.2`, where `result.output` is stdout+stderr combined while `result.stdout` and `result.stderr` are populated independently. The older `CliRunner(mix_stderr=False)` kwarg referenced in some online snippets was removed in 8.2 -- don't copy those. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`" (lands on main via #16).
 
 ### 4. URL-encoding query params
 

--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -199,7 +199,7 @@ Why. Link out to helper docstrings or [GUIDE.md](GUIDE.md) for depth.
 
 **Pitfall:** asserting on `result.output` when you specifically want stdout-only or stderr-only content (`result.output` interleaves BOTH streams).
 **Instead:** assert on `result.stdout` or `result.stderr` directly.
-**Why:** clickwork declares `click>=8.2`, where `result.output` is stdout+stderr combined while `result.stdout` and `result.stderr` are populated independently. The older `CliRunner(mix_stderr=False)` kwarg referenced in some online snippets was removed in 8.2 -- don't copy those. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`" (lands on main via #16).
+**Why:** on Click 8.2+ (removed the `mix_stderr` kwarg) `result.output` is stdout+stderr combined while `result.stdout` and `result.stderr` are populated independently. On 8.1 `result.stderr` raises `ValueError: stderr not separately captured` unless `CliRunner(mix_stderr=False)` was passed; the pinned clickwork environment is on 8.2+ but the declared floor is `click>=8.1`, so if your tests run on 8.1 use the `mix_stderr=False` form of the runner instead. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`".
 
 ### 4. URL-encoding query params
 

--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -178,6 +178,77 @@ def tool(ctx: CliContext, args: tuple):
     ctx.run([*base_cmd, *args])
 ```
 
+## Common Footguns
+
+Quick hits for "why is my thing broken?" Each entry is Pitfall / Instead /
+Why. Link out to helper docstrings or [GUIDE.md](GUIDE.md) for depth.
+
+### 1. Patching `ctx.require`
+
+**Pitfall:** patching `clickwork.cli._require` (old workaround).
+**Instead:** `patch("clickwork.prereqs.require")`.
+**Why:** Wave 1 #8 made the public symbol patchable; the internal alias was removed.
+
+### 2. Signalling user errors
+
+**Pitfall:** `sys.exit(1)` with manual `click.echo`.
+**Instead:** `raise click.ClickException("message")`.
+**Why:** Wave 1 #5 made `ClickException` route correctly; ad-hoc exits bypass that.
+
+### 3. CliRunner mixed output
+
+**Pitfall:** asserting on `result.output` when you specifically want stdout-only or stderr-only content (`result.output` interleaves BOTH streams).
+**Instead:** assert on `result.stdout` or `result.stderr` directly.
+**Why:** on current Click (8.2+) `output` is stdout+stderr combined; the older `mix_stderr` kwarg that some online snippets reference has been removed. See [GUIDE.md](GUIDE.md#testing-commands-with-clickworktesting) (anchor resolves once #16 merges first -- see plan's merge-order note).
+
+### 4. URL-encoding query params
+
+**Pitfall:** string-concatenating user values into URL query strings.
+**Instead:** build params as a dict and use `urllib.parse.urlencode`.
+**Why:** spaces, `&`, `#` in user values silently break URLs or enable injection.
+
+### 5. Secrets in argv
+
+**Pitfall:** `ctx.run(["wrangler", "secret", "put", name, Secret(token)])`.
+**Instead:** `ctx.run_with_secrets(...)` (Wave 3 #11).
+**Why:** argv is world-readable in `ps`; the helper enforces this and routes via env/stdin.
+
+### 6. Shell-sourceable config files
+
+**Pitfall:** hand-rolling a `.env` parser.
+**Instead:** `clickwork.config.load_env_file(path)` (Wave 2 #9).
+**Why:** parser gotchas are solved once; the helper also enforces owner-only permissions.
+
+### 7. Platform dispatch
+
+**Pitfall:** repeating `if sys.platform == "linux": ... elif sys.platform == "win32": ...`.
+**Instead:** `@clickwork.platform_dispatch(linux=..., windows=..., macos=...)` (Wave 2 #12).
+**Why:** the helper handles "unsupported platform" errors consistently.
+
+### 8. HTTP calls
+
+**Pitfall:** building a `urllib.request` helper in each command, or adding `requests`.
+**Instead:** `clickwork.http.get/post/put/delete` (Wave 3 #13).
+**Why:** stdlib-only helper with URL allowlist, JSON auto-parse, structured `HttpError`. See `clickwork.http` docstring.
+
+### 9. Missing `import sys`
+
+**Pitfall:** calling `sys.exit()` or `sys.stdin` without importing.
+**Instead:** explicit `import sys`.
+**Why:** easy to forget; `sys` is not a builtin.
+
+### 10. `bash -c`
+
+**Pitfall:** `ctx.run(["bash", "-c", "command $VAR"])`.
+**Instead:** use Python stdlib directly, or `ctx.run(["command"], env={...})`.
+**Why:** `bash -c` opens a shell-injection vector if any part of the command string is user-influenced, and creates a cross-platform dependency on `bash`.
+
+### 11. `Secret.get()` at module scope
+
+**Pitfall:** `TOKEN = Secret(...).get()` at module import.
+**Instead:** call `.get()` at the call site when you actually need the value.
+**Why:** module-scope unwrap defeats the "value stays wrapped until used" invariant.
+
 ## Lessons Learned
 
 _This section is updated as we migrate commands and discover patterns._


### PR DESCRIPTION
## Summary

Adds a top-level "Common Footguns" section to \`docs/LLM_REFERENCE.md\` — 11 entries, each 3 lines (Pitfall / Instead / Why), for quick "why is my thing broken?" lookups.

## Entries

1. Patching \`ctx.require\` (Wave 1 #8)
2. Signalling user errors via \`ClickException\` (Wave 1 #5)
3. CliRunner mixed output (interleaved \`result.output\`)
4. URL-encoding query params (\`urllib.parse.urlencode\`)
5. Secrets in argv → \`ctx.run_with_secrets\` (Wave 3 #11)
6. Shell-sourceable config → \`clickwork.config.load_env_file\` (Wave 2 #9)
7. Platform dispatch → \`@clickwork.platform_dispatch\` (Wave 2 #12)
8. HTTP calls → \`clickwork.http.get/post/put/delete\` (Wave 3 #13)
9. Missing \`import sys\`
10. \`bash -c\` shell-injection risk
11. \`Secret.get()\` at module scope

## Merge order

**This PR must merge AFTER #16.** Entry 3 cross-references the "Testing commands with \`clickwork.testing\`" subsection that #16 adds to GUIDE.md. If #17 merges first, the anchor briefly points at a section that doesn't exist on main yet. See plan note.

## Test plan

- [x] Docs only, no tests (none required)
- [x] All 11 helper paths verified against the live codebase before writing
- [x] No other file touched — avoids conflict with #16's concurrent edit to LLM_REFERENCE.md (different section)

Refs plan: \`docs/plans/2026-04-17-wave-4-docs.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)