### PR TITLE
feat: ship clickwork as a PEP 561 typed package (Fixes #37)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 dependencies = [
     "click>=8.2",


### PR DESCRIPTION
Ships the `py.typed` marker so mypy/pyright/pyre treat clickwork's inline annotations as public. Wave 1 #35 removed the `Typing :: Typed` classifier pending this PR; it's re-added here.

**Changes:** 2 files (new `src/clickwork/py.typed`, classifier in `pyproject.toml`).

**Verification:** `uv build` + zipfile inspection confirms the wheel ships `clickwork/py.typed` under the existing Hatchling config. No `include` override needed. 257 tests pass.

Roadmap: Wave 2a #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)