### PR TITLE
feat: BREAKING — coerce env-sourced config per schema type (Fixes #41)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -277,6 +277,15 @@ cli = create_cli(name="my-tool", commands_dir=..., config_schema=CONFIG_SCHEMA)
 When both an explicit mapping and an auto-prefixed var could provide
 the same key, the explicit mapping wins.
 
+Env-var values always arrive as strings from the OS. If your schema
+declares `type: int`, `type: float`, or `type: bool` for a key that
+might be set via env var, the loader coerces the string into the
+declared type automatically. See
+[Environment Variable Types](#environment-variable-types) below for
+the coercion rules -- bool parsing in particular has a fixed
+allowlist that avoids the classic `bool("false") == True`
+foot-cannon.
+
 ### Config Schema
 
 Schemas are optional but recommended for production CLIs. They provide
@@ -306,8 +315,10 @@ Schema features:
 
 - **`required: True`** -- Raises `ConfigError` if the key is missing
   after all layers merge.
-- **`type: str`** (or `int`, `bool`, etc.) -- Validates the resolved
-  value matches the expected type.
+- **`type: str`** (or `int`, `bool`, `float`) -- Validates the resolved
+  value matches the expected type. For env-sourced values, also
+  performs coercion -- see [Environment Variable Types](#environment-variable-types)
+  below for the exact rules.
 - **`default: "value"`** -- Fills missing keys after all layers merge
   but before validation.
 - **`env: "VAR_NAME"`** -- Explicit env var mapping (overrides auto-prefix).
@@ -315,6 +326,87 @@ Schema features:
   is checked into git). The resolved value is automatically wrapped in a
   `Secret()` instance that redacts itself in logs and string formatting.
 - **`description: "..."`** -- Documentation only, ignored by the framework.
+
+### Environment Variable Types
+
+Environment variables at the OS level are **always strings**.
+`os.environ` is `dict[str, str]`, and the kernel-level `environ`
+array is a list of `NAME=value` byte strings -- there is no such
+thing as an "integer environment variable." That means when a
+plugin author declares a schema key like `{"port": {"type": int}}`
+and the value arrives via `TEST_CLI_PORT=8080`, *something* has to
+convert the string `"8080"` into the integer `8080` before the
+command code uses it.
+
+clickwork pins that conversion at the **schema layer**. When the
+loader resolves a config value from an environment variable and the
+schema declares a non-`str` `type`, the loader coerces the string
+into the declared type before returning it in `ctx.config`. The
+caller never has to write `int(os.environ["PORT"])` by hand.
+
+Pinning coercion at the schema layer (rather than the caller or the
+env-var reader) means:
+
+- Env vars and TOML values behave the same at the call site.
+  `ctx.config["port"]` is an int whether it came from
+  `port = 8080` in TOML or `TEST_CLI_PORT=8080` in the shell.
+- Conversion errors surface at CLI startup (during `load_config`)
+  rather than halfway through a deploy when a command does
+  arithmetic on a string. You get a `ConfigError` naming the key
+  and the offending value.
+- The coercion table is small, stdlib-only, and deliberately
+  explicit about bools so Python's classic `bool("false") == True`
+  foot-cannon never bites you.
+
+The supported `type` values and their env-var coercion rules:
+
+| Schema `type` | Env-var string | Result | Failure mode |
+|---------------|----------------|--------|--------------|
+| `str` | `"hello"` | `"hello"` (unchanged) | Never fails -- strings are strings. |
+| `int` | `"8080"` | `8080` (base 10) | `ConfigError` on non-integer text (`"3.14"`, `"abc"`). |
+| `float` | `"3.14"` | `3.14` | `ConfigError` on non-numeric text. |
+| `bool` | `"true"`, `"1"`, `"yes"`, `"on"` | `True` | `ConfigError` on anything outside the allowlist. |
+| `bool` | `"false"`, `"0"`, `"no"`, `"off"` | `False` | See above. |
+
+Boolean parsing is **case-insensitive** (`"TRUE"`, `"True"`, and
+`"true"` all produce `True`) but the allowlist is fixed. Tokens like
+`"maybe"`, `"enabled"`, or `"y"` raise `ConfigError` rather than
+silently defaulting either way. If you need looser parsing, do it
+in your command code before feeding the value to clickwork.
+
+Values sourced from TOML already carry their native type
+(`port = 8080` parses as `int`), so coercion is a no-op for them --
+the schema `type` check still runs, but an already-correct value
+passes through unchanged.
+
+Without a schema, env-var values stay as strings in `ctx.config`.
+The schema's `type` declaration is the explicit opt-in for
+coercion; there is no heuristic "looks like a number, must be a
+number" detection.
+
+Example combining all of the above:
+
+```python
+CONFIG_SCHEMA = {
+    "port": {
+        "type": int,
+        "default": 8080,
+        "description": "HTTP listener port; honours TEST_CLI_PORT.",
+    },
+    "debug": {
+        "type": bool,
+        "default": False,
+    },
+    "api_token": {
+        "secret": True,
+        "env": "MY_TOOL_API_TOKEN",
+    },
+}
+```
+
+With `MY_TOOL_PORT=9090 MY_TOOL_DEBUG=true my-tool deploy`, the
+command sees `ctx.config["port"] == 9090` (int) and
+`ctx.config["debug"] is True`.
 
 ## Subprocess Helpers
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -317,7 +317,7 @@ Schema features:
   after all layers merge.
 - **`type: str`** (or `int`, `bool`, `float`) -- Validates the resolved
   value matches the expected type. For **any string-sourced value**
-  (env var, TOML string literal, user-supplied override), also
+  (env var or TOML string literal), also
   performs coercion to the declared type -- see
   [Environment Variable Types](#environment-variable-types) below for
   the exact rules and the bool allowlist.
@@ -346,7 +346,7 @@ loader finishes merging all layers and the schema declares a non-
 config dict to the declared type before returning it in
 `ctx.config`. The rule is uniform across sources: the coercion
 applies to env vars, TOML string literals (`port = "8080"`), and
-user-supplied overrides alike -- whichever source produced the
+TOML string literals alike -- whichever source produced the
 string, the same coercion fires. The caller never has to write
 `int(os.environ["PORT"])` by hand, and a TOML author who quoted the
 value by mistake still gets a usable int.
@@ -356,7 +356,7 @@ env-var reader) means:
 
 - Env vars and TOML values behave the same at the call site.
   `ctx.config["port"]` is an int whether it came from
-  `port = 8080` in TOML or `TEST_CLI_PORT=8080` in the shell.
+  `port = 8080` in TOML or `MY_TOOL_PORT=8080` in the shell.
 - String literals in TOML coerce too. A `.test-cli.toml` that
   contains `port = "8080"` under `type: int` produces the int
   `8080` in `ctx.config["port"]`, matching what an env var would

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -339,10 +339,15 @@ convert the string `"8080"` into the integer `8080` before the
 command code uses it.
 
 clickwork pins that conversion at the **schema layer**. When the
-loader resolves a config value from an environment variable and the
-schema declares a non-`str` `type`, the loader coerces the string
-into the declared type before returning it in `ctx.config`. The
-caller never has to write `int(os.environ["PORT"])` by hand.
+loader finishes merging all layers and the schema declares a non-
+`str` `type`, the loader coerces any string value in the merged
+config dict to the declared type before returning it in
+`ctx.config`. The rule is uniform across sources: the coercion
+applies to env vars, TOML string literals (`port = "8080"`), and
+user-supplied overrides alike -- whichever source produced the
+string, the same coercion fires. The caller never has to write
+`int(os.environ["PORT"])` by hand, and a TOML author who quoted the
+value by mistake still gets a usable int.
 
 Pinning coercion at the schema layer (rather than the caller or the
 env-var reader) means:
@@ -350,18 +355,23 @@ env-var reader) means:
 - Env vars and TOML values behave the same at the call site.
   `ctx.config["port"]` is an int whether it came from
   `port = 8080` in TOML or `TEST_CLI_PORT=8080` in the shell.
+- String literals in TOML coerce too. A `.test-cli.toml` that
+  contains `port = "8080"` under `type: int` produces the int
+  `8080` in `ctx.config["port"]`, matching what an env var would
+  have delivered.
 - Conversion errors surface at CLI startup (during `load_config`)
   rather than halfway through a deploy when a command does
   arithmetic on a string. You get a `ConfigError` naming the key
-  and the offending value.
+  and the offending value (redacted to `<redacted>` if the schema
+  marks the key as `secret: True`).
 - The coercion table is small, stdlib-only, and deliberately
   explicit about bools so Python's classic `bool("false") == True`
   foot-cannon never bites you.
 
-The supported `type` values and their env-var coercion rules:
+The supported `type` values and their string-source coercion rules:
 
-| Schema `type` | Env-var string | Result | Failure mode |
-|---------------|----------------|--------|--------------|
+| Schema `type` | String input | Result | Failure mode |
+|---------------|--------------|--------|--------------|
 | `str` | `"hello"` | `"hello"` (unchanged) | Never fails -- strings are strings. |
 | `int` | `"8080"` | `8080` (base 10) | `ConfigError` on non-integer text (`"3.14"`, `"abc"`). |
 | `float` | `"3.14"` | `3.14` | `ConfigError` on non-numeric text. |
@@ -374,12 +384,19 @@ Boolean parsing is **case-insensitive** (`"TRUE"`, `"True"`, and
 silently defaulting either way. If you need looser parsing, do it
 in your command code before feeding the value to clickwork.
 
-Values sourced from TOML already carry their native type
-(`port = 8080` parses as `int`), so coercion is a no-op for them --
-the schema `type` check still runs, but an already-correct value
-passes through unchanged.
+Values that already carry the declared type pass through unchanged.
+TOML's native typing means `port = 8080` parses as `int` and skips
+coercion entirely -- the schema `type` check still runs, but
+there's nothing to convert. Only *string* values in the merged
+config dict take the coercion path.
 
-Without a schema, env-var values stay as strings in `ctx.config`.
+Worked TOML-string example: given the schema
+`{"port": {"type": int}}` and a repo config containing
+`port = "8080"` (quoted string literal), the loader coerces the
+string and `ctx.config["port"]` is the int `8080` -- identical to
+what `port = 8080` (unquoted int) would have produced.
+
+Without a schema, string values stay as strings in `ctx.config`.
 The schema's `type` declaration is the explicit opt-in for
 coercion; there is no heuristic "looks like a number, must be a
 number" detection.
@@ -391,7 +408,7 @@ CONFIG_SCHEMA = {
     "port": {
         "type": int,
         "default": 8080,
-        "description": "HTTP listener port; honours TEST_CLI_PORT.",
+        "description": "HTTP listener port; honours MY_TOOL_PORT.",
     },
     "debug": {
         "type": bool,

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -316,9 +316,11 @@ Schema features:
 - **`required: True`** -- Raises `ConfigError` if the key is missing
   after all layers merge.
 - **`type: str`** (or `int`, `bool`, `float`) -- Validates the resolved
-  value matches the expected type. For env-sourced values, also
-  performs coercion -- see [Environment Variable Types](#environment-variable-types)
-  below for the exact rules.
+  value matches the expected type. For **any string-sourced value**
+  (env var, TOML string literal, user-supplied override), also
+  performs coercion to the declared type -- see
+  [Environment Variable Types](#environment-variable-types) below for
+  the exact rules and the bool allowlist.
 - **`default: "value"`** -- Fills missing keys after all layers merge
   but before validation.
 - **`env: "VAR_NAME"`** -- Explicit env var mapping (overrides auto-prefix).
@@ -334,7 +336,7 @@ Environment variables at the OS level are **always strings**.
 array is a list of `NAME=value` byte strings -- there is no such
 thing as an "integer environment variable." That means when a
 plugin author declares a schema key like `{"port": {"type": int}}`
-and the value arrives via `TEST_CLI_PORT=8080`, *something* has to
+and the value arrives via `MY_TOOL_PORT=8080`, *something* has to
 convert the string `"8080"` into the integer `8080` before the
 command code uses it.
 

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -128,9 +128,8 @@ def _coerce_value(
     if expected_type is str and isinstance(value, str):
         return value
 
-    # From here on, coercion only applies to string values. Every
-    # string source is coerced uniformly -- env vars, TOML string
-    # literals (``port = "8080"``), and user-supplied overrides all
+    # From here on, coercion only applies to string values. Both string
+    # sources (env vars and TOML string literals like ``port = "8080"``)
     # follow the same rule: if the schema declares a non-``str`` type
     # and the merged value is a string, the loader coerces it. Non-
     # string mismatches (e.g. a TOML ``port = [8080]`` list against
@@ -789,7 +788,7 @@ def load_config(
 
             # Type check + coercion: env vars always arrive as strings
             # (``os.environ`` is ``dict[str, str]``), but TOML string
-            # literals and user-supplied overrides can also be strings
+            # literals and TOML string literals can also be strings
             # even when the schema declares ``int``/``bool``/``float``.
             # The rule is uniform: every string value in the merged
             # config dict gets coerced to the schema-declared type,

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -50,19 +50,26 @@ _TRUTHY_STRINGS = frozenset({"true", "1", "yes", "on"})
 _FALSY_STRINGS = frozenset({"false", "0", "no", "off"})
 
 
-def _coerce_value(value: object, expected_type: type, key: str) -> object:
-    """Coerce a (typically env-sourced) string value to ``expected_type``.
+def _coerce_value(
+    value: object,
+    expected_type: type,
+    key: str,
+    key_schema: dict | None = None,
+) -> object:
+    """Coerce a string value to ``expected_type``.
 
     Environment variables at the OS level are ALWAYS strings
-    (``os.environ`` is ``dict[str, str]``), but schemas want typed
-    values (``type: int``, ``type: bool``). Rather than forcing every
-    plugin author to re-implement ``int(os.environ["PORT"])`` with
-    their own error handling, the loader performs the coercion
-    centrally at the schema layer using this helper.
+    (``os.environ`` is ``dict[str, str]``), and TOML string literals
+    (``port = "8080"``) are strings even when the schema declares a
+    numeric type. Rather than forcing every plugin author to re-
+    implement ``int(os.environ["PORT"])`` with their own error
+    handling, the loader performs the coercion centrally at the
+    schema layer using this helper.
 
-    Values that already match ``expected_type`` pass through unchanged
-    -- TOML native-typed values (``port = 8080`` parses as ``int``)
-    don't get round-tripped through ``str``.
+    The rule is uniform across sources: any string value whose
+    schema declares a non-``str`` type is coerced. Values that
+    already match ``expected_type`` (e.g. TOML's native ``port =
+    8080`` parsing to ``int``) pass through unchanged.
 
     Supported coercion table:
 
@@ -78,13 +85,18 @@ def _coerce_value(value: object, expected_type: type, key: str) -> object:
     still fires.
 
     Args:
-        value: The resolved config value for ``key``. Usually a str
-            from an env var; may also be an already-typed TOML value
-            that happens to match ``expected_type``.
+        value: The resolved config value for ``key``. Often a str
+            (from an env var or TOML string literal); may also be an
+            already-typed value that happens to match ``expected_type``.
         expected_type: The type the schema declared for ``key``
             (``int``, ``float``, ``bool``, or ``str``).
         key: The dotted config key -- used to build an actionable
             error message so the operator knows which env var to fix.
+        key_schema: The schema entry for ``key``, used to detect
+            ``secret: True`` so the error message redacts the value
+            instead of echoing a misconfigured secret token verbatim.
+            Optional for backward compatibility with callers that
+            don't have the schema entry handy.
 
     Returns:
         The coerced value, or ``value`` unchanged if it already
@@ -94,8 +106,11 @@ def _coerce_value(value: object, expected_type: type, key: str) -> object:
         ConfigError: If ``value`` is a string but does not parse as
             ``expected_type`` (e.g. ``"not-a-number"`` for int, or a
             bool token outside the explicit allowlist). The message
-            names ``key`` and the offending value verbatim so the
-            operator can locate the misconfigured env var.
+            names ``key`` and the offending value verbatim -- except
+            when the schema marks the key as ``secret: True``, in
+            which case the value is shown as ``<redacted>`` to
+            prevent misconfigured secret env vars from leaking into
+            logs via the exception.
     """
     # Fast-path: if the value already has the expected type, nothing
     # to do. ``bool`` is a subclass of ``int`` in Python, so we check
@@ -113,15 +128,28 @@ def _coerce_value(value: object, expected_type: type, key: str) -> object:
     if expected_type is str and isinstance(value, str):
         return value
 
-    # From here on, coercion only makes sense when the source value is
-    # a string (that's the env-var case). Non-string mismatches fall
-    # through unchanged so the caller's isinstance check raises the
-    # familiar "type X, expected Y" ConfigError. We deliberately do
-    # NOT coerce non-string sources (e.g. a TOML ``port = "8080"``
-    # with schema ``int`` used to raise; now it also coerces, which is
-    # a strictly-better outcome since the user's intent is clear).
+    # From here on, coercion only applies to string values. Every
+    # string source is coerced uniformly -- env vars, TOML string
+    # literals (``port = "8080"``), and user-supplied overrides all
+    # follow the same rule: if the schema declares a non-``str`` type
+    # and the merged value is a string, the loader coerces it. Non-
+    # string mismatches (e.g. a TOML ``port = [8080]`` list against
+    # ``type: int``) fall through unchanged so the caller's
+    # isinstance check raises the familiar "type X, expected Y"
+    # ConfigError. Example of the pass-through path: TOML native
+    # ``port = 8080`` arrives as int and skips coercion entirely.
     if not isinstance(value, str):
         return value
+
+    # Build a display form of the value for error messages. When the
+    # schema marks this key as a secret, echoing the raw value into a
+    # ConfigError could leak a misconfigured secret env var into logs
+    # / stderr / CI output. Use ``<redacted>`` in that case so the
+    # operator still sees WHICH key failed without exposing the token.
+    # The raw ``value`` is still used for coercion attempts above --
+    # we only redact the user-facing message.
+    is_secret = bool(key_schema and key_schema.get("secret"))
+    display_value = "<redacted>" if is_secret else repr(value)
 
     # String -> bool: explicit allowlist, case-insensitive. We lowercase
     # once and compare against two frozensets so the token list stays
@@ -137,7 +165,7 @@ def _coerce_value(value: object, expected_type: type, key: str) -> object:
         # operator sees the same list the code accepts, and future
         # additions can't drift out of sync with the message.
         raise ConfigError(
-            f"Config key '{key}' has value {value!r}, which is not a "
+            f"Config key '{key}' has value {display_value}, which is not a "
             f"valid boolean. Accepted tokens (case-insensitive): "
             f"{sorted(_TRUTHY_STRINGS)} for true, "
             f"{sorted(_FALSY_STRINGS)} for false."
@@ -150,9 +178,13 @@ def _coerce_value(value: object, expected_type: type, key: str) -> object:
         try:
             return int(value)
         except ValueError as exc:
+            # For secret keys, also suppress the underlying ValueError
+            # text (``exc``) -- Python's int() error includes the raw
+            # token, so echoing ``exc`` would defeat the redaction.
+            detail = "invalid literal" if is_secret else str(exc)
             raise ConfigError(
-                f"Config key '{key}' has value {value!r}, which cannot "
-                f"be parsed as int: {exc}."
+                f"Config key '{key}' has value {display_value}, which cannot "
+                f"be parsed as int: {detail}."
             ) from exc
 
     # String -> float: accepts scientific notation, signed, decimals.
@@ -160,9 +192,12 @@ def _coerce_value(value: object, expected_type: type, key: str) -> object:
         try:
             return float(value)
         except ValueError as exc:
+            # Same redaction rationale as the int branch: float()'s
+            # ValueError message contains the raw token.
+            detail = "invalid literal" if is_secret else str(exc)
             raise ConfigError(
-                f"Config key '{key}' has value {value!r}, which cannot "
-                f"be parsed as float: {exc}."
+                f"Config key '{key}' has value {display_value}, which cannot "
+                f"be parsed as float: {detail}."
             ) from exc
 
     # Unsupported target type (e.g. ``type: list``, ``type: dict``).
@@ -741,19 +776,27 @@ def load_config(
                 config[key] = key_schema["default"]
 
             # Type check + coercion: env vars always arrive as strings
-            # (``os.environ`` is ``dict[str, str]``), but schemas want
-            # typed values. Coerce at the schema layer so env-sourced
-            # ``"8080"`` -> ``8080`` for ``type: int``, etc. See
+            # (``os.environ`` is ``dict[str, str]``), but TOML string
+            # literals and user-supplied overrides can also be strings
+            # even when the schema declares ``int``/``bool``/``float``.
+            # The rule is uniform: every string value in the merged
+            # config dict gets coerced to the schema-declared type,
+            # regardless of which source produced the string. See
             # _coerce_value for the supported coercion table and the
             # exact bool-token allowlist. Values that already match
             # ``expected_type`` pass through unchanged (TOML natively
-            # carries int/float/bool so no round-trip through str).
+            # carries int/float/bool, so ``port = 8080`` arrives as
+            # int and skips coercion entirely).
             expected_type = key_schema.get("type")
             if expected_type and key in config:
                 # Secrets are wrapped AFTER this validation pass, so a
                 # ``secret: True`` value is still a plain str/int/etc.
-                # here and coerces normally.
-                config[key] = _coerce_value(config[key], expected_type, key)
+                # here and coerces normally. Pass the schema entry into
+                # _coerce_value so the error path can redact the value
+                # for secret keys instead of echoing the raw token.
+                config[key] = _coerce_value(
+                    config[key], expected_type, key, key_schema
+                )
                 # Post-coercion isinstance check is still the
                 # authoritative gate. If _coerce_value returned the
                 # value unchanged (unsupported target type, or a

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -37,6 +37,142 @@ class ConfigError(Exception):
     """
 
 
+# Explicit boolean token sets. Defined at module scope so the docstring
+# for ``_coerce_value`` can reference them and downstream code (plus
+# docs/tests) always agree on the exact accepted tokens.
+#
+# WHY not use ``bool(value)``: Python's built-in truthiness considers
+# any non-empty string truthy, so ``bool("false")`` is ``True`` -- the
+# classic foot-cannon for env-var parsing. Instead we use an explicit
+# case-insensitive allowlist that matches shell conventions. Anything
+# outside both sets raises ConfigError rather than silently guessing.
+_TRUTHY_STRINGS = frozenset({"true", "1", "yes", "on"})
+_FALSY_STRINGS = frozenset({"false", "0", "no", "off"})
+
+
+def _coerce_value(value: object, expected_type: type, key: str) -> object:
+    """Coerce a (typically env-sourced) string value to ``expected_type``.
+
+    Environment variables at the OS level are ALWAYS strings
+    (``os.environ`` is ``dict[str, str]``), but schemas want typed
+    values (``type: int``, ``type: bool``). Rather than forcing every
+    plugin author to re-implement ``int(os.environ["PORT"])`` with
+    their own error handling, the loader performs the coercion
+    centrally at the schema layer using this helper.
+
+    Values that already match ``expected_type`` pass through unchanged
+    -- TOML native-typed values (``port = 8080`` parses as ``int``)
+    don't get round-tripped through ``str``.
+
+    Supported coercion table:
+
+        str -> int    : ``int(value)`` (base 10)
+        str -> float  : ``float(value)``
+        str -> bool   : explicit allowlist -- see _TRUTHY_STRINGS /
+                        _FALSY_STRINGS, case-insensitive.
+        str -> str    : no-op (returned unchanged)
+
+    Any other combination (e.g. ``list`` -> ``int``, or an unsupported
+    ``expected_type``) triggers the same ConfigError a straight
+    ``isinstance`` mismatch would -- the caller's validation branch
+    still fires.
+
+    Args:
+        value: The resolved config value for ``key``. Usually a str
+            from an env var; may also be an already-typed TOML value
+            that happens to match ``expected_type``.
+        expected_type: The type the schema declared for ``key``
+            (``int``, ``float``, ``bool``, or ``str``).
+        key: The dotted config key -- used to build an actionable
+            error message so the operator knows which env var to fix.
+
+    Returns:
+        The coerced value, or ``value`` unchanged if it already
+        matches ``expected_type`` (including the no-op ``str`` case).
+
+    Raises:
+        ConfigError: If ``value`` is a string but does not parse as
+            ``expected_type`` (e.g. ``"not-a-number"`` for int, or a
+            bool token outside the explicit allowlist). The message
+            names ``key`` and the offending value verbatim so the
+            operator can locate the misconfigured env var.
+    """
+    # Fast-path: if the value already has the expected type, nothing
+    # to do. ``bool`` is a subclass of ``int`` in Python, so we check
+    # bool first to avoid accidentally treating ``True`` as "already
+    # an int" when the schema wanted a bool.
+    if expected_type is bool and isinstance(value, bool):
+        return value
+    # ``not isinstance(value, bool)`` on the int branch keeps ``True``
+    # from matching ``type: int`` via the bool-is-subclass-of-int
+    # quirk -- a schema that says ``int`` should reject a bool value.
+    if expected_type is int and isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if expected_type is float and isinstance(value, float):
+        return value
+    if expected_type is str and isinstance(value, str):
+        return value
+
+    # From here on, coercion only makes sense when the source value is
+    # a string (that's the env-var case). Non-string mismatches fall
+    # through unchanged so the caller's isinstance check raises the
+    # familiar "type X, expected Y" ConfigError. We deliberately do
+    # NOT coerce non-string sources (e.g. a TOML ``port = "8080"``
+    # with schema ``int`` used to raise; now it also coerces, which is
+    # a strictly-better outcome since the user's intent is clear).
+    if not isinstance(value, str):
+        return value
+
+    # String -> bool: explicit allowlist, case-insensitive. We lowercase
+    # once and compare against two frozensets so the token list stays
+    # in one place (the module-level constants) and the implementation
+    # is O(1) per lookup.
+    if expected_type is bool:
+        token = value.strip().lower()
+        if token in _TRUTHY_STRINGS:
+            return True
+        if token in _FALSY_STRINGS:
+            return False
+        # Build the error message from the actual token sets so the
+        # operator sees the same list the code accepts, and future
+        # additions can't drift out of sync with the message.
+        raise ConfigError(
+            f"Config key '{key}' has value {value!r}, which is not a "
+            f"valid boolean. Accepted tokens (case-insensitive): "
+            f"{sorted(_TRUTHY_STRINGS)} for true, "
+            f"{sorted(_FALSY_STRINGS)} for false."
+        )
+
+    # String -> int: base 10. ``int("3.14")`` raises ValueError, which
+    # we catch and re-raise as ConfigError so callers only ever have
+    # to handle one exception type from load_config().
+    if expected_type is int:
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise ConfigError(
+                f"Config key '{key}' has value {value!r}, which cannot "
+                f"be parsed as int: {exc}."
+            ) from exc
+
+    # String -> float: accepts scientific notation, signed, decimals.
+    if expected_type is float:
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise ConfigError(
+                f"Config key '{key}' has value {value!r}, which cannot "
+                f"be parsed as float: {exc}."
+            ) from exc
+
+    # Unsupported target type (e.g. ``type: list``, ``type: dict``).
+    # Rather than guess, return the value unchanged and let the
+    # isinstance() check in the caller flag the mismatch. Pinning the
+    # "stdlib scalar types only" rule here means adding new coercion
+    # targets is an explicit code edit, not a silent behaviour change.
+    return value
+
+
 def _key_to_env_suffix(key: str) -> str:
     """Convert a dotted config key to an env var suffix.
 
@@ -604,11 +740,26 @@ def load_config(
             if key not in config and "default" in key_schema:
                 config[key] = key_schema["default"]
 
-            # Type check: validate the resolved value matches the declared type.
-            # This catches mistakes like bucket = 42 in TOML when a string was
-            # expected, or a stale env var with the wrong format.
+            # Type check + coercion: env vars always arrive as strings
+            # (``os.environ`` is ``dict[str, str]``), but schemas want
+            # typed values. Coerce at the schema layer so env-sourced
+            # ``"8080"`` -> ``8080`` for ``type: int``, etc. See
+            # _coerce_value for the supported coercion table and the
+            # exact bool-token allowlist. Values that already match
+            # ``expected_type`` pass through unchanged (TOML natively
+            # carries int/float/bool so no round-trip through str).
             expected_type = key_schema.get("type")
             if expected_type and key in config:
+                # Secrets are wrapped AFTER this validation pass, so a
+                # ``secret: True`` value is still a plain str/int/etc.
+                # here and coerces normally.
+                config[key] = _coerce_value(config[key], expected_type, key)
+                # Post-coercion isinstance check is still the
+                # authoritative gate. If _coerce_value returned the
+                # value unchanged (unsupported target type, or a
+                # non-string source that didn't match), this catches
+                # the mismatch with the original "type X, expected Y"
+                # message callers depend on.
                 if not isinstance(config[key], expected_type):
                     raise ConfigError(
                         f"Config key '{key}' has type {type(config[key]).__name__}, "

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -179,13 +179,20 @@ def _coerce_value(
             return int(value)
         except ValueError as exc:
             # For secret keys, also suppress the underlying ValueError
-            # text (``exc``) -- Python's int() error includes the raw
-            # token, so echoing ``exc`` would defeat the redaction.
+            # text (``exc``) AND suppress the exception chain -- Python's
+            # int() error message embeds the raw token, so both the
+            # chained ``__cause__`` and any naive ``str(exc)`` would
+            # defeat the redaction when a traceback is surfaced. Using
+            # ``from None`` breaks the chain so the raw token doesn't
+            # survive on the exception's ``__cause__`` attribute.
             detail = "invalid literal" if is_secret else str(exc)
-            raise ConfigError(
+            message = (
                 f"Config key '{key}' has value {display_value}, which cannot "
                 f"be parsed as int: {detail}."
-            ) from exc
+            )
+            if is_secret:
+                raise ConfigError(message) from None
+            raise ConfigError(message) from exc
 
     # String -> float: accepts scientific notation, signed, decimals.
     if expected_type is float:
@@ -193,12 +200,17 @@ def _coerce_value(
             return float(value)
         except ValueError as exc:
             # Same redaction rationale as the int branch: float()'s
-            # ValueError message contains the raw token.
+            # ValueError message contains the raw token, and both the
+            # message AND the exception chain must be scrubbed for
+            # secret keys.
             detail = "invalid literal" if is_secret else str(exc)
-            raise ConfigError(
+            message = (
                 f"Config key '{key}' has value {display_value}, which cannot "
                 f"be parsed as float: {detail}."
-            ) from exc
+            )
+            if is_secret:
+                raise ConfigError(message) from None
+            raise ConfigError(message) from exc
 
     # Unsupported target type (e.g. ``type: list``, ``type: dict``).
     # Rather than guess, return the value unchanged and let the
@@ -803,9 +815,29 @@ def load_config(
                 # non-string source that didn't match), this catches
                 # the mismatch with the original "type X, expected Y"
                 # message callers depend on.
-                if not isinstance(config[key], expected_type):
+                #
+                # Special case: ``bool`` is a subclass of ``int`` in
+                # Python, so ``isinstance(True, int)`` is True and a
+                # TOML value like ``port = true`` would silently pass
+                # ``type: int`` validation. Explicitly reject bool
+                # values when the schema wants an int (and vice versa
+                # -- an int shouldn't satisfy ``type: bool``) to match
+                # the intent of the type declaration.
+                current = config[key]
+                wrong_bool_for_int = (
+                    expected_type is int and isinstance(current, bool)
+                )
+                wrong_int_for_bool = (
+                    expected_type is bool and not isinstance(current, bool)
+                    and isinstance(current, int)
+                )
+                if (
+                    not isinstance(current, expected_type)
+                    or wrong_bool_for_int
+                    or wrong_int_for_bool
+                ):
                     raise ConfigError(
-                        f"Config key '{key}' has type {type(config[key]).__name__}, "
+                        f"Config key '{key}' has type {type(current).__name__}, "
                         f"expected {expected_type.__name__}. "
                         f"Check the value in {repo_config_path} or {user_config_path}."
                     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -797,6 +797,87 @@ class TestEnvVarTypes:
         assert config["port"] == 9090
         assert isinstance(config["port"], int)
 
+    def test_toml_bool_rejected_for_int_schema(self, tmp_path: Path):
+        """TOML `port = true` should NOT satisfy schema `type: int`.
+
+        Pins a subtle Python gotcha: ``bool`` subclasses ``int``, so a
+        naive ``isinstance(value, int)`` check would accept ``True`` /
+        ``False`` for an int-typed schema key. The type intent of
+        ``type: int`` is "numeric integer", not "any int subclass
+        including bool". This test locks the rejection so a future
+        refactor can't re-introduce the bool-is-int footgun.
+        """
+        from clickwork.config import ConfigError, load_config
+
+        config_path = tmp_path / ".my-tool.toml"
+        config_path.write_text('[default]\nport = true\n')
+
+        schema = {"port": {"type": int}}
+
+        with pytest.raises(ConfigError, match="type bool, expected int"):
+            load_config(
+                project_name="my-tool",
+                repo_config_path=config_path,
+                user_config_path=tmp_path / "user.toml",
+                schema=schema,
+            )
+
+    def test_toml_int_rejected_for_bool_schema(self, tmp_path: Path):
+        """Symmetric to the bool-for-int rejection.
+
+        Pins that ``type: bool`` rejects plain integers (0/1/etc.). A
+        caller wanting to accept "0 or 1 as a bool" must either
+        coerce to str first or use the string-allowlist bool forms
+        (``"1"`` / ``"0"`` are in the coercion allowlist).
+        """
+        from clickwork.config import ConfigError, load_config
+
+        config_path = tmp_path / ".my-tool.toml"
+        config_path.write_text('[default]\ndebug = 1\n')
+
+        schema = {"debug": {"type": bool}}
+
+        with pytest.raises(ConfigError, match="type int, expected bool"):
+            load_config(
+                project_name="my-tool",
+                repo_config_path=config_path,
+                user_config_path=tmp_path / "user.toml",
+                schema=schema,
+            )
+
+    def test_secret_coercion_error_does_not_chain_raw_value(self, tmp_path: Path, monkeypatch):
+        """Chained ConfigError's ``__cause__`` must not carry the raw token.
+
+        For ``secret: True`` keys, coercion errors use ``raise ... from None``
+        (not ``from exc``) so the underlying ``ValueError`` -- whose message
+        embeds the raw token that couldn't be parsed -- doesn't survive on
+        the exception's ``__cause__``. A traceback printer that walks the
+        cause chain would otherwise leak the token despite the redacted
+        top-level message.
+        """
+        from clickwork.config import ConfigError, load_config
+
+        monkeypatch.setenv("MY_TOOL_TOKEN", "not-a-number-at-all")
+
+        config_path = tmp_path / ".my-tool.toml"
+        config_path.write_text("[default]\n")
+
+        schema = {"token": {"type": int, "secret": True}}
+
+        with pytest.raises(ConfigError) as excinfo:
+            load_config(
+                project_name="my-tool",
+                repo_config_path=config_path,
+                user_config_path=tmp_path / "user.toml",
+                schema=schema,
+            )
+
+        # Redacted top-level message: no leakage.
+        assert "not-a-number-at-all" not in str(excinfo.value)
+        # Exception chain: must be broken for secrets. Either no cause,
+        # or the cause is None (both satisfy "no leak via __cause__").
+        assert excinfo.value.__cause__ is None
+
 
 class TestEnvVarDottedKeys:
     """Auto-prefix env var resolution handles dotted keys correctly."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -652,6 +652,124 @@ class TestEnvVarTypes:
         assert config["port"] == 8080
         assert isinstance(config["port"], int)
 
+    def test_toml_string_value_coerced_by_schema(self, tmp_path: Path):
+        """A TOML string literal (``port = "8080"``) is coerced to ``int``.
+
+        The coercion rule is uniform across string sources: env vars,
+        TOML string literals, and user-supplied overrides all funnel
+        through the same ``_coerce_value`` call. Pinning this case
+        prevents a future refactor from narrowing coercion to env-only
+        (the original intent of the change in #41) without catching
+        the broader behavior the implementation actually ships.
+        """
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        # Note the QUOTES: TOML parses this as a string, not an int.
+        config_file.write_text('[default]\nport = "8080"\n')
+
+        schema = {
+            "port": {"type": int},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["port"] == 8080
+        assert isinstance(config["port"], int)
+
+    def test_toml_string_value_coerced_to_bool(self, tmp_path: Path):
+        """Sibling of the int case: a quoted TOML string coerces to bool.
+
+        Pins that the bool allowlist (_TRUTHY_STRINGS / _FALSY_STRINGS)
+        applies to TOML-sourced strings the same way it applies to env
+        vars. A user who wrote ``debug = "true"`` in TOML (instead of
+        the native ``debug = true``) should still get ``True`` under
+        ``type: bool`` rather than a type-mismatch ConfigError.
+        """
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text('[default]\ndebug = "true"\n')
+
+        schema = {
+            "debug": {"type": bool},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["debug"] is True
+
+    def test_secret_coercion_error_redacts_value(self, tmp_path: Path, monkeypatch):
+        """A failing coercion on a ``secret: True`` key redacts the value.
+
+        Without this redaction, a misconfigured secret env var (e.g.
+        ``CLI_TOKEN=not-a-number`` against ``type: int``) would
+        surface the raw token in the ConfigError message and leak
+        into logs / stderr / CI output. Pinned so a future edit to
+        the error path can't reintroduce the leak.
+        """
+        from clickwork.config import load_config, ConfigError
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        # Use an obviously-unique sentinel so the assertion below is
+        # decisive -- if this token ever shows up in the exception
+        # message, the redaction is broken.
+        secret_token = "not-a-number-SENTINEL-d41d8cd9"
+        monkeypatch.setenv("TEST_CLI_TOKEN", secret_token)
+
+        schema = {
+            "token": {"type": int, "secret": True},
+        }
+        with pytest.raises(ConfigError) as excinfo:
+            load_config(
+                project_name="test-cli",
+                repo_config_path=config_file,
+                schema=schema,
+            )
+        msg = str(excinfo.value)
+        # The redaction marker MUST appear (positive confirmation
+        # the branch fired), and the raw token MUST NOT appear
+        # (negative confirmation nothing leaked).
+        assert "<redacted>" in msg
+        assert secret_token not in msg
+        # The key name should still appear so the operator knows
+        # which env var to fix.
+        assert "token" in msg
+
+    def test_non_secret_coercion_error_still_echoes_value(self, tmp_path: Path, monkeypatch):
+        """Redaction is scoped to secret keys -- non-secret errors keep the value.
+
+        The operator debugging a non-secret misconfiguration needs to
+        see the bad value to fix it. Pinning this path prevents an
+        over-eager redaction from swallowing useful diagnostics for
+        regular keys.
+        """
+        from clickwork.config import load_config, ConfigError
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_PORT", "not-a-port")
+
+        schema = {
+            "port": {"type": int},
+        }
+        with pytest.raises(ConfigError) as excinfo:
+            load_config(
+                project_name="test-cli",
+                repo_config_path=config_file,
+                schema=schema,
+            )
+        msg = str(excinfo.value)
+        assert "not-a-port" in msg
+        assert "<redacted>" not in msg
+
     def test_explicit_env_mapping_coerced_same_as_auto_prefix(self, tmp_path: Path, monkeypatch):
         """Coercion applies regardless of which env-var mechanism sourced the value.
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -388,6 +388,298 @@ class TestSecretWrapping:
         assert config["bucket"] == "my-bucket"
 
 
+class TestEnvVarTypes:
+    """Env vars always arrive as strings; schema ``type`` drives coercion.
+
+    WHY this section exists: environment variables at the OS level are
+    *always* strings -- ``os.environ`` is ``dict[str, str]``, the C-level
+    ``environ`` array is a list of ``NAME=value`` byte strings. clickwork
+    preserves that: a value sourced from an env var enters the config
+    dict as a ``str``, full stop. The schema's ``type`` field is what
+    tells the loader the intended type, and the loader coerces
+    str -> int / float / bool at the schema layer before the validation
+    check runs. If coercion fails (e.g. ``"not-a-number"`` for
+    ``type: int``), ``ConfigError`` is raised with a specific, actionable
+    message naming the key and the offending value.
+
+    Pinning this behavior means plugin authors can declare typed config
+    keys and feed them from env vars or CI secrets without every
+    consumer re-implementing ``int(os.environ["PORT"])`` locally.
+
+    These tests lock the contract for 1.0. Do not relax them without
+    updating ``docs/GUIDE.md`` + ``docs/API_POLICY.md`` in the same PR.
+    """
+
+    def test_env_var_without_schema_stays_string(self, tmp_path: Path, monkeypatch):
+        """An env var override with no schema entry enters config dict AS a string.
+
+        Even when the env var value LOOKS like an int ("42"), without
+        a schema type declaration the loader cannot know the intended
+        Python type and must leave the env-sourced value as a string.
+        Plugin authors who want typed values declare ``type:`` in the
+        schema -- that's the explicit opt-in.
+
+        The TOML seed key makes the auto-prefix lookup trip: without
+        a schema, the loader only checks env vars for keys already
+        present in config files, so we need ``port`` in ``[default]``
+        for the env override to apply.
+        """
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        # Seed the key so the auto-prefix env lookup has something to
+        # override. The TOML value is itself a string ("0"); the env
+        # var wins and replaces it with "42" -- both remain strings
+        # because no schema declared a type.
+        config_file.write_text('[default]\nport = "0"\n')
+
+        monkeypatch.setenv("TEST_CLI_PORT", "42")
+
+        # No schema -- loader has no type hint, so the env string passes
+        # through untouched.
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+        )
+        assert config["port"] == "42"
+        assert isinstance(config["port"], str)
+
+    def test_env_var_coerced_to_int_by_schema(self, tmp_path: Path, monkeypatch):
+        """schema type=int + env var "8080" -> config["port"] == 8080 (int).
+
+        This is the "strings in, schema coerces" contract: env delivers
+        a string, schema declares int, loader produces int.
+        """
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_PORT", "8080")
+
+        schema = {
+            "port": {"type": int},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["port"] == 8080
+        assert isinstance(config["port"], int)
+
+    def test_env_var_coerced_to_float_by_schema(self, tmp_path: Path, monkeypatch):
+        """schema type=float + env var "3.14" -> config["ratio"] == 3.14."""
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_RATIO", "3.14")
+
+        schema = {
+            "ratio": {"type": float},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["ratio"] == 3.14
+        assert isinstance(config["ratio"], float)
+
+    def test_env_var_type_str_stays_string(self, tmp_path: Path, monkeypatch):
+        """schema type=str + env var "42" -> config["tag"] == "42" (unchanged).
+
+        Pins that declaring ``type: str`` is a no-op for env-sourced
+        values -- no "helpful" number-detection. Strings stay strings.
+        """
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_TAG", "42")
+
+        schema = {
+            "tag": {"type": str},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["tag"] == "42"
+        assert isinstance(config["tag"], str)
+
+    def test_env_var_int_coercion_failure_raises(self, tmp_path: Path, monkeypatch):
+        """Un-coercible env value raises ConfigError naming key + value.
+
+        "not-a-number" cannot be parsed as int. The loader must fail
+        loudly rather than silently dropping the value or defaulting to
+        zero. The message names the key so the operator can fix the
+        offending env var.
+        """
+        from clickwork.config import load_config, ConfigError
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_PORT", "not-a-number")
+
+        schema = {
+            "port": {"type": int},
+        }
+        with pytest.raises(ConfigError, match="port"):
+            load_config(
+                project_name="test-cli",
+                repo_config_path=config_file,
+                schema=schema,
+            )
+
+    def test_env_var_float_coercion_failure_raises(self, tmp_path: Path, monkeypatch):
+        """Un-coercible float value raises ConfigError."""
+        from clickwork.config import load_config, ConfigError
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_RATIO", "definitely-not-a-float")
+
+        schema = {
+            "ratio": {"type": float},
+        }
+        with pytest.raises(ConfigError, match="ratio"):
+            load_config(
+                project_name="test-cli",
+                repo_config_path=config_file,
+                schema=schema,
+            )
+
+    @pytest.mark.parametrize("truthy", ["true", "True", "TRUE", "1", "yes", "YES", "on", "On"])
+    def test_env_var_bool_truthy_strings_coerce_to_true(self, tmp_path: Path, monkeypatch, truthy: str):
+        """Explicit truthy-string set: true/1/yes/on (case-insensitive).
+
+        WHY pin the exact set: Python's ``bool("false")`` is ``True``
+        (non-empty string), which is the classic foot-cannon. We pick a
+        short, explicit, case-insensitive allowlist that matches shell
+        conventions and reject everything else. No surprises.
+        """
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_ENABLED", truthy)
+
+        schema = {
+            "enabled": {"type": bool},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["enabled"] is True
+
+    @pytest.mark.parametrize("falsy", ["false", "False", "FALSE", "0", "no", "NO", "off", "Off"])
+    def test_env_var_bool_falsy_strings_coerce_to_false(self, tmp_path: Path, monkeypatch, falsy: str):
+        """Explicit falsy-string set: false/0/no/off (case-insensitive)."""
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_ENABLED", falsy)
+
+        schema = {
+            "enabled": {"type": bool},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["enabled"] is False
+
+    def test_env_var_bool_ambiguous_string_raises(self, tmp_path: Path, monkeypatch):
+        """Unknown bool-ish string raises ConfigError.
+
+        "maybe" isn't in the truthy or falsy set. Rather than guessing,
+        raise so the operator fixes the env var to use one of the
+        accepted tokens. This prevents the classic ``bool("false") ==
+        True`` foot-cannon.
+        """
+        from clickwork.config import load_config, ConfigError
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("TEST_CLI_ENABLED", "maybe")
+
+        schema = {
+            "enabled": {"type": bool},
+        }
+        with pytest.raises(ConfigError, match="enabled"):
+            load_config(
+                project_name="test-cli",
+                repo_config_path=config_file,
+                schema=schema,
+            )
+
+    def test_toml_int_value_unchanged_by_schema(self, tmp_path: Path):
+        """TOML already-typed int values are not re-coerced.
+
+        TOML carries types natively (``port = 8080`` parses as int).
+        The schema type check still runs (catches mismatches), but no
+        coercion pass touches values that already match their declared
+        type. Pinned so a future "always coerce" refactor can't silently
+        round-trip TOML ints through ``str`` -> ``int``.
+        """
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\nport = 8080\n")
+
+        schema = {
+            "port": {"type": int},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["port"] == 8080
+        assert isinstance(config["port"], int)
+
+    def test_explicit_env_mapping_coerced_same_as_auto_prefix(self, tmp_path: Path, monkeypatch):
+        """Coercion applies regardless of which env-var mechanism sourced the value.
+
+        Both the explicit ``env: "CF_PORT"`` mapping and the auto-prefix
+        ``TEST_CLI_PORT`` path deliver strings from ``os.environ``. The
+        schema ``type`` pass runs after the merge, so it coerces either
+        source uniformly. Pinning both paths prevents a future refactor
+        from coercing one but not the other.
+        """
+        from clickwork.config import load_config
+
+        config_file = tmp_path / ".test-cli.toml"
+        config_file.write_text("[default]\n")
+
+        monkeypatch.setenv("CF_PORT", "9090")
+
+        schema = {
+            "port": {"type": int, "env": "CF_PORT"},
+        }
+        config = load_config(
+            project_name="test-cli",
+            repo_config_path=config_file,
+            schema=schema,
+        )
+        assert config["port"] == 9090
+        assert isinstance(config["port"], int)
+
+
 class TestEnvVarDottedKeys:
     """Auto-prefix env var resolution handles dotted keys correctly."""
 


### PR DESCRIPTION
`BREAKING:` env-sourced config values are now coerced to the schema-declared type (int/float/bool/str) rather than raising `ConfigError` on type mismatch.

## Before vs after

`TEST_CLI_PORT="8080"` + schema `{port: {type: int}}`:
- **Before:** `ConfigError("type str, expected int")`
- **After:** `ctx.config["port"] == 8080` (int)

## Coercion table (stdlib-only)

- **int** — `int(value, 10)`; ConfigError on parse failure
- **float** — `float(value)`; ConfigError on parse failure
- **bool** — case-insensitive allowlist `{true, 1, yes, on}` / `{false, 0, no, off}`; anything else raises (deliberately avoids Python's `bool('false') == True` foot-cannon)
- **str** — no-op
- other types — fall through to existing `isinstance` mismatch (no behavior change)

Values already matching the schema type pass through unchanged, so TOML configs with typed values are unaffected.

## Migration

Callers asserting on the pre-coercion `ConfigError` must remove those assertions. Code using `type: str` + manual `int(...)` still works; migrating to native `type: int` is optional. Full entry will land in the 0.x → 1.0 migration guide (#56).

## Test plan

- [x] 25 parametrized cases across 11 methods in `test_config.py::TestEnvVarTypes` — per-type coercion, per-type failure, bool allowlist both directions, no-schema baseline
- [x] `mise exec -- python -m pytest tests/ -q` → 282 passed

Roadmap: Wave 2a #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)