### PR TITLE
deps: raise click floor to >=8.2

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -532,8 +532,10 @@ assert "normal line" in result.stderr         # NO -- would fail
 > interleaved form. clickwork declares `click>=8.2` so this guidance
 > always applies: snippets in older tutorials that use
 > `CliRunner(mix_stderr=False)` will raise `TypeError`, and the
-> `result.stderr` advice above cannot fall back to Click 8.1 where
-> it would have raised `ValueError: stderr not separately captured`.
+> `result.stderr` advice above cannot fall back to Click 8.1 where,
+> under the default `CliRunner()` configuration (streams mixed unless
+> `mix_stderr=False` was passed), it would have raised
+> `ValueError: stderr not separately captured`.
 
 ### Unit Testing with CliRunner
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -529,11 +529,11 @@ assert "normal line" in result.stderr         # NO -- would fail
 > `CliRunner.__init__` that used to toggle whether stderr was folded
 > into `output`. Post-removal, `result.stdout` / `result.stderr` are
 > populated independently and `result.output` keeps providing the
-> interleaved form. clickwork declares `click>=8.1`, so in principle
-> a consumer could still be on 8.1 where the kwarg works. If you
-> are reading an older snippet that uses `CliRunner(mix_stderr=False)`,
-> check the Click version in your test environment: 8.2+ will raise
-> `TypeError`; older releases still accept it.
+> interleaved form. clickwork declares `click>=8.2` so this guidance
+> always applies: snippets in older tutorials that use
+> `CliRunner(mix_stderr=False)` will raise `TypeError`, and the
+> `result.stderr` advice above cannot fall back to Click 8.1 where
+> it would have raised `ValueError: stderr not separately captured`.
 
 ### Unit Testing with CliRunner
 

--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -202,7 +202,7 @@ Why. Link out to helper docstrings or [GUIDE.md](GUIDE.md) for depth.
 
 **Pitfall:** asserting on `result.output` when you specifically want stdout-only or stderr-only content (`result.output` interleaves BOTH streams).
 **Instead:** assert on `result.stdout` or `result.stderr` directly.
-**Why:** on Click 8.2+ (removed the `mix_stderr` kwarg) `result.output` is stdout+stderr combined while `result.stdout` and `result.stderr` are populated independently. On 8.1 `result.stderr` raises `ValueError: stderr not separately captured` unless `CliRunner(mix_stderr=False)` was passed; the pinned clickwork environment is on 8.2+ but the declared floor is `click>=8.1`, so if your tests run on 8.1 use the `mix_stderr=False` form of the runner instead. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`".
+**Why:** clickwork declares `click>=8.2`, where `result.output` is stdout+stderr combined while `result.stdout` and `result.stderr` are populated independently. The older `CliRunner(mix_stderr=False)` kwarg referenced in some online snippets was removed in 8.2 -- don't copy those. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`".
 
 ### 4. URL-encoding query params
 

--- a/docs/LLM_REFERENCE.md
+++ b/docs/LLM_REFERENCE.md
@@ -202,7 +202,7 @@ Why. Link out to helper docstrings or [GUIDE.md](GUIDE.md) for depth.
 
 **Pitfall:** asserting on `result.output` when you specifically want stdout-only or stderr-only content (`result.output` interleaves BOTH streams).
 **Instead:** assert on `result.stdout` or `result.stderr` directly.
-**Why:** clickwork declares `click>=8.2`, where `result.output` is stdout+stderr combined while `result.stdout` and `result.stderr` are populated independently. The older `CliRunner(mix_stderr=False)` kwarg referenced in some online snippets was removed in 8.2 -- don't copy those. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`".
+**Why:** clickwork declares `click>=8.2`, where `result.output` is stdout+stderr interleaved while `result.stdout` and `result.stderr` are populated independently. The older `CliRunner(mix_stderr=False)` kwarg referenced in some online snippets was removed in 8.2 -- don't copy those. See [GUIDE.md](GUIDE.md) "Testing commands with `clickwork.testing`".
 
 ### 4. URL-encoding query params
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}
 dependencies = [
-    "click>=8.1",
+    "click>=8.2",
 ]
 
 [project.optional-dependencies]

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -52,7 +52,7 @@ from typing import Any
 
 import click
 # NOTE on the click.core import: at the project's declared minimum
-# Click version (``click>=8.1`` per pyproject.toml) ``ParameterSource``
+# Click version (``click>=8.2`` per pyproject.toml) ``ParameterSource``
 # lives at ``click.core.ParameterSource`` and is NOT re-exported to
 # top-level. ``click.ParameterSource`` raises AttributeError on every
 # Click 8.x release currently shipping (verified on 8.3.2, which is

--- a/src/clickwork/testing.py
+++ b/src/clickwork/testing.py
@@ -76,9 +76,10 @@ clickwork declares ``click>=8.2`` precisely so this guidance always
 applies -- snippets in older tutorials that use
 ``CliRunner(mix_stderr=False)`` will raise ``TypeError`` against the
 supported Click range, and on 8.1 and earlier ``result.stderr`` would
-have raised ``ValueError: stderr not separately captured`` which is
-why we floor the dependency at 8.2 rather than documenting a
-conditional behaviour.
+have raised ``ValueError: stderr not separately captured`` under the
+default ``CliRunner()`` configuration (where streams were mixed unless
+``mix_stderr=False`` was passed explicitly). Flooring at 8.2 gets us
+out of documenting that conditional behaviour.
 """
 from __future__ import annotations
 

--- a/src/clickwork/testing.py
+++ b/src/clickwork/testing.py
@@ -72,12 +72,13 @@ Historical note: Click 8.2 removed the ``mix_stderr`` kwarg that
 ``CliRunner.__init__`` used to accept. Post-removal, all three stream
 attributes on ``Result`` are populated separately (``output`` is the
 interleaved form; ``stdout`` and ``stderr`` are kept independent).
-clickwork declares ``click>=8.1`` so in principle a consumer could be
-running on 8.1 where ``mix_stderr`` still exists. If you are looking
-at an older snippet that uses ``CliRunner(mix_stderr=False)``, check
-the Click version in your test environment rather than assuming the
-8.2+ API: 8.2+ will raise ``TypeError``; older releases still accept
-the kwarg.
+clickwork declares ``click>=8.2`` precisely so this guidance always
+applies -- snippets in older tutorials that use
+``CliRunner(mix_stderr=False)`` will raise ``TypeError`` against the
+supported Click range, and on 8.1 and earlier ``result.stderr`` would
+have raised ``ValueError: stderr not separately captured`` which is
+why we floor the dependency at 8.2 rather than documenting a
+conditional behaviour.
 """
 from __future__ import annotations
 

--- a/tests/fixtures/sample-plugin/pyproject.toml
+++ b/tests/fixtures/sample-plugin/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Sample plugin for clickwork -- test fixture and reference implementation"
 requires-python = ">=3.11"
 dependencies = [
-    "click>=8.1",
+    "click>=8.2",
     "clickwork",
 ]
 


### PR DESCRIPTION
## Summary

Raises the Click dependency floor from \`>=8.1\` to \`>=8.2\` so the canonical testing guidance shipped in #31 (testing helpers) and #32 (Common Footguns) applies uniformly to every supported install. Follow-up to the cross-PR review on #32.

## Why

On Click 8.1.x, \`CliRunner()\` defaults \`mix_stderr=True\`, which means:
- \`result.stderr\` raises \`ValueError: stderr not separately captured\`
- \`result.output\` and \`result.stdout\` both return the mixed stream

The Wave 4 docs advise "assert on \`result.stdout\` or \`result.stderr\` directly" as canonical guidance. On 8.1.x that advice literally crashes — forcing every doc entry to carry an 8.1-specific escape hatch. Bumping the floor to 8.2 (where \`mix_stderr\` was removed and the three attributes are populated independently) lets the canonical guidance stand on its own.

## Compatibility

- The pinned environment (\`uv.lock\`) is already on \`click==8.3.2\`
- clickwork is pre-1.0 with only 0.1.0 installed anywhere (by the maintainer)
- No lock regeneration required — existing pin satisfies \`>=8.2\`

## Net changes (4 files)

- \`pyproject.toml\`: \`click>=8.1\` → \`click>=8.2\`
- \`src/clickwork/testing.py\`: dropped the "consumer could be running on 8.1" hedge from the module docstring; replaced with a short "why we floor at 8.2" rationale pinned inline
- \`docs/GUIDE.md\`: same simplification in the "Testing commands" footgun callout
- \`docs/LLM_REFERENCE.md\`: Entry 3 (CliRunner mixed output) loses the 8.1 escape-hatch prose and directly references the \`click>=8.2\` declaration

## Test plan

- [x] \`mise exec -- python -m pytest tests/\` → 257 passed, zero warnings
- [x] Verified on Click 8.2.1 that \`result.stderr\` is populated independently (empirically, on the pinned runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)