### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to clickwork will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-04-18
+
+A broad expansion of the framework, closing 12 issues (#4-#17). Major
+new modules: `clickwork.http`, `clickwork.platform`, `clickwork.testing`.
+New helpers on `CliContext`: `run_with_secrets`, stdin forwarding. New
+public API for docs-level CLIs: `add_global_option`. New dotenv helper:
+`clickwork.config.load_env_file`. Plus docs: LLM_REFERENCE "Common
+Footguns" section and GUIDE "Testing commands" subsection.
+
+### Added
+
+- `clickwork.http` — stdlib-only HTTP client with URL allowlist,
+  no-redirect security, JSON auto-parse, and structured `HttpError`.
+  `get` / `post` / `put` / `delete` helpers, host allowlist enforced
+  before any network activity, userinfo/query/fragment stripped from
+  all log lines and exception messages. (#13)
+- `clickwork.platform` — `@platform_dispatch(linux=, windows=, macos=)`
+  decorator and `dispatch(ctx, linux=, ...)` helper so commands that
+  behave differently per OS stop repeating `if sys.platform == ...`
+  chains. (#12)
+- `clickwork.testing` — `run_cli()` + `make_test_cli()` helpers for
+  plugin test suites. `run_cli` pins `catch_exceptions=False` so bugs
+  surface as real pytest tracebacks instead of being swallowed;
+  `make_test_cli` wraps `create_cli` with a sensible default name.
+  (#16)
+- `clickwork.add_global_option()` — installs a Click option at the
+  root CLI and every nested group/subcommand in one call, with
+  OR-semantics for boolean flags and innermost-wins for value
+  options. (#14)
+- `clickwork.config.load_env_file(path)` — owner-only-permissions
+  dotenv parser, no variable substitution, no shell interpretation.
+  (#9)
+- `CliContext.run_with_secrets(cmd, secrets=, stdin_secret=, ...)` —
+  safe subprocess secret delivery via env or stdin, never argv. Type
+  checks + validation ensure `Secret` objects can't leak into argv or
+  logs. (#11)
+- `ctx.run()` now accepts `stdin_text=` / `stdin_bytes=` kwargs while
+  preserving SIGINT forwarding. (#10)
+- `create_cli()` now accepts `enable_parent_package_imports=True` to
+  opt into importing commands as relative to a parent package. (#15)
+- LLM_REFERENCE.md — new "Common Footguns" section (11 entries:
+  patching prereqs, `ClickException` routing, CliRunner streams,
+  URL-encoding, secrets-in-argv, `.env` parsing, platform dispatch,
+  HTTP calls, `import sys`, `bash -c` risk, module-scope
+  `Secret.get()`). (#17)
+- GUIDE.md — new "Testing commands with `clickwork.testing`"
+  subsection covering the new helpers and `result.output` /
+  `.stdout` / `.stderr` semantics on Click 8.2+.
+- CHANGELOG.md (this file).
+
+### Changed
+
+- **Breaking: raised `click` dependency floor from `>=8.1` to
+  `>=8.2`.** On Click 8.1 a default `CliRunner()` mixed streams,
+  causing `result.stderr` to raise `ValueError: stderr not separately
+  captured`. 0.2.0's testing guidance ("assert on `result.stdout` /
+  `result.stderr` directly") crashes on 8.1 with the default runner.
+  Flooring at 8.2 -- where `mix_stderr` was removed and the three
+  stream attributes are populated independently -- makes the
+  canonical guidance always applicable. (#33)
+- `ctx.require` is now patchable via
+  `patch("clickwork.prereqs.require")` — the internal
+  `clickwork.cli._require` alias was removed, so tests that targeted
+  it must update the patch path. (#8)
+- `CliException` subclasses now re-raise correctly instead of being
+  swallowed, so user errors exit with the intended non-zero code.
+  (#5)
+
+### Fixed
+
+- `--help` text no longer leaks the full docstring when a `description`
+  is passed to `create_cli`. (#4)
+
+### Security
+
+- `clickwork.http` refuses to follow redirects (a custom
+  `HTTPRedirectHandler` raises on 3xx so callers control any redirect
+  themselves). Prevents cross-host credential forwarding via
+  `Authorization`, and prevents allowlist bypass via `Location`
+  header. (#13)
+- `clickwork.http` sanitizes URLs in every log line and every
+  `HttpError.url` / message by stripping userinfo, query, and
+  fragment. URLs with malformed ports or missing hostnames are
+  rejected with clean `ValueError` messages that never echo the raw
+  URL back into an exception. (#13, #29)
+- `load_env_file` rejects any file not owner-only via a TOCTOU-safe
+  `os.fstat` check on the already-opened file descriptor. (#9)
+- `run_with_secrets` refuses to place `Secret` objects in argv, and
+  redacts all env values (secret-sourced as `<redacted>`, other env
+  entries as `<set>`) from the single INFO-level log line. (#11)
+
+[0.2.0]: https://github.com/qubitrenegade/clickwork/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/qubitrenegade/clickwork/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-18
 
-A broad expansion of the framework, closing 12 issues (#4-#17). Major
-new modules: `clickwork.http`, `clickwork.platform`, `clickwork.testing`.
+A broad expansion of the framework closing 12 issues (#4-#17), plus one
+PR-only follow-up (#33) that raised the `click` dependency floor during
+release prep. Numbers in parens on each entry below are **issue
+numbers**, except where explicitly noted as `(PR #NN)`. Major new
+modules: `clickwork.http`, `clickwork.platform`, `clickwork.testing`.
 New helpers on `CliContext`: `run_with_secrets`, stdin forwarding. New
 public API for docs-level CLIs: `add_global_option`. New dotenv helper:
 `clickwork.config.load_env_file`. Plus docs: LLM_REFERENCE "Common
@@ -64,14 +67,14 @@ Footguns" section and GUIDE "Testing commands" subsection.
   `result.stderr` directly") crashes on 8.1 with the default runner.
   Flooring at 8.2 -- where `mix_stderr` was removed and the three
   stream attributes are populated independently -- makes the
-  canonical guidance always applicable. (#33)
+  canonical guidance always applicable. (PR #33)
 - `ctx.require` is now patchable via
   `patch("clickwork.prereqs.require")` — the internal
   `clickwork.cli._require` alias was removed, so tests that targeted
   it must update the patch path. (#8)
-- `CliException` subclasses now re-raise correctly instead of being
-  swallowed, so user errors exit with the intended non-zero code.
-  (#5)
+- `click.exceptions.ClickException` subclasses now re-raise correctly
+  instead of being swallowed, so user errors exit with the intended
+  non-zero code. (#5)
 
 ### Fixed
 
@@ -89,7 +92,8 @@ Footguns" section and GUIDE "Testing commands" subsection.
   `HttpError.url` / message by stripping userinfo, query, and
   fragment. URLs with malformed ports or missing hostnames are
   rejected with clean `ValueError` messages that never echo the raw
-  URL back into an exception. (#13, #29)
+  URL back into an exception. (#13; security hardening landed in PR
+  #29 during the Copilot review loop.)
 - `load_env_file` rejects any file not owner-only via a TOCTOU-safe
   `os.fstat` check on the already-opened file descriptor. (#9)
 - `run_with_secrets` refuses to place `Secret` objects in argv, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2026-04-18
 
 A broad expansion of the framework closing 12 issues (#4-#17), plus one
-PR-only follow-up (#33) that raised the `click` dependency floor during
+PR-only follow-up (PR #33) that raised the `click` dependency floor during
 release prep. Numbers in parens on each entry below are **issue
 numbers**, except where explicitly noted as `(PR #NN)`. Major new
 modules: `clickwork.http`, `clickwork.platform`, `clickwork.testing`.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ utilities -- so your commands focus on business logic, not boilerplate.
 ## Installation
 
 ```bash
-# Pin to a tag or SHA for reproducibility
-uv pip install "git+https://github.com/qubitrenegade/clickwork.git@v0.1.0"
+# From PyPI (preferred)
+uv pip install "clickwork==0.2.0"
+# or, pinning to a git tag if you need a ref PyPI doesn't expose
+uv pip install "git+https://github.com/qubitrenegade/clickwork.git@v0.2.0"
 ```
 
 For local development alongside a consumer project:

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -26,7 +26,10 @@ clickwork gives you the scaffolding. You write the commands.
 ## Installation
 
 ```bash
-uv pip install "git+https://github.com/qubitrenegade/clickwork.git@v0.1.0"
+# From PyPI (preferred)
+uv pip install "clickwork==0.2.0"
+# or, pinning to a git tag if you need a ref PyPI doesn't expose
+uv pip install "git+https://github.com/qubitrenegade/clickwork.git@v0.2.0"
 ```
 
 For local development alongside your project:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickwork"
-version = "0.1.0"
+version = "0.2.0"
 description = "Reusable CLI framework for project automation"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/clickwork/__init__.py
+++ b/src/clickwork/__init__.py
@@ -21,7 +21,7 @@ Public API:
     testing           - Submodule exposing run_cli() + make_test_cli() helpers
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # WHY ``testing`` is imported here alongside ``http`` / ``platform``: all
 # three are advertised as importable both as ``clickwork.<name>`` and as

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ wheels = [
 
 [[package]]
 name = "clickwork"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -30,7 +30,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.1" },
+    { name = "click", specifier = ">=8.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12" },
 ]


### PR DESCRIPTION
## Summary

Version bump to 0.2.0 and a new CHANGELOG. Closes 12 issues (#4-#17) since 0.1.0.

## Highlights

- **New modules**: \`clickwork.http\` (allowlisted stdlib HTTP client), \`clickwork.platform\` (per-OS dispatch), \`clickwork.testing\` (CliRunner helpers)
- **New CliContext method**: \`run_with_secrets\` — safe subprocess secret delivery via env / stdin, never argv
- **New utilities**: \`add_global_option\`, \`clickwork.config.load_env_file\`, \`ctx.run\` stdin forwarding, \`create_cli(enable_parent_package_imports=...)\`
- **New docs**: GUIDE.md "Testing commands" subsection, LLM_REFERENCE.md "Common Footguns" section (11 entries)

## Breaking changes

- \`click\` dependency floor raised from \`>=8.1\` to \`>=8.2\` (see CHANGELOG.md \"Changed\" for why)
- \`ctx.require\` internal alias removed; patch \`clickwork.prereqs.require\` instead

## Security

See the \"Security\" subsection in CHANGELOG.md for the full set — no-redirect HTTP client, URL credential sanitization, TOCTOU-safe owner-only \`.env\` checks, secret redaction in subprocess logs.

## Release procedure

After merge:
1. Tag \`v0.2.0\` on the merge commit
2. Create a GitHub Release on that tag — triggers \`.github/workflows/publish.yml\` (PyPI publish via trusted-publisher OIDC)
3. Verify \`pip install clickwork==0.2.0\` resolves on PyPI

## Test plan

- [x] \`mise exec -- python -m pytest tests/\` → 257 passed, zero warnings
- [x] \`pyproject.toml\` and \`src/clickwork/__init__.py\` both pinned to \`0.2.0\`
- [x] CHANGELOG links point at correct compare ranges (\`v0.1.0...v0.2.0\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)