### PR TITLE
feat: BREAKING — clickwork loggers preserve host's root logging config (Fixes #43)

### DIFF
--- a/src/clickwork/_logging.py
+++ b/src/clickwork/_logging.py
@@ -1,13 +1,23 @@
 """Logging setup for clickwork CLIs.
 
 This module is the *host-friendly* logging entry point for clickwork. The
-name of the game here: **never silently override a host application's
-logging configuration.** clickwork is a library as well as a CLI
-framework; when a host app (think: an orbit-admin plugin imported from
-another tool, or a test harness that calls ``clickwork.http.get`` directly)
-has already run ``logging.basicConfig()`` or installed its own root
-handler, clickwork must NOT attach a second handler that duplicates every
-log line.
+name of the game here: **respect the host's root logging configuration,
+and only touch loggers inside the ``clickwork`` namespace.** clickwork is
+a library as well as a CLI framework; when a host app (think: an
+orbit-admin plugin imported from another tool, or a test harness that
+calls ``clickwork.http.get`` directly) has already run
+``logging.basicConfig()`` or installed its own root handler, clickwork
+must NOT attach a second stderr handler that duplicates every log line.
+
+Scope of clickwork's overrides: we DO set the ``propagate`` flag to
+``True`` on the ``clickwork`` logger and any CLI-named logger, because
+records flowing up to the root is how the host-preserving design
+delivers output. A host that wants to break propagation intentionally
+(e.g., it attaches its own handler to ``clickwork`` and sets
+``propagate=False`` to avoid double-emission to root) should do that
+AFTER calling ``setup_logging()``; the helper is meant for the common
+case and documents this tradeoff rather than trying to autodetect
+every host configuration pattern.
 
 ## The rules
 
@@ -163,15 +173,15 @@ def setup_logging(
             #   setup_logging()              # still attached to our handler
             # produces duplicate output again (the clickwork stderr handler
             # AND the propagated record reaching the host's root handler).
-            # We remove only stderr StreamHandlers -- NullHandler is fine
-            # to leave in place (no output) and a host-attached handler on
-            # the clickwork logger is not ours to evict.
+            # We identify OUR handlers by the ``_clickwork_owned``
+            # attribute set at attach time below, NOT by ``handler.stream
+            # is sys.stderr`` -- the latter is fragile under frameworks
+            # that swap ``sys.stderr`` (pytest capture, uvicorn, etc.).
+            # NullHandler is fine to leave in place (no output); any host-
+            # attached handler on the clickwork logger is not ours to
+            # evict (no ``_clickwork_owned`` flag).
             for existing in list(logger.handlers):
-                if (
-                    isinstance(existing, logging.StreamHandler)
-                    and not isinstance(existing, logging.NullHandler)
-                    and getattr(existing, "stream", None) is sys.stderr
-                ):
+                if getattr(existing, "_clickwork_owned", False):
                     logger.removeHandler(existing)
             # Records propagate up to the host's root handler. Do NOT
             # attach a StreamHandler -- that's what caused the
@@ -189,22 +199,28 @@ def setup_logging(
             fmt = "%(name)s %(message)s"
         formatter = logging.Formatter(fmt)
 
-        # Find an existing stderr StreamHandler we previously attached so
-        # re-invocations (e.g., nested test runs, or the CLI callback
-        # running twice in-process) just update its level + format
-        # rather than doubling up.
+        # Find an existing clickwork-owned StreamHandler so re-invocations
+        # (nested test runs, or the CLI callback running twice in-process)
+        # update its level + format rather than stacking. Identity is
+        # tracked via the ``_clickwork_owned`` marker attribute (set when
+        # we first attach). Again, we deliberately don't compare
+        # ``existing.stream is sys.stderr`` -- pytest capture replaces
+        # ``sys.stderr`` so the identity check would miss our own handler.
         stream_handler = next(
             (
                 existing
                 for existing in logger.handlers
-                if isinstance(existing, logging.StreamHandler)
+                if getattr(existing, "_clickwork_owned", False)
+                and isinstance(existing, logging.StreamHandler)
                 and not isinstance(existing, logging.NullHandler)
-                and getattr(existing, "stream", None) is sys.stderr
             ),
             None,
         )
         if stream_handler is None:
             stream_handler = logging.StreamHandler(sys.stderr)
+            # Mark this handler as ours so future calls can find/evict it
+            # via a robust identity check that survives sys.stderr swaps.
+            stream_handler._clickwork_owned = True  # type: ignore[attr-defined]
             logger.addHandler(stream_handler)
 
         stream_handler.setLevel(level)

--- a/src/clickwork/_logging.py
+++ b/src/clickwork/_logging.py
@@ -122,11 +122,31 @@ def setup_logging(
             ``"orbit-admin"``). clickwork also mirrors the level onto
             the shared ``"clickwork"`` logger so framework-internal
             modules (``clickwork.http``, ``clickwork.discovery``, ...)
-            honor the same verbosity.
+            honor the same verbosity. MUST be a non-empty string --
+            ``""`` resolves to the root logger via
+            ``logging.getLogger("")`` and configuring root would
+            violate the host-preserving contract.
 
     Returns:
         The ``logging.Logger`` instance for ``name``.
+
+    Raises:
+        ValueError: If ``name`` is an empty string. Callers must pass
+            a non-empty project name (e.g. ``"orbit-admin"``).
     """
+    # Reject empty name up front so the rest of the function can
+    # assume it's configuring a named, non-root logger. Without this
+    # guard, ``setup_logging(name="")`` would silently start mutating
+    # the root logger's handlers/level/propagate -- exactly the
+    # embedding-host-owned state we've pledged not to touch.
+    if not name:
+        raise ValueError(
+            "setup_logging(name=...) must be a non-empty string; "
+            "logging.getLogger('') resolves to the root logger and "
+            "configuring root would violate clickwork's "
+            "host-preserving contract. Pass your project name "
+            "(e.g. 'orbit-admin') instead."
+        )
     # --quiet always wins over --verbose (they're mutually exclusive at
     # the CLI level, but handle it defensively here too).
     if quiet:
@@ -224,6 +244,15 @@ def setup_logging(
             # via a robust identity check that survives sys.stderr swaps.
             stream_handler._clickwork_owned = True  # type: ignore[attr-defined]
             logger.addHandler(stream_handler)
+        else:
+            # Reusing an existing clickwork-owned handler: re-bind its
+            # stream to the CURRENT sys.stderr. Pytest capture, uvicorn,
+            # and similar tools swap sys.stderr between invocations --
+            # the old stream reference inside the handler becomes stale
+            # and subsequent records go to a detached stream the test
+            # harness isn't watching. Rebinding here keeps the handler
+            # writing to whatever "current stderr" means right now.
+            stream_handler.stream = sys.stderr
 
         stream_handler.setLevel(level)
         stream_handler.setFormatter(formatter)

--- a/src/clickwork/_logging.py
+++ b/src/clickwork/_logging.py
@@ -1,13 +1,15 @@
 """Logging setup for clickwork CLIs.
 
 This module is the *host-friendly* logging entry point for clickwork. The
-name of the game here: **respect the host's root logging configuration,
-and only touch loggers inside the ``clickwork`` namespace.** clickwork is
-a library as well as a CLI framework; when a host app (think: an
-orbit-admin plugin imported from another tool, or a test harness that
-calls ``clickwork.http.get`` directly) has already run
-``logging.basicConfig()`` or installed its own root handler, clickwork
-must NOT attach a second stderr handler that duplicates every log line.
+name of the game here: **respect the host's root logging configuration.
+The loggers we touch are the ``clickwork`` namespace and the CLI-named
+logger the caller passes to ``setup_logging()`` (typically the project
+name -- e.g. ``"orbit-admin"``).** clickwork is a library as well as a
+CLI framework; when a host app (think: an orbit-admin plugin imported
+from another tool, or a test harness that calls ``clickwork.http.get``
+directly) has already run ``logging.basicConfig()`` or installed its
+own root handler, clickwork must NOT attach a second stderr handler
+that duplicates every log line.
 
 Scope of clickwork's overrides: we DO set the ``propagate`` flag to
 ``True`` on the ``clickwork`` logger and any CLI-named logger, because

--- a/src/clickwork/_logging.py
+++ b/src/clickwork/_logging.py
@@ -52,7 +52,13 @@ import sys
 # propagation and reach this handler implicitly; we don't need to attach
 # a separate ``NullHandler`` to each descendant.
 _clickwork_logger = logging.getLogger("clickwork")
-_clickwork_logger.addHandler(logging.NullHandler())
+# Idempotent NullHandler attach: in reload-heavy test harnesses (or any
+# environment that re-imports clickwork), unconditionally appending here
+# would accumulate duplicate NullHandlers across imports. A single
+# NullHandler is enough -- they're no-op -- so skip the append when one
+# is already on the logger.
+if not any(isinstance(h, logging.NullHandler) for h in _clickwork_logger.handlers):
+    _clickwork_logger.addHandler(logging.NullHandler())
 # Explicit for clarity even though ``True`` is the stdlib default -- we
 # want readers of this file to see, without spelunking, that records flow
 # up to the root logger where a host handler (if installed) can pick them
@@ -148,10 +154,28 @@ def setup_logging(
             logger.addHandler(logging.NullHandler())
 
         if host_configured:
-            # Host owns output. We've set level + NullHandler; records
-            # propagate up to the host's root handler. Do NOT attach a
-            # StreamHandler -- that's what causes the duplicate-output
-            # bug this rewrite exists to fix (#43).
+            # Host owns output. Before returning, evict any
+            # clickwork-owned stderr ``StreamHandler`` that an earlier
+            # bare-root call to ``setup_logging()`` may have attached.
+            # Without this eviction, a sequence of
+            #   setup_logging()              # bare root -> attach stderr handler
+            #   logging.basicConfig()        # host takes over root
+            #   setup_logging()              # still attached to our handler
+            # produces duplicate output again (the clickwork stderr handler
+            # AND the propagated record reaching the host's root handler).
+            # We remove only stderr StreamHandlers -- NullHandler is fine
+            # to leave in place (no output) and a host-attached handler on
+            # the clickwork logger is not ours to evict.
+            for existing in list(logger.handlers):
+                if (
+                    isinstance(existing, logging.StreamHandler)
+                    and not isinstance(existing, logging.NullHandler)
+                    and getattr(existing, "stream", None) is sys.stderr
+                ):
+                    logger.removeHandler(existing)
+            # Records propagate up to the host's root handler. Do NOT
+            # attach a StreamHandler -- that's what caused the
+            # duplicate-output bug this rewrite exists to fix (#43).
             return
 
         # Standalone CLI mode: no host handler, so clickwork is

--- a/src/clickwork/_logging.py
+++ b/src/clickwork/_logging.py
@@ -1,10 +1,32 @@
 """Logging setup for clickwork CLIs.
 
-Provides a single setup_logging() function that configures a named logger
-with the correct verbosity level and a consistent output format. Color
-support is automatic based on terminal detection.
+This module is the *host-friendly* logging entry point for clickwork. The
+name of the game here: **never silently override a host application's
+logging configuration.** clickwork is a library as well as a CLI
+framework; when a host app (think: an orbit-admin plugin imported from
+another tool, or a test harness that calls ``clickwork.http.get`` directly)
+has already run ``logging.basicConfig()`` or installed its own root
+handler, clickwork must NOT attach a second handler that duplicates every
+log line.
 
-The verbosity mapping:
+## The rules
+
+1.  Every ``clickwork`` (and descendant) logger gets a ``NullHandler``
+    baseline so stdlib's "no handler configured" warning never fires and
+    records aren't dropped *just because* no handler exists.
+2.  ``propagate=True`` (stdlib default) is preserved so records bubble up
+    to the root logger, where the host's handler -- if any -- picks them
+    up.
+3.  ``setup_logging()`` only attaches a ``StreamHandler`` when the root
+    logger has zero handlers. If the host has configured root logging,
+    we leave it alone. This is the core of the BREAKING change vs 0.2:
+    previously clickwork unconditionally attached its own handler,
+    causing duplicate output in embedded contexts.
+4.  clickwork *never* calls ``logging.basicConfig()`` or touches the root
+    logger's handler list. That's the host's prerogative.
+
+## Verbosity mapping (unchanged from 0.2)
+
   - Default (no flags): WARNING -- only problems
   - -v (verbose=1): INFO -- progress updates
   - -vv (verbose=2): DEBUG -- implementation details
@@ -16,24 +38,79 @@ from __future__ import annotations
 import logging
 import sys
 
+# ---------------------------------------------------------------------------
+# Module-load baseline
+# ---------------------------------------------------------------------------
+#
+# As soon as this module is imported, attach a ``NullHandler`` to the
+# top-level ``clickwork`` logger. This is the pattern recommended by the
+# Python logging HOWTO for libraries: it prevents the "No handlers could
+# be found for logger X" warning on stderr when a host hasn't configured
+# logging at all, without assuming anything about what the host WANTS.
+#
+# Children (``clickwork.http``, ``clickwork.discovery``, ...) inherit via
+# propagation and reach this handler implicitly; we don't need to attach
+# a separate ``NullHandler`` to each descendant.
+_clickwork_logger = logging.getLogger("clickwork")
+_clickwork_logger.addHandler(logging.NullHandler())
+# Explicit for clarity even though ``True`` is the stdlib default -- we
+# want readers of this file to see, without spelunking, that records flow
+# up to the root logger where a host handler (if installed) can pick them
+# up.
+_clickwork_logger.propagate = True
+
+
+def _host_root_is_configured() -> bool:
+    """Return True if the root logger already has any handler attached.
+
+    This is the signal that a host app has opted into its own logging
+    configuration (e.g., via ``logging.basicConfig()``, an explicit
+    ``root.addHandler(...)``, or a framework like ``uvicorn`` /
+    ``structlog`` that installs root handlers at import time).
+
+    When this returns True, ``setup_logging()`` must NOT attach its own
+    ``StreamHandler`` -- doing so would produce duplicate output for
+    every record that propagates up to the configured root handler.
+    """
+    return len(logging.getLogger().handlers) > 0
+
 
 def setup_logging(
     verbose: int = 0,
     quiet: bool = False,
     name: str = "clickwork",
 ) -> logging.Logger:
-    """Configure and return a logger with the appropriate verbosity level.
+    """Configure the clickwork logging stack for a CLI invocation.
+
+    Host-preserving behavior (new in 1.0): if the root logger already has
+    a handler attached (e.g., the embedding application called
+    ``logging.basicConfig()`` or configured its own), this function will
+    NOT attach a stderr handler. It will still set the verbosity level
+    on the clickwork-namespace loggers so ``-v`` / ``-q`` continue to
+    work as users expect, but emission is delegated to the host's root
+    handler via propagation.
+
+    If no host handler is installed, ``setup_logging()`` attaches a
+    stderr ``StreamHandler`` with clickwork's format so standalone CLI
+    use still prints records.
+
+    The public signature is unchanged from 0.2, so 0.2-era call sites
+    continue to work -- only the side effects differ.
 
     Args:
         verbose: How many -v flags were passed (0, 1, or 2+).
         quiet: Whether --quiet was passed. Overrides verbose.
-        name: Logger name, typically the CLI project name (e.g., "orbit-admin").
+        name: Logger name, typically the CLI project name (e.g.,
+            ``"orbit-admin"``). clickwork also mirrors the level onto
+            the shared ``"clickwork"`` logger so framework-internal
+            modules (``clickwork.http``, ``clickwork.discovery``, ...)
+            honor the same verbosity.
 
     Returns:
-        A configured logging.Logger instance.
+        The ``logging.Logger`` instance for ``name``.
     """
-    # --quiet always wins over --verbose (they're mutually exclusive at the
-    # CLI level, but we handle it defensively here too).
+    # --quiet always wins over --verbose (they're mutually exclusive at
+    # the CLI level, but handle it defensively here too).
     if quiet:
         level = logging.ERROR
     elif verbose >= 2:
@@ -43,39 +120,79 @@ def setup_logging(
     else:
         level = logging.WARNING
 
-    def configure_logger(logger: logging.Logger) -> None:
-        """Attach or update a stderr handler with the requested verbosity."""
-        logger.setLevel(level)
+    # Decide ONCE whether the host has configured root. We snapshot this
+    # up front because the decision applies symmetrically to the named
+    # CLI logger and the shared "clickwork" logger -- we don't want to
+    # attach to one and skip the other based on state drift mid-call.
+    host_configured = _host_root_is_configured()
 
-        # Use color if stderr is a real terminal (not piped/redirected).
+    def configure_logger(logger: logging.Logger) -> None:
+        """Set level + baseline handlers for a clickwork-namespace logger.
+
+        Always attaches a ``NullHandler`` so the "no handlers" warning
+        can't fire even if a host clears the root logger between imports.
+        Only attaches a ``StreamHandler`` when the host hasn't taken
+        responsibility for root -- see ``_host_root_is_configured()``.
+        """
+        logger.setLevel(level)
+        # Keep propagation on so records reach the host root handler
+        # when one exists. This is the default, but restate it in case
+        # 0.2-era callers (or tests) disabled propagation manually.
+        logger.propagate = True
+
+        # Ensure a NullHandler is present so stdlib never complains about
+        # missing handlers. Idempotent: we only add one if there isn't
+        # already a NullHandler on this logger.
+        has_null = any(isinstance(h, logging.NullHandler) for h in logger.handlers)
+        if not has_null:
+            logger.addHandler(logging.NullHandler())
+
+        if host_configured:
+            # Host owns output. We've set level + NullHandler; records
+            # propagate up to the host's root handler. Do NOT attach a
+            # StreamHandler -- that's what causes the duplicate-output
+            # bug this rewrite exists to fix (#43).
+            return
+
+        # Standalone CLI mode: no host handler, so clickwork is
+        # responsible for actually printing records. Attach a stderr
+        # StreamHandler with the usual format, but do it idempotently so
+        # repeated calls to ``setup_logging()`` don't stack handlers.
         use_color = hasattr(sys.stderr, "isatty") and sys.stderr.isatty()
         if use_color:
             fmt = "\033[2m%(name)s\033[0m %(message)s"
         else:
             fmt = "%(name)s %(message)s"
-
         formatter = logging.Formatter(fmt)
-        handler = next(
+
+        # Find an existing stderr StreamHandler we previously attached so
+        # re-invocations (e.g., nested test runs, or the CLI callback
+        # running twice in-process) just update its level + format
+        # rather than doubling up.
+        stream_handler = next(
             (
-                existing_handler
-                for existing_handler in logger.handlers
-                if isinstance(existing_handler, logging.StreamHandler)
-                and getattr(existing_handler, "stream", None) is sys.stderr
+                existing
+                for existing in logger.handlers
+                if isinstance(existing, logging.StreamHandler)
+                and not isinstance(existing, logging.NullHandler)
+                and getattr(existing, "stream", None) is sys.stderr
             ),
             None,
         )
-        if handler is None:
-            handler = logging.StreamHandler(sys.stderr)
-            logger.addHandler(handler)
+        if stream_handler is None:
+            stream_handler = logging.StreamHandler(sys.stderr)
+            logger.addHandler(stream_handler)
 
-        handler.setLevel(level)
-        handler.setFormatter(formatter)
+        stream_handler.setLevel(level)
+        stream_handler.setFormatter(formatter)
 
     logger = logging.getLogger(name)
     configure_logger(logger)
 
-    # Framework modules log to the shared clickwork namespace, so keep that
-    # logger aligned with the CLI logger as well.
+    # Mirror the level + handler policy onto the shared ``clickwork``
+    # logger so framework modules (``clickwork.http``, ...) honor the
+    # same verbosity. Skipped when the named CLI logger IS the clickwork
+    # logger -- nothing to mirror.
     if name != "clickwork":
         configure_logger(logging.getLogger("clickwork"))
 

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -56,7 +56,7 @@ def _coerce_value(
     value: object,
     expected_type: type,
     key: str,
-    key_schema: dict | None = None,
+    key_schema: dict[str, Any] | None = None,
 ) -> object:
     """Coerce a string value to ``expected_type``.
 
@@ -802,9 +802,7 @@ def load_config(
                 # here and coerces normally. Pass the schema entry into
                 # _coerce_value so the error path can redact the value
                 # for secret keys instead of echoing the raw token.
-                config[key] = _coerce_value(
-                    config[key], expected_type, key, key_schema
-                )
+                config[key] = _coerce_value(config[key], expected_type, key, key_schema)
                 # Post-coercion isinstance check is still the
                 # authoritative gate. If _coerce_value returned the
                 # value unchanged (unsupported target type, or a
@@ -820,11 +818,10 @@ def load_config(
                 # -- an int shouldn't satisfy ``type: bool``) to match
                 # the intent of the type declaration.
                 current = config[key]
-                wrong_bool_for_int = (
-                    expected_type is int and isinstance(current, bool)
-                )
+                wrong_bool_for_int = expected_type is int and isinstance(current, bool)
                 wrong_int_for_bool = (
-                    expected_type is bool and not isinstance(current, bool)
+                    expected_type is bool
+                    and not isinstance(current, bool)
                     and isinstance(current, int)
                 )
                 if (

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -390,9 +390,7 @@ class TestVersionFlag:
         from clickwork.cli import create_cli
 
         expected_version = importlib.metadata.version("clickwork")
-        cli = create_cli(
-            name="test-cli", commands_dir=tmp_path, package_name="clickwork"
-        )
+        cli = create_cli(name="test-cli", commands_dir=tmp_path, package_name="clickwork")
         runner = CliRunner()
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
@@ -429,6 +427,7 @@ class TestVersionFlag:
         # enough to contain only one version is enough to pin the
         # precedence rule.
         import importlib.metadata
+
         real_version = importlib.metadata.version("clickwork")
         if real_version != "override-9.9.9":  # sanity: they're different
             assert real_version not in result.output, (
@@ -734,9 +733,9 @@ class TestConvenienceMethods:
         assert result.exit_code == 0, f"CLI failed: {result.output!r}"
         assert received["returncode"] == 0
         captured = capfd.readouterr()
-        assert captured.out == "ctx-forwarded-token", (
-            f"Expected stdin payload to round-trip through ctx.run; got {captured.out!r}"
-        )
+        assert (
+            captured.out == "ctx-forwarded-token"
+        ), f"Expected stdin payload to round-trip through ctx.run; got {captured.out!r}"
 
     def test_ctx_run_with_confirm_forwards_stdin_text(self, tmp_path: Path, capfd):
         """ctx.run_with_confirm(stdin_text=...) must also forward.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -519,7 +519,7 @@ class TestEnvVarTypes:
         zero. The message names the key so the operator can fix the
         offending env var.
         """
-        from clickwork.config import load_config, ConfigError
+        from clickwork.config import ConfigError, load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text("[default]\n")
@@ -538,7 +538,7 @@ class TestEnvVarTypes:
 
     def test_env_var_float_coercion_failure_raises(self, tmp_path: Path, monkeypatch):
         """Un-coercible float value raises ConfigError."""
-        from clickwork.config import load_config, ConfigError
+        from clickwork.config import ConfigError, load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text("[default]\n")
@@ -556,7 +556,9 @@ class TestEnvVarTypes:
             )
 
     @pytest.mark.parametrize("truthy", ["true", "True", "TRUE", "1", "yes", "YES", "on", "On"])
-    def test_env_var_bool_truthy_strings_coerce_to_true(self, tmp_path: Path, monkeypatch, truthy: str):
+    def test_env_var_bool_truthy_strings_coerce_to_true(
+        self, tmp_path: Path, monkeypatch, truthy: str
+    ):
         """Explicit truthy-string set: true/1/yes/on (case-insensitive).
 
         WHY pin the exact set: Python's ``bool("false")`` is ``True``
@@ -582,7 +584,9 @@ class TestEnvVarTypes:
         assert config["enabled"] is True
 
     @pytest.mark.parametrize("falsy", ["false", "False", "FALSE", "0", "no", "NO", "off", "Off"])
-    def test_env_var_bool_falsy_strings_coerce_to_false(self, tmp_path: Path, monkeypatch, falsy: str):
+    def test_env_var_bool_falsy_strings_coerce_to_false(
+        self, tmp_path: Path, monkeypatch, falsy: str
+    ):
         """Explicit falsy-string set: false/0/no/off (case-insensitive)."""
         from clickwork.config import load_config
 
@@ -609,7 +613,7 @@ class TestEnvVarTypes:
         accepted tokens. This prevents the classic ``bool("false") ==
         True`` foot-cannon.
         """
-        from clickwork.config import load_config, ConfigError
+        from clickwork.config import ConfigError, load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text("[default]\n")
@@ -711,7 +715,7 @@ class TestEnvVarTypes:
         into logs / stderr / CI output. Pinned so a future edit to
         the error path can't reintroduce the leak.
         """
-        from clickwork.config import load_config, ConfigError
+        from clickwork.config import ConfigError, load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text("[default]\n")
@@ -749,7 +753,7 @@ class TestEnvVarTypes:
         over-eager redaction from swallowing useful diagnostics for
         regular keys.
         """
-        from clickwork.config import load_config, ConfigError
+        from clickwork.config import ConfigError, load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text("[default]\n")
@@ -809,7 +813,7 @@ class TestEnvVarTypes:
         from clickwork.config import ConfigError, load_config
 
         config_path = tmp_path / ".my-tool.toml"
-        config_path.write_text('[default]\nport = true\n')
+        config_path.write_text("[default]\nport = true\n")
 
         schema = {"port": {"type": int}}
 
@@ -832,7 +836,7 @@ class TestEnvVarTypes:
         from clickwork.config import ConfigError, load_config
 
         config_path = tmp_path / ".my-tool.toml"
-        config_path.write_text('[default]\ndebug = 1\n')
+        config_path.write_text("[default]\ndebug = 1\n")
 
         schema = {"debug": {"type": bool}}
 

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -582,9 +582,9 @@ class TestAddGlobalOptionEntryPointPropagation:
             f"Expected UsageError (exit 2) on nested-subcommand flag collision; "
             f"got exit={result.exit_code}, output={result.output!r}"
         )
-        assert "sub" in result.output, (
-            f"Error message must name the colliding subcommand path; got output={result.output!r}"
-        )
+        assert (
+            "sub" in result.output
+        ), f"Error message must name the colliding subcommand path; got output={result.output!r}"
         assert "--json" in result.output
 
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -4,44 +4,221 @@ The logging module configures Python's stdlib logging with consistent formatting
 verbosity levels driven by CLI flags, and automatic color detection. It's the
 first thing the CLI sets up, so it must be reliable and have no side effects
 when imported.
-"""
 
+## Host-preserving behavior (1.0, #43)
+
+A second cluster of tests below (``TestHostPreservingBehavior``) exercises
+the 1.0 semantic change: clickwork must NOT double-emit records when a
+host application has already configured root logging. The stdlib logging
+module is global mutable state, so these tests rigorously reset handlers
+and propagation flags around every case to keep tests order-independent.
+"""
+import io
 import logging
+
+import pytest
+
+
+@pytest.fixture
+def reset_logging():
+    """Snapshot-and-restore the clickwork + root logger state per test.
+
+    Python's logging module is global -- handlers installed in one test
+    persist into the next unless we actively clean up. This fixture
+    captures handlers / level / propagate for the loggers we touch, and
+    restores them after the test runs regardless of pass/fail. It's
+    opt-in (tests request it explicitly) because the pre-existing
+    ``TestSetupLogging`` cases don't need it; they only check return-
+    value attributes.
+    """
+    logger_names = ["clickwork", "clickwork.http", "", "my-cli", "test_default",
+                    "test_v1", "test_v2", "test_quiet", "test_host",
+                    "test_nullfallback", "test_propagate", "test_no_dup"]
+    snapshots = []
+    for name in logger_names:
+        logger = logging.getLogger(name)
+        snapshots.append((
+            logger,
+            list(logger.handlers),
+            logger.level,
+            logger.propagate,
+        ))
+
+    yield
+
+    for logger, handlers, level, propagate in snapshots:
+        logger.handlers = handlers
+        logger.setLevel(level)
+        logger.propagate = propagate
 
 
 class TestSetupLogging:
     """setup_logging() configures the root logger based on CLI verbosity flags."""
 
-    def test_default_is_warning_level(self):
+    def test_default_is_warning_level(self, reset_logging):
         """With no flags, only warnings and above should show."""
         from clickwork._logging import setup_logging
 
         logger = setup_logging(verbose=0, quiet=False, name="test_default")
         assert logger.level == logging.WARNING
 
-    def test_verbose_1_is_info(self):
+    def test_verbose_1_is_info(self, reset_logging):
         """Single -v flag should show INFO messages."""
         from clickwork._logging import setup_logging
 
         logger = setup_logging(verbose=1, quiet=False, name="test_v1")
         assert logger.level == logging.INFO
 
-    def test_verbose_2_is_debug(self):
+    def test_verbose_2_is_debug(self, reset_logging):
         """Double -vv flag should show DEBUG messages."""
         from clickwork._logging import setup_logging
 
         logger = setup_logging(verbose=2, quiet=False, name="test_v2")
         assert logger.level == logging.DEBUG
 
-    def test_quiet_is_error_only(self):
+    def test_quiet_is_error_only(self, reset_logging):
         """--quiet should suppress everything below ERROR."""
         from clickwork._logging import setup_logging
 
         logger = setup_logging(verbose=0, quiet=True, name="test_quiet")
         assert logger.level == logging.ERROR
 
-    def test_returns_named_logger(self):
+    def test_returns_named_logger(self, reset_logging):
         from clickwork._logging import setup_logging
 
         logger = setup_logging(verbose=0, quiet=False, name="my-cli")
         assert logger.name == "my-cli"
+
+
+class TestHostPreservingBehavior:
+    """1.0 #43 -- don't double-emit records when the host configured root logging.
+
+    The key invariant: when a host has installed any handler on the root
+    logger (e.g., via ``logging.basicConfig()``), clickwork's
+    ``setup_logging()`` must not attach its OWN stderr handler.
+    Otherwise a ``clickwork.http`` record emits twice -- once via the
+    clickwork stderr handler, once via propagation to the host's root
+    handler.
+    """
+
+    def test_no_duplicate_logs_when_host_configured_basicconfig(self, reset_logging):
+        """Simulates a host that called basicConfig() before importing clickwork.
+
+        After ``setup_logging()``, emitting a record from the shared
+        ``clickwork`` logger should reach the host's root handler
+        exactly once. If clickwork attached its own StreamHandler we'd
+        see two emissions.
+        """
+        # Reset root's handlers -- pytest's logging plugin installs its
+        # own by default, which would count as "host configured" before
+        # we want it to. We install our OWN root handler to simulate the
+        # embedding-application scenario.
+        root = logging.getLogger()
+        root.handlers = []
+
+        buffer = io.StringIO()
+        host_handler = logging.StreamHandler(buffer)
+        host_handler.setLevel(logging.DEBUG)
+        host_handler.setFormatter(logging.Formatter("HOST:%(name)s:%(message)s"))
+        root.addHandler(host_handler)
+        root.setLevel(logging.DEBUG)
+
+        # Host has called basicConfig-equivalent. Now clickwork runs.
+        from clickwork._logging import setup_logging
+        setup_logging(verbose=1, quiet=False, name="test_no_dup")
+
+        # Emit a record on the shared clickwork logger -- this is what
+        # framework modules (http, discovery) do.
+        logging.getLogger("clickwork").info("hello from clickwork")
+
+        # Exactly one "hello from clickwork" should appear in the host's
+        # buffer. If clickwork installed its own StreamHandler on the
+        # "clickwork" logger AND propagation is on, we'd see two. If it
+        # installed one and disabled propagation, we'd see one but the
+        # host wouldn't get it at all. The correct behavior is: host
+        # handler gets exactly one copy.
+        output = buffer.getvalue()
+        assert output.count("hello from clickwork") == 1, (
+            f"Expected exactly one emission; got: {output!r}"
+        )
+        # And we should also verify no clickwork-attached StreamHandler
+        # was installed on the "clickwork" logger when the host was
+        # already configured. (NullHandler is fine / expected.)
+        clickwork_logger = logging.getLogger("clickwork")
+        non_null_stream_handlers = [
+            h for h in clickwork_logger.handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.NullHandler)
+        ]
+        assert non_null_stream_handlers == [], (
+            "clickwork should not attach its own StreamHandler when "
+            f"the host configured root; found: {non_null_stream_handlers}"
+        )
+
+    def test_null_handler_fallback_when_host_unconfigured(self, reset_logging, capsys):
+        """With no host config, clickwork must not crash AND must not spam stdout.
+
+        The library-HOWTO pattern is: attach NullHandler so stdlib
+        doesn't warn "No handlers could be found", and let the CLI's
+        ``setup_logging()`` attach a real stderr handler for standalone
+        use. Critically, importing clickwork alone (without calling
+        setup_logging) must NEVER print to stdout, because that'd
+        corrupt any CLI that produces machine-readable stdout.
+        """
+        # Clear the root handlers so we simulate a "no host config"
+        # environment -- pytest would otherwise have installed its own.
+        root = logging.getLogger()
+        root.handlers = []
+
+        # Re-import clickwork's logging module fresh so the module-load
+        # side effects re-run and we can observe them.
+        import importlib
+        import clickwork._logging
+        importlib.reload(clickwork._logging)
+
+        # After the module reloads, the clickwork logger MUST have a
+        # NullHandler attached. This is the "baseline" that prevents
+        # stdlib's "no handlers" warning.
+        clickwork_logger = logging.getLogger("clickwork")
+        has_null = any(isinstance(h, logging.NullHandler) for h in clickwork_logger.handlers)
+        assert has_null, (
+            f"clickwork logger must have a NullHandler baseline; "
+            f"handlers are: {clickwork_logger.handlers}"
+        )
+
+        # Emitting a record before setup_logging is ever called should
+        # produce no stdout (it can go to stderr via stdlib lastResort
+        # for WARNING+, but should never hit stdout). The critical
+        # assertion here is "no error raised" -- the NullHandler means
+        # the record is accepted and silently dropped.
+        logging.getLogger("clickwork").debug("pre-setup debug record")
+        logging.getLogger("clickwork").info("pre-setup info record")
+
+        captured = capsys.readouterr()
+        assert captured.out == "", (
+            f"clickwork must not emit to stdout when no handlers are "
+            f"configured; got stdout: {captured.out!r}"
+        )
+
+    def test_propagate_is_true_for_clickwork_loggers(self, reset_logging):
+        """The clickwork logger must propagate so host root handlers see records.
+
+        If a previous clickwork version set propagate=False (to "own"
+        output), embedding that version in a host that configured root
+        logging would silently swallow all clickwork records -- they'd
+        hit clickwork's private StreamHandler but never reach the
+        host's root handler. The 1.0 contract is propagate=True.
+        """
+        import importlib
+        import clickwork._logging
+        importlib.reload(clickwork._logging)
+
+        assert logging.getLogger("clickwork").propagate is True
+
+        # Also verify propagate stays True after setup_logging() runs,
+        # since setup_logging explicitly restates the value.
+        from clickwork._logging import setup_logging
+        setup_logging(verbose=0, quiet=False, name="test_propagate")
+        assert logging.getLogger("clickwork").propagate is True
+        # And the named CLI logger should also propagate.
+        assert logging.getLogger("test_propagate").propagate is True

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -29,10 +29,15 @@ def reset_logging():
     Python's logging module is global -- handlers installed in one test
     persist into the next unless we actively clean up. This fixture
     captures handlers / level / propagate for the loggers we touch, and
-    restores them after the test runs regardless of pass/fail. It's
-    opt-in (tests request it explicitly) because the pre-existing
-    ``TestSetupLogging`` cases don't need it; they only check return-
-    value attributes.
+    restores them after the test runs regardless of pass/fail. Every
+    test in this file requests it explicitly, including the pre-existing
+    ``TestSetupLogging`` cases that originally didn't need it -- once
+    ``TestHostPreservingBehavior`` started mutating root, all tests need
+    the snapshot-and-restore to stay order-independent. We keep the
+    fixture explicit (not ``autouse=True``) so new tests in this file
+    declare the dependency clearly; adding a test that forgets
+    ``reset_logging`` should break obviously instead of inheriting
+    cleanup silently.
     """
     logger_names = [
         "clickwork",
@@ -297,8 +302,12 @@ class TestHostPreservingBehavior:
         )
 
         # Emit a record and confirm the installed handler actually
-        # prints it. pytest's capsys captures fd-level stderr so this
-        # works even with the _clickwork_owned marker-based seam.
+        # prints it. pytest's capsys captures SYS-LEVEL stderr (writes
+        # via sys.stderr) rather than fd-level -- that's exactly what we
+        # want here because setup_logging's StreamHandler is bound to
+        # sys.stderr (it doesn't write to fd 2 directly). If we needed
+        # fd-level capture instead we'd use capfd, but that's not the
+        # contract this test is pinning.
         logger.warning("standalone warn record")
         captured = capsys.readouterr()
         assert "standalone warn record" in captured.err

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -231,3 +231,83 @@ class TestHostPreservingBehavior:
         assert logging.getLogger("clickwork").propagate is True
         # And the named CLI logger should also propagate.
         assert logging.getLogger("test_propagate").propagate is True
+
+    def test_standalone_mode_attaches_stderr_handler(self, reset_logging, capsys):
+        """No host root handlers -> setup_logging attaches a stderr StreamHandler.
+
+        Pins the bare-script path: when a consumer runs a clickwork CLI
+        directly (no embedding framework, no ``logging.basicConfig()``),
+        clickwork MUST attach its own stderr StreamHandler so records
+        actually get printed. Without this path the record would only
+        propagate to root, which has no handlers, and stdlib would fall
+        back to the "handler of last resort" or silently drop below-WARN
+        records.
+        """
+        # Start from a bare root: no handlers at all.
+        root = logging.getLogger()
+        root.handlers = []
+        # Reload so the module-load baseline runs against the cleared
+        # root. Without the reload, module state from an earlier test
+        # could pre-attach handlers and mask the "bare root" scenario.
+        import importlib
+        import clickwork._logging
+        importlib.reload(clickwork._logging)
+
+        from clickwork._logging import setup_logging
+
+        logger = setup_logging(verbose=1, quiet=False, name="test_standalone")
+
+        # The named CLI logger should have a clickwork-owned
+        # StreamHandler attached. Identified by the marker attribute we
+        # set at attach time (more robust than ``handler.stream is
+        # sys.stderr``, which breaks under pytest capture).
+        owned_handlers = [
+            h
+            for h in logger.handlers
+            if getattr(h, "_clickwork_owned", False)
+            and isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.NullHandler)
+        ]
+        assert len(owned_handlers) == 1, (
+            f"standalone mode must attach exactly one clickwork-owned "
+            f"StreamHandler; got: {logger.handlers}"
+        )
+
+        # Emit a record and confirm the installed handler actually
+        # prints it. pytest's capsys captures fd-level stderr so this
+        # works even with the _clickwork_owned marker-based seam.
+        logger.warning("standalone warn record")
+        captured = capsys.readouterr()
+        assert "standalone warn record" in captured.err
+
+    def test_stderr_handler_marker_survives_setup_logging_reinvocation(self, reset_logging):
+        """setup_logging is idempotent: a second call updates-in-place, not stacks.
+
+        Without the ``_clickwork_owned`` marker, the old
+        ``handler.stream is sys.stderr`` identity check would fail under
+        frameworks that swap ``sys.stderr`` (pytest capture, uvicorn's
+        stream wrapping, etc.). This test confirms a second
+        ``setup_logging()`` call finds and updates the original handler
+        via the marker instead of stacking a duplicate.
+        """
+        root = logging.getLogger()
+        root.handlers = []
+        import importlib
+        import clickwork._logging
+        importlib.reload(clickwork._logging)
+
+        from clickwork._logging import setup_logging
+
+        name = "test_no_dup"
+        setup_logging(verbose=0, quiet=False, name=name)
+        setup_logging(verbose=2, quiet=False, name=name)  # second call, -vv
+        setup_logging(verbose=1, quiet=False, name=name)  # third call, -v
+
+        logger = logging.getLogger(name)
+        owned = [h for h in logger.handlers if getattr(h, "_clickwork_owned", False)]
+        assert len(owned) == 1, (
+            f"setup_logging must not stack handlers on re-invocation; "
+            f"got: {logger.handlers}"
+        )
+        # Final level should reflect the LAST call (-v -> INFO).
+        assert owned[0].level == logging.INFO

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -178,8 +178,7 @@ class TestHostPreservingBehavior:
         non_null_stream_handlers = [
             h
             for h in clickwork_logger.handlers
-            if isinstance(h, logging.StreamHandler)
-            and not isinstance(h, logging.NullHandler)
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.NullHandler)
         ]
         assert non_null_stream_handlers == [], (
             "clickwork should not attach its own StreamHandler when "
@@ -204,6 +203,7 @@ class TestHostPreservingBehavior:
         # Re-import clickwork's logging module fresh so the module-load
         # side effects re-run and we can observe them.
         import importlib
+
         import clickwork._logging
 
         importlib.reload(clickwork._logging)
@@ -212,9 +212,7 @@ class TestHostPreservingBehavior:
         # NullHandler attached. This is the "baseline" that prevents
         # stdlib's "no handlers" warning.
         clickwork_logger = logging.getLogger("clickwork")
-        has_null = any(
-            isinstance(h, logging.NullHandler) for h in clickwork_logger.handlers
-        )
+        has_null = any(isinstance(h, logging.NullHandler) for h in clickwork_logger.handlers)
         assert has_null, (
             f"clickwork logger must have a NullHandler baseline; "
             f"handlers are: {clickwork_logger.handlers}"
@@ -244,6 +242,7 @@ class TestHostPreservingBehavior:
         host's root handler. The 1.0 contract is propagate=True.
         """
         import importlib
+
         import clickwork._logging
 
         importlib.reload(clickwork._logging)
@@ -277,6 +276,7 @@ class TestHostPreservingBehavior:
         # root. Without the reload, module state from an earlier test
         # could pre-attach handlers and mask the "bare root" scenario.
         import importlib
+
         import clickwork._logging
 
         importlib.reload(clickwork._logging)
@@ -312,9 +312,7 @@ class TestHostPreservingBehavior:
         captured = capsys.readouterr()
         assert "standalone warn record" in captured.err
 
-    def test_stderr_handler_marker_survives_setup_logging_reinvocation(
-        self, reset_logging
-    ):
+    def test_stderr_handler_marker_survives_setup_logging_reinvocation(self, reset_logging):
         """setup_logging is idempotent: a second call updates-in-place, not stacks.
 
         Without the ``_clickwork_owned`` marker, the old
@@ -327,6 +325,7 @@ class TestHostPreservingBehavior:
         root = logging.getLogger()
         root.handlers = []
         import importlib
+
         import clickwork._logging
 
         importlib.reload(clickwork._logging)
@@ -341,8 +340,7 @@ class TestHostPreservingBehavior:
         logger = logging.getLogger(name)
         owned = [h for h in logger.handlers if getattr(h, "_clickwork_owned", False)]
         assert len(owned) == 1, (
-            f"setup_logging must not stack handlers on re-invocation; "
-            f"got: {logger.handlers}"
+            f"setup_logging must not stack handlers on re-invocation; " f"got: {logger.handlers}"
         )
         # Final level should reflect the LAST call (-v -> INFO).
         assert owned[0].level == logging.INFO

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -15,6 +15,7 @@ host application has already configured root logging. The stdlib logging
 module is global mutable state, so these tests rigorously reset handlers
 and propagation flags around every case to keep tests order-independent.
 """
+
 import io
 import logging
 
@@ -33,18 +34,32 @@ def reset_logging():
     ``TestSetupLogging`` cases don't need it; they only check return-
     value attributes.
     """
-    logger_names = ["clickwork", "clickwork.http", "", "my-cli", "test_default",
-                    "test_v1", "test_v2", "test_quiet", "test_host",
-                    "test_nullfallback", "test_propagate", "test_no_dup"]
+    logger_names = [
+        "clickwork",
+        "clickwork.http",
+        "",  # root, snapshotted so we can fully restore handler list
+        "my-cli",
+        "test_default",
+        "test_v1",
+        "test_v2",
+        "test_quiet",
+        "test_host",
+        "test_nullfallback",
+        "test_propagate",
+        "test_no_dup",
+        "test_standalone",
+    ]
     snapshots = []
     for name in logger_names:
         logger = logging.getLogger(name)
-        snapshots.append((
-            logger,
-            list(logger.handlers),
-            logger.level,
-            logger.propagate,
-        ))
+        snapshots.append(
+            (
+                logger,
+                list(logger.handlers),
+                logger.level,
+                logger.propagate,
+            )
+        )
 
     yield
 
@@ -134,6 +149,7 @@ class TestHostPreservingBehavior:
 
         # Host has called basicConfig-equivalent. Now clickwork runs.
         from clickwork._logging import setup_logging
+
         setup_logging(verbose=1, quiet=False, name="test_no_dup")
 
         # Emit a record on the shared clickwork logger -- this is what
@@ -147,15 +163,16 @@ class TestHostPreservingBehavior:
         # host wouldn't get it at all. The correct behavior is: host
         # handler gets exactly one copy.
         output = buffer.getvalue()
-        assert output.count("hello from clickwork") == 1, (
-            f"Expected exactly one emission; got: {output!r}"
-        )
+        assert (
+            output.count("hello from clickwork") == 1
+        ), f"Expected exactly one emission; got: {output!r}"
         # And we should also verify no clickwork-attached StreamHandler
         # was installed on the "clickwork" logger when the host was
         # already configured. (NullHandler is fine / expected.)
         clickwork_logger = logging.getLogger("clickwork")
         non_null_stream_handlers = [
-            h for h in clickwork_logger.handlers
+            h
+            for h in clickwork_logger.handlers
             if isinstance(h, logging.StreamHandler)
             and not isinstance(h, logging.NullHandler)
         ]
@@ -183,13 +200,16 @@ class TestHostPreservingBehavior:
         # side effects re-run and we can observe them.
         import importlib
         import clickwork._logging
+
         importlib.reload(clickwork._logging)
 
         # After the module reloads, the clickwork logger MUST have a
         # NullHandler attached. This is the "baseline" that prevents
         # stdlib's "no handlers" warning.
         clickwork_logger = logging.getLogger("clickwork")
-        has_null = any(isinstance(h, logging.NullHandler) for h in clickwork_logger.handlers)
+        has_null = any(
+            isinstance(h, logging.NullHandler) for h in clickwork_logger.handlers
+        )
         assert has_null, (
             f"clickwork logger must have a NullHandler baseline; "
             f"handlers are: {clickwork_logger.handlers}"
@@ -220,6 +240,7 @@ class TestHostPreservingBehavior:
         """
         import importlib
         import clickwork._logging
+
         importlib.reload(clickwork._logging)
 
         assert logging.getLogger("clickwork").propagate is True
@@ -227,6 +248,7 @@ class TestHostPreservingBehavior:
         # Also verify propagate stays True after setup_logging() runs,
         # since setup_logging explicitly restates the value.
         from clickwork._logging import setup_logging
+
         setup_logging(verbose=0, quiet=False, name="test_propagate")
         assert logging.getLogger("clickwork").propagate is True
         # And the named CLI logger should also propagate.
@@ -251,6 +273,7 @@ class TestHostPreservingBehavior:
         # could pre-attach handlers and mask the "bare root" scenario.
         import importlib
         import clickwork._logging
+
         importlib.reload(clickwork._logging)
 
         from clickwork._logging import setup_logging
@@ -280,7 +303,9 @@ class TestHostPreservingBehavior:
         captured = capsys.readouterr()
         assert "standalone warn record" in captured.err
 
-    def test_stderr_handler_marker_survives_setup_logging_reinvocation(self, reset_logging):
+    def test_stderr_handler_marker_survives_setup_logging_reinvocation(
+        self, reset_logging
+    ):
         """setup_logging is idempotent: a second call updates-in-place, not stacks.
 
         Without the ``_clickwork_owned`` marker, the old
@@ -294,6 +319,7 @@ class TestHostPreservingBehavior:
         root.handlers = []
         import importlib
         import clickwork._logging
+
         importlib.reload(clickwork._logging)
 
         from clickwork._logging import setup_logging

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -2,8 +2,10 @@
 
 The logging module configures Python's stdlib logging with consistent formatting,
 verbosity levels driven by CLI flags, and automatic color detection. It's the
-first thing the CLI sets up, so it must be reliable and have no side effects
-when imported.
+first thing the CLI sets up, so it must be reliable and avoid surprising
+import-time side effects; the only expected import-time behavior is attaching
+a ``NullHandler`` baseline to the ``clickwork`` logger (library convention --
+see the module docstring in ``clickwork/_logging.py`` for the rationale).
 
 ## Host-preserving behavior (1.0, #43)
 
@@ -53,7 +55,14 @@ def reset_logging():
 
 
 class TestSetupLogging:
-    """setup_logging() configures the root logger based on CLI verbosity flags."""
+    """setup_logging() configures the named logger (not root) based on CLI verbosity flags.
+
+    These tests predate the 1.0 host-preserving rewrite. They only check
+    return-value attributes (``logger.level``, formatter choice, etc.),
+    so they didn't need updating for the new host-preserving behavior.
+    See ``TestHostPreservingBehavior`` below for the root-touches-nothing
+    assertions.
+    """
 
     def test_default_is_warning_level(self, reset_logging):
         """With no flags, only warnings and above should show."""

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -404,9 +404,9 @@ class TestRunWithSecrets:
 
         # Error message must reference the position (index 1) so the
         # caller knows which arg to fix.
-        assert "1" in str(exc_info.value), (
-            f"Expected error to name the offending position, got: {exc_info.value!r}"
-        )
+        assert "1" in str(
+            exc_info.value
+        ), f"Expected error to name the offending position, got: {exc_info.value!r}"
         # The raw secret value must NOT appear anywhere in the error -- a
         # regression here would mean our "don't leak secrets" helper leaks
         # secrets in its own rejection path.
@@ -511,9 +511,9 @@ class TestRunWithSecrets:
 
         # Flatten all captured log messages for substring checks.
         all_log_text = "\n".join(rec.getMessage() for rec in caplog.records)
-        assert "<redacted>" in all_log_text, (
-            f"Expected '<redacted>' marker in log output, got: {all_log_text!r}"
-        )
+        assert (
+            "<redacted>" in all_log_text
+        ), f"Expected '<redacted>' marker in log output, got: {all_log_text!r}"
         # The env-var NAME stays visible so operators can see which keys
         # were set.
         assert "K" in all_log_text
@@ -556,9 +556,9 @@ class TestRunWithSecrets:
             )
 
         all_log_text = "\n".join(rec.getMessage() for rec in caplog.records)
-        assert accidental_plaintext not in all_log_text, (
-            f"Non-secret env value leaked into log: {all_log_text!r}"
-        )
+        assert (
+            accidental_plaintext not in all_log_text
+        ), f"Non-secret env value leaked into log: {all_log_text!r}"
         # Non-secret VALUES also hidden: "us-east-1" must not appear either.
         assert "us-east-1" not in all_log_text
         # But the NAMES must still be visible so operators can see shape.


### PR DESCRIPTION
`BREAKING:` `clickwork.setup_logging()` no longer attaches its own stderr `StreamHandler` when the host has already configured the root logger. This eliminates the duplicate-log-lines bug that appeared in any host using `logging.basicConfig()`, structlog, etc.

## New behavior

- `clickwork` logger gets a `NullHandler` baseline at import time.
- `propagate=True` so records reach the root logger if the host configured one.
- `setup_logging()` attaches a `StreamHandler` ONLY when the root logger has no handlers (bare-script case).

Public signature of `setup_logging(verbose, quiet, name)` is unchanged — 0.2 callers keep working. Only the observable output changes: one line instead of two.

## Migration

Hosts relying on double-output (unlikely) can install their own stderr handler on the `clickwork` logger explicitly. Full entry will land in the 0.x → 1.0 migration guide (#56).

## Test plan

- [x] `test_no_duplicate_logs_when_host_configured_basicconfig` (main pin)
- [x] `test_null_handler_fallback_when_host_unconfigured`
- [x] `test_propagate_is_true_for_clickwork_loggers`
- [x] New `reset_logging` fixture isolates global logging state between tests
- [x] `mise exec -- python -m pytest tests/ -q` → 260 passed

Roadmap: Wave 2a #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)