### PR TITLE
docs: 1.0 release roadmap spec (tracker #45)

### DIFF
--- a/docs/superpowers/specs/2026-04-18-clickwork-1.0-roadmap.md
+++ b/docs/superpowers/specs/2026-04-18-clickwork-1.0-roadmap.md
@@ -119,7 +119,7 @@ Everything downstream references the decisions made in this wave. Merge the whol
 - Floor: `requires-python = ">=3.11"` (matches pyproject today).
 - Rationale: 3.11 is the oldest still-supported CPython that has PEP 654 exception groups, structured `tomllib`, PEP 673 `Self`, and the typing improvements we rely on. 3.10 lacks all four.
 - Ceiling: none. New Python releases get smoke-tested on CI's matrix.
-- Deprecation runway: we drop a Python minor no earlier than 18 months after CPython EOL's it. Concretely: 3.11 EOL is 2027-10 → earliest drop is 2029-04. Callers get ≥2 clickwork minor releases of warning.
+- Deprecation runway: we drop a Python minor no earlier than 18 months after CPython reaches EOL for it. Concretely: 3.11 EOL is 2027-10 → earliest drop is 2029-04. Callers get ≥2 clickwork minor releases of warning.
 
 ---
 
@@ -132,9 +132,9 @@ Largest wave by PR count. Two sub-groups, each dispatchable mostly-in-parallel.
 | Issue | Scope | BREAKING? |
 |-------|-------|-----------|
 | [#37 `py.typed`](https://github.com/qubitrenegade/clickwork/issues/37) | Add `src/clickwork/py.typed` marker file; include in wheel; `Typing :: Typed` classifier assumed present from #35. | No |
-| [#41 config env-var types](https://github.com/qubitrenegade/clickwork/issues/41) | Lock the behaviour: env-var values always arrive as strings; schema is responsible for coercion. Document in `docs/config.md` (or inline in `clickwork.config`). Adds test coverage. | Possibly — see PR body |
+| [#41 config env-var types](https://github.com/qubitrenegade/clickwork/issues/41) | Lock the behavior: env-var values always arrive as strings; schema is responsible for coercion. Document in `docs/GUIDE.md` (or inline in `clickwork.config`). Adds test coverage. | Possibly — see PR body |
 | [#42 strict discovery validation](https://github.com/qubitrenegade/clickwork/issues/42) | Add `strict=True` kwarg to `create_cli()` / discovery. When set, a discovery failure (broken import, missing `cli` attribute, flag collision) raises immediately at CLI startup instead of silently dropping the command. Default stays `False` for 1.0 compat. | No (opt-in) |
-| [#43 logger propagation](https://github.com/qubitrenegade/clickwork/issues/43) | `clickwork` loggers no longer attach their own handler when the root logger already has one. Uses `propagate=True` + `NullHandler` fallback. Tested against `logging.basicConfig()` + a no-setup host. | **Yes** — silent behaviour change for embedded consumers |
+| [#43 logger propagation](https://github.com/qubitrenegade/clickwork/issues/43) | `clickwork` loggers no longer attach their own handler when the root logger already has one. Uses `propagate=True` + `NullHandler` fallback. Tested against `logging.basicConfig()` + a no-setup host. | **Yes** — silent behavior change for embedded consumers |
 | [#47 deprecation mechanism](https://github.com/qubitrenegade/clickwork/issues/47) | New `clickwork._deprecated.deprecated(since, removed_in, reason)` decorator. Emits `DeprecationWarning` at first call. Used by later waves when we want deprecation shims. | No |
 | [#48 `--version` flag](https://github.com/qubitrenegade/clickwork/issues/48) | `create_cli()` gains `version=` kwarg (defaults to the consumer's `__version__` if derivable, else required). Adds `--version` via `click.version_option`. | No |
 
@@ -163,11 +163,11 @@ All five are independent. Dispatch together.
 |-------|-------|
 | [#50 SIGINT coverage](https://github.com/qubitrenegade/clickwork/issues/50) | Real signal-forwarding tests: spawn a subprocess that installs a SIGINT handler, send `SIGINT` to `ctx.run`, assert the child saw it and the elapsed time is under the forward timeout. Plus SIGKILL escalation after the `--timeout` window. Linux + macOS only — Windows signal semantics differ enough that the test is marked skipped there. |
 | [#51 mixed discovery local-wins](https://github.com/qubitrenegade/clickwork/issues/51) | Integration test: install a sample plugin via an entry point, put a same-named command file in the commands dir, assert the local one wins, assert the installed one is still callable via a fully-qualified invocation path if we support one (decide in PR). |
-| [#52 in-file config precedence](https://github.com/qubitrenegade/clickwork/issues/52) | Test that `[env.staging]` overrides `[default]` within the same file. Lock the behaviour; document it in `docs/config.md` (part of #54's output). |
+| [#52 in-file config precedence](https://github.com/qubitrenegade/clickwork/issues/52) | Test that `[env.staging]` overrides `[default]` within the same file. Lock the behavior; document it in `docs/GUIDE.md` (part of #54's output). |
 | **#60a** `setup_logging` re-invocation | Part of #60. Calling `setup_logging(level="DEBUG")` twice shouldn't double-attach handlers. Use a module-level flag keyed by logger name. PR title: `fix: setup_logging is idempotent (part of #60)`. |
 | **#60b** `add_global_option` override semantics | Part of #60. When a plugin's subcommand defines an option with the same name as a global option, the subcommand's definition wins inside that subcommand's scope. Document + test. PR title: `feat: add_global_option override semantics (part of #60)`. |
 
-#60 closes when 3a + 3b land. **#60c** (sigstore) is out of scope for 1.0 → [#61](https://github.com/qubitrenegade/clickwork/issues/61).
+#60 closes when #60a + #60b land. **#60c** (sigstore) is out of scope for 1.0 → [#61](https://github.com/qubitrenegade/clickwork/issues/61).
 
 ---
 
@@ -178,12 +178,12 @@ All five produce new files in `docs/`, fully independent.
 | Issue | Deliverable | Depends on |
 |-------|-------------|------------|
 | [#53 plugin authoring guide](https://github.com/qubitrenegade/clickwork/issues/53) | `docs/PLUGINS.md` — minimal plugin walkthrough, entry-point wiring, testing with `clickwork.testing`, packaging, publishing. | #35 (classifier list), #36 (public API), #47 (deprecation), #48 (--version) |
-| [#54 config precedence table](https://github.com/qubitrenegade/clickwork/issues/54) | Replace the prose in `docs/GUIDE.md`'s config section with an explicit precedence table; cross-ref from `docs/API_POLICY.md`. | #52 test results (locks the behaviour) |
-| [#55 security + threat model](https://github.com/qubitrenegade/clickwork/issues/55) | `docs/SECURITY.md` — subprocess secret handling, URL allowlist, redirect policy, env-file permissions, what we do/don't defend against. | Wave 2 code behaviour is in main |
+| [#54 config precedence table](https://github.com/qubitrenegade/clickwork/issues/54) | Replace the prose in `docs/GUIDE.md`'s config section with an explicit precedence table; cross-ref from `docs/API_POLICY.md`. | #52 test results (locks the behavior) |
+| [#55 security + threat model](https://github.com/qubitrenegade/clickwork/issues/55) | `docs/SECURITY.md` — subprocess secret handling, URL allowlist, redirect policy, env-file permissions, what we do/don't defend against. | Wave 2 code behavior is in main |
 | [#56 0.x → 1.0 migration guide](https://github.com/qubitrenegade/clickwork/issues/56) | `docs/MIGRATING.md` — every breaking change from Wave 2 (#43 especially), every new public API, deprecation shims. | Wave 2 fully merged |
 | [#58 `CONTRIBUTING.md`](https://github.com/qubitrenegade/clickwork/issues/58) | Dev setup (`uv sync`), test command, lint command, PR conventions, code review expectations. | #38 (lint command), #59 (bench command) |
 
-All five can start as soon as Wave 2 merges. #55 and #56 reference Wave 2 behaviour and must not speculate about unmerged changes.
+All five can start as soon as Wave 2 merges. #55 and #56 reference Wave 2 behavior and must not speculate about unmerged changes.
 
 ---
 
@@ -191,7 +191,9 @@ All five can start as soon as Wave 2 merges. #55 and #56 reference Wave 2 behavi
 
 ### [#44 — Validate against `orbit-admin`](https://github.com/qubitrenegade/clickwork/issues/44)
 
-**Deliverable:** a `feat/clickwork-1.0` branch on `qbrd-orbit-widener` that installs the 1.0 release candidate (a git SHA on `main`) and runs the full `tests/tools/` suite. PR body documents any breakage + fix.
+**Deliverable:** a `feat/clickwork-1.0` branch on `qbrd-orbit-widener` that installs the 1.0 release candidate (a git SHA on clickwork's `main`) and runs the full `tests/tools/` suite. PR body documents any breakage + fix.
+
+**SHA pin is a deliberate temporary exception** to the "always pin exact release" discipline stated under [Merge discipline](#merge-discipline). The RC doesn't have a version number yet, so there's no tag to pin to. Once 1.0.0 ships on PyPI, the orbit-admin bump follow-up PR replaces the SHA pin with `clickwork==1.0.0`, restoring the exact-release invariant.
 
 **Reserve time for findings.** If #44 uncovers real issues, spin off fix PRs against clickwork main and re-run. Budget 60-90 minutes before declaring RC-ready.
 

--- a/docs/superpowers/specs/2026-04-18-clickwork-1.0-roadmap.md
+++ b/docs/superpowers/specs/2026-04-18-clickwork-1.0-roadmap.md
@@ -1,0 +1,221 @@
+# clickwork 1.0 roadmap
+
+**Date:** 2026-04-18
+**Milestone:** [1.0](https://github.com/qubitrenegade/clickwork/milestone/1)
+**Parent tracker:** [#45](https://github.com/qubitrenegade/clickwork/issues/45)
+**Predecessor release:** [v0.2.0](https://github.com/qubitrenegade/clickwork/releases/tag/v0.2.0)
+
+## Goal
+
+Ship clickwork 1.0.0 the same day this roadmap merges. 1.0 is a **stabilization release** — no major new features. The work is release hardening, public-API policy, packaging polish, cross-platform confidence, and the documentation that those commitments depend on.
+
+Because we're still pre-1.0, **breaking changes relative to 0.2 are acceptable** where they represent genuine corrections. The 1.0 promise starts the moment 1.0.0 ships, not retroactively; callers who want to continue on 0.2.x can pin.
+
+## Execution principles
+
+These are the ground rules that shape every wave below.
+
+### Smaller PRs, more of them
+
+Default bias: split issues across PRs if that keeps each diff focused enough for Copilot + human review in one pass. The goal is low **mean-time-to-merge** per PR, not minimum PR count. Anecdotally from 0.2.0: Copilot review quality drops sharply on PRs larger than ~200 lines.
+
+### Parallelism policy
+
+Same as 0.2.0's "policy B": within a wave, agents run in parallel; during the Copilot review loop on wave N's PRs, start preparing wave N+1's worktrees. Do **not** merge two waves concurrently — wait for wave N to fully merge before merging wave N+1's first PR.
+
+### Roadmap-before-code
+
+This document locks wave structure, per-issue API shape decisions where non-obvious, and merge-order constraints. Per-wave plan PRs only happen if a wave needs additional upfront design work beyond what's captured here. Most 1.0 waves are small enough to skip the plan PR and go straight to parallel agent dispatch.
+
+### Breaking changes
+
+Allowed where they correct real design mistakes. Each breaking change:
+
+1. Must be flagged in its PR description with a `BREAKING:` marker.
+2. Must land in the 0.x → 1.0 migration guide (#56).
+3. Should, when practical, ship a deprecation shim using the mechanism from #47 — even if the shim only lives for the 1.0.0 release cycle — so existing callers get a one-release warning rather than a silent semantic change.
+
+### Merge discipline
+
+- No PR merges without Copilot having had at least one clean round, except where the user explicitly greenlights on round 1.
+- Skip Copilot loops on pure-rename or trivially-mechanical diffs if the user approves inline.
+- Always pin the CI-side version of clickwork used by downstream consumers (`orbit-admin`) to an exact release. Range pins belong in library dependency declarations, not in install steps.
+
+## Wave structure
+
+| Wave | Theme | Issues | Approx. PR count | Parallelism within wave |
+|------|-------|--------|-------------------|--------------------------|
+| 1 | Foundation — API policy, packaging metadata, version ranges | #35, #36, #46, #49 | 4 | 4 parallel |
+| 2 | Code + CI — runtime polish, typed package, static gates, OS coverage | #37, #38, #39, #40, #41, #42, #43, #47, #48, #57, #59 | 11–12 | Up to 8 parallel (see notes) |
+| 3 | Test coverage + small polish | #50, #51, #52, parts of #60 | 5 | 5 parallel |
+| 4 | Documentation | #53, #54, #55, #56, #58 | 5 | 5 parallel |
+| 5 | Integration + release | #44 → cut 1.0.0 | 1 + release | Sequential |
+
+Post-1.0 (not covered by this roadmap): [#61 sigstore + signed tags](https://github.com/qubitrenegade/clickwork/issues/61) shipping as 1.0.1; [#62 conda-forge](https://github.com/qubitrenegade/clickwork/issues/62) as a later-still follow-up.
+
+---
+
+## Wave 1 — Foundation (4 PRs parallel)
+
+Everything downstream references the decisions made in this wave. Merge the whole wave before starting Wave 2.
+
+### [#36 — Public API + compatibility policy](https://github.com/qubitrenegade/clickwork/issues/36)
+
+**Deliverable:** `docs/API_POLICY.md` (new).
+
+**What it decides:**
+
+- Exact list of public symbols (every name in `clickwork/__init__.py`'s `__all__`, plus documented submodule surfaces like `clickwork.http`, `clickwork.platform`, `clickwork.testing`, `clickwork.config`).
+- Compatibility promise: post-1.0, the public surface follows semver — breaking changes bump the major. Private symbols (leading underscore, or not re-exported) carry no promise.
+- Deprecation runway length: a deprecated public symbol stays available for at least one full minor release (e.g. deprecated in 1.1, removed no earlier than 1.2). Ties into #47.
+- Which surfaces are **explicitly excluded** from the promise: anything under `clickwork._internal` (doesn't exist yet — reserved), anything we consider "protocol" rather than "API" (e.g. the command-entry-point format is stable, but the internal loader path is not).
+
+**Constraints:**
+
+- This PR is docs-only. It doesn't change code behavior.
+- Publish the symbol list by literally iterating `__all__` in CI so drift is detectable (defer that CI check to Wave 2 #38 static gates).
+
+### [#35 — Package metadata + LICENSE](https://github.com/qubitrenegade/clickwork/issues/35)
+
+**Deliverable:** `LICENSE` (new), `pyproject.toml` metadata filled in.
+
+**Concrete scope:**
+
+- `LICENSE` file with MIT text (matches the `license = {text = "MIT"}` already in pyproject).
+- Trove classifiers:
+  - `Development Status :: 5 - Production/Stable` once 1.0 ships (land as `4 - Beta` in this PR, bumped to `5` in the release PR).
+  - `Intended Audience :: Developers`
+  - `License :: OSI Approved :: MIT License`
+  - `Operating System :: POSIX :: Linux`, `:: MacOS`, `:: Microsoft :: Windows` (matches the OS matrix from #39).
+  - `Programming Language :: Python :: 3`, `:: 3.11`, `:: 3.12`, `:: 3.13`.
+  - `Topic :: Software Development :: Libraries :: Python Modules`.
+  - `Typing :: Typed` (ties into #37 `py.typed`).
+- `project.urls` table: Homepage, Repository, Issues, Changelog, Documentation.
+- `project.keywords`: `cli`, `click`, `plugin`, `framework`, `command-line`.
+- `project.authors` / `maintainers`.
+
+**Out of scope for this PR (captured as follow-ups):**
+
+- conda-forge publishing → [#62](https://github.com/qubitrenegade/clickwork/issues/62).
+- Artifact signing / sigstore → [#61](https://github.com/qubitrenegade/clickwork/issues/61).
+- Subcategory trove classifiers beyond the above (e.g. `Environment :: Console` was considered and dropped as noise).
+
+### [#46 — Click version range policy](https://github.com/qubitrenegade/clickwork/issues/46)
+
+**Deliverable:** document the policy in `docs/API_POLICY.md` (#36's output), possibly a single line in `pyproject.toml` comment.
+
+**Decision (pinned here to avoid re-litigating in the PR):**
+
+- **No upper bound on `click`.** Pinning an upper bound creates a dependency-resolution ratchet that makes clickwork uninstallable whenever Click ships a major we haven't yet tested — a worse outcome than silent breakage we didn't predict.
+- Instead, document in the API policy doc: "clickwork declares `click>=8.2` with no upper bound. Each new Click major (9.x, 10.x, …) will be smoke-tested by the test suite on CI's matrix. Breakages get a fix release, not a ratchet."
+- CI (#39) will include a "latest Click" job separate from the pinned-Click lockfile job so we catch Click-major drift the moment it lands on PyPI.
+
+### [#49 — Python version support policy](https://github.com/qubitrenegade/clickwork/issues/49)
+
+**Deliverable:** section in `docs/API_POLICY.md` (#36's output).
+
+**Decision (pinned here):**
+
+- Floor: `requires-python = ">=3.11"` (matches pyproject today).
+- Rationale: 3.11 is the oldest still-supported CPython that has PEP 654 exception groups, structured `tomllib`, PEP 673 `Self`, and the typing improvements we rely on. 3.10 lacks all four.
+- Ceiling: none. New Python releases get smoke-tested on CI's matrix.
+- Deprecation runway: we drop a Python minor no earlier than 18 months after CPython EOL's it. Concretely: 3.11 EOL is 2027-10 → earliest drop is 2029-04. Callers get ≥2 clickwork minor releases of warning.
+
+---
+
+## Wave 2 — Code + CI (≈11 PRs)
+
+Largest wave by PR count. Two sub-groups, each dispatchable mostly-in-parallel.
+
+### 2a — Runtime polish (6 PRs, fully parallel, distinct modules)
+
+| Issue | Scope | BREAKING? |
+|-------|-------|-----------|
+| [#37 `py.typed`](https://github.com/qubitrenegade/clickwork/issues/37) | Add `src/clickwork/py.typed` marker file; include in wheel; `Typing :: Typed` classifier assumed present from #35. | No |
+| [#41 config env-var types](https://github.com/qubitrenegade/clickwork/issues/41) | Lock the behaviour: env-var values always arrive as strings; schema is responsible for coercion. Document in `docs/config.md` (or inline in `clickwork.config`). Adds test coverage. | Possibly — see PR body |
+| [#42 strict discovery validation](https://github.com/qubitrenegade/clickwork/issues/42) | Add `strict=True` kwarg to `create_cli()` / discovery. When set, a discovery failure (broken import, missing `cli` attribute, flag collision) raises immediately at CLI startup instead of silently dropping the command. Default stays `False` for 1.0 compat. | No (opt-in) |
+| [#43 logger propagation](https://github.com/qubitrenegade/clickwork/issues/43) | `clickwork` loggers no longer attach their own handler when the root logger already has one. Uses `propagate=True` + `NullHandler` fallback. Tested against `logging.basicConfig()` + a no-setup host. | **Yes** — silent behaviour change for embedded consumers |
+| [#47 deprecation mechanism](https://github.com/qubitrenegade/clickwork/issues/47) | New `clickwork._deprecated.deprecated(since, removed_in, reason)` decorator. Emits `DeprecationWarning` at first call. Used by later waves when we want deprecation shims. | No |
+| [#48 `--version` flag](https://github.com/qubitrenegade/clickwork/issues/48) | `create_cli()` gains `version=` kwarg (defaults to the consumer's `__version__` if derivable, else required). Adds `--version` via `click.version_option`. | No |
+
+Merge order within 2a: no strict constraint, but prefer to merge **#47 before any PR that uses the deprecation decorator**. Wave 2's PRs mostly don't need the decorator; Wave 3's might.
+
+### 2b — CI hardening (5–6 PRs, serialize the workflow-file touchers)
+
+| Issue | New file? | Depends on | Notes |
+|-------|-----------|------------|-------|
+| [#38 lint + format](https://github.com/qubitrenegade/clickwork/issues/38) | New `.github/workflows/lint.yml` | — | `ruff check` + `ruff format --check`. One workflow, two jobs. |
+| #38 (split) type-check | Append to `lint.yml` OR new `types.yml` | #37 `py.typed` | `mypy --strict src/clickwork`. Split PR because the toolchain (mypy vs ruff) is distinct and review concerns differ. |
+| [#39 OS matrix](https://github.com/qubitrenegade/clickwork/issues/39) | Modifies existing `test.yml` | #35 (so classifiers match) | Matrix: linux, macos, windows × 3.11, 3.12, 3.13. |
+| [#40 wheel + sdist install](https://github.com/qubitrenegade/clickwork/issues/40) | New `.github/workflows/release-smoke.yml` | — | Builds, installs from the built artifacts in a fresh venv, runs tests against the installed package (not the checkout). |
+| [#57 release-notes automation](https://github.com/qubitrenegade/clickwork/issues/57) | Extends `publish.yml` OR `.github/release.yml` | — | Start with [GitHub's `release.yml` config](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). Conventional-commits parser is overkill for our volume. |
+| [#59 cold-start benchmark](https://github.com/qubitrenegade/clickwork/issues/59) | New `.github/workflows/bench.yml` + `scripts/bench_coldstart.py` | — | Run `python -c "import clickwork"` under `time`. Record baseline in `benchmarks/baseline.json`. PR fails if cold-start regresses >20%. |
+
+**Conflict avoidance:** prefer **new workflow files** over editing existing ones. The only existing-file edits are #39 (matrix in `test.yml`) and possibly #57 (`publish.yml`). Instruct agents to base their branches off the same fresh-main SHA; merge #39 first since it sets the matrix shape everything else depends on.
+
+---
+
+## Wave 3 — Tests + polish (5 PRs parallel)
+
+All five are independent. Dispatch together.
+
+| Issue | Scope |
+|-------|-------|
+| [#50 SIGINT coverage](https://github.com/qubitrenegade/clickwork/issues/50) | Real signal-forwarding tests: spawn a subprocess that installs a SIGINT handler, send `SIGINT` to `ctx.run`, assert the child saw it and the elapsed time is under the forward timeout. Plus SIGKILL escalation after the `--timeout` window. Linux + macOS only — Windows signal semantics differ enough that the test is marked skipped there. |
+| [#51 mixed discovery local-wins](https://github.com/qubitrenegade/clickwork/issues/51) | Integration test: install a sample plugin via an entry point, put a same-named command file in the commands dir, assert the local one wins, assert the installed one is still callable via a fully-qualified invocation path if we support one (decide in PR). |
+| [#52 in-file config precedence](https://github.com/qubitrenegade/clickwork/issues/52) | Test that `[env.staging]` overrides `[default]` within the same file. Lock the behaviour; document it in `docs/config.md` (part of #54's output). |
+| **#60a** `setup_logging` re-invocation | Part of #60. Calling `setup_logging(level="DEBUG")` twice shouldn't double-attach handlers. Use a module-level flag keyed by logger name. PR title: `fix: setup_logging is idempotent (part of #60)`. |
+| **#60b** `add_global_option` override semantics | Part of #60. When a plugin's subcommand defines an option with the same name as a global option, the subcommand's definition wins inside that subcommand's scope. Document + test. PR title: `feat: add_global_option override semantics (part of #60)`. |
+
+#60 closes when 3a + 3b land. **#60c** (sigstore) is out of scope for 1.0 → [#61](https://github.com/qubitrenegade/clickwork/issues/61).
+
+---
+
+## Wave 4 — Documentation (5 PRs parallel)
+
+All five produce new files in `docs/`, fully independent.
+
+| Issue | Deliverable | Depends on |
+|-------|-------------|------------|
+| [#53 plugin authoring guide](https://github.com/qubitrenegade/clickwork/issues/53) | `docs/PLUGINS.md` — minimal plugin walkthrough, entry-point wiring, testing with `clickwork.testing`, packaging, publishing. | #35 (classifier list), #36 (public API), #47 (deprecation), #48 (--version) |
+| [#54 config precedence table](https://github.com/qubitrenegade/clickwork/issues/54) | Replace the prose in `docs/GUIDE.md`'s config section with an explicit precedence table; cross-ref from `docs/API_POLICY.md`. | #52 test results (locks the behaviour) |
+| [#55 security + threat model](https://github.com/qubitrenegade/clickwork/issues/55) | `docs/SECURITY.md` — subprocess secret handling, URL allowlist, redirect policy, env-file permissions, what we do/don't defend against. | Wave 2 code behaviour is in main |
+| [#56 0.x → 1.0 migration guide](https://github.com/qubitrenegade/clickwork/issues/56) | `docs/MIGRATING.md` — every breaking change from Wave 2 (#43 especially), every new public API, deprecation shims. | Wave 2 fully merged |
+| [#58 `CONTRIBUTING.md`](https://github.com/qubitrenegade/clickwork/issues/58) | Dev setup (`uv sync`), test command, lint command, PR conventions, code review expectations. | #38 (lint command), #59 (bench command) |
+
+All five can start as soon as Wave 2 merges. #55 and #56 reference Wave 2 behaviour and must not speculate about unmerged changes.
+
+---
+
+## Wave 5 — Integration + release
+
+### [#44 — Validate against `orbit-admin`](https://github.com/qubitrenegade/clickwork/issues/44)
+
+**Deliverable:** a `feat/clickwork-1.0` branch on `qbrd-orbit-widener` that installs the 1.0 release candidate (a git SHA on `main`) and runs the full `tests/tools/` suite. PR body documents any breakage + fix.
+
+**Reserve time for findings.** If #44 uncovers real issues, spin off fix PRs against clickwork main and re-run. Budget 60-90 minutes before declaring RC-ready.
+
+### Release cut
+
+Same process as 0.2.0:
+
+1. Release PR on clickwork: bump `pyproject.toml` + `__init__.py` to `1.0.0`. Regenerate `uv.lock`. Update `CHANGELOG.md`. Classifier bumps: `Development Status :: 4 - Beta` → `5 - Production/Stable`. Update README install snippet to `clickwork==1.0.0`.
+2. Merge release PR → `git tag v1.0.0` → push tag → `gh release create v1.0.0`.
+3. Approve the `pypi` environment deployment when prompted.
+4. Verify `pip install clickwork==1.0.0` resolves.
+5. Open a follow-up PR on `qbrd-orbit-widener` bumping the install pin from 0.2.0 → 1.0.0.
+
+## Out of scope for 1.0 (filed as follow-ups)
+
+- [#61](https://github.com/qubitrenegade/clickwork/issues/61) — Sigstore signing + signed git tags. 1.0.x patch release.
+- [#62](https://github.com/qubitrenegade/clickwork/issues/62) — conda-forge publishing. Post-1.0.
+- Speculative new framework features. The 1.0 tracker (#45) is explicit: 1.0 stabilises what exists; it doesn't add new surface area.
+
+## Success criteria for merging this roadmap
+
+- [ ] Wave structure locked (5 waves + release).
+- [ ] Per-issue scope + deliverables pinned above.
+- [ ] Breaking-change policy documented.
+- [ ] Merge-order constraints called out where they matter (intra-Wave 2b CI files, #44 before release cut).
+- [ ] Follow-up tracker issues exist for everything deferred out of scope (#61, #62 already filed).
+- [ ] Copilot + user have reviewed and agreed on the wave boundaries.


### PR DESCRIPTION
## Summary

Locks the plan for shipping clickwork 1.0.0 today. Five waves plus a release cut, modeled on the 0.2.0 workflow.

## Wave structure at a glance

| Wave | Theme | Issues | PRs |
|------|-------|--------|-----|
| 1 | Foundation (API policy, metadata, version ranges) | #35, #36, #46, #49 | 4 parallel |
| 2 | Code + CI | #37, #38/#38b, #39, #40, #41, #42, #43, #47, #48, #57, #59 | ~11, up to 8 parallel |
| 3 | Tests + polish | #50, #51, #52, #60a, #60b | 5 parallel |
| 4 | Documentation | #53, #54, #55, #56, #58 | 5 parallel |
| 5 | Integration + release | #44 → cut 1.0.0 → plugin bump | sequential |

## What this PR pins (so wave PRs don't re-litigate)

- **No upper bound on Click** (#46). Breakage gets a fix release, not a ratchet.
- **Python floor stays `>=3.11`** (#49). Rationale: PEP 654, PEP 673, `tomllib`.
- **Breaking changes allowed** for 0.x → 1.0 corrections, gated by \`BREAKING:\` marker + migration guide entry + deprecation shim where practical.
- **#60 split:** #60a (\`setup_logging\` idempotent) + #60b (\`add_global_option\` override) ship in Wave 3. #60c (sigstore) spun off to #61 for 1.0.x.
- **CI conflict policy** (Wave 2b): prefer new workflow files over editing existing ones; #39 matrix change merges first.

## Out-of-scope follow-ups already filed

- [#61](https://github.com/qubitrenegade/clickwork/issues/61) — Sigstore + signed git tags (1.0.x patch)
- [#62](https://github.com/qubitrenegade/clickwork/issues/62) — conda-forge (post-1.0)

## Review focus

Most valuable places to push back:

1. **Wave 2 parallelism** — is "up to 8 agents at once" too aggressive for review bandwidth? Would a hard cap of 4–5 keep quality higher?
2. **#43 logger propagation as BREAKING** — confirm you're comfortable with the behaviour change in a 1.0 release rather than a 1.1.
3. **#44 orbit-admin validation timing** — 60–90 min budget realistic for finding + fixing whatever it surfaces?
4. **Trove classifiers list in #35 scope** — any you want added/removed?

## Test plan

N/A — roadmap is docs-only. Verification is whether the wave boundaries survive contact with execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)