### PR TITLE
feat: clickwork._deprecated decorator for post-1.0 evolution (Fixes #47)

### DIFF
--- a/docs/API_POLICY.md
+++ b/docs/API_POLICY.md
@@ -146,13 +146,22 @@ than 1.2, giving callers at least one version of overlap where the
 symbol still works and also emits a `DeprecationWarning`.
 
 Deprecations use the `deprecated(since, removed_in, reason)` decorator
-that lives at `clickwork._deprecated.deprecated`. That module is a
-Wave 2 deliverable tracked by issue #47; it does not exist in the
-codebase yet. Plugin authors should not import from
-`clickwork._deprecated` directly (the underscore makes it private).
+that lives at `clickwork._deprecated.deprecated`. The module is
+intentionally underscore-prefixed and is NOT re-exported from
+`clickwork/__init__.py`; plugin authors should not import from it.
 The decorator is an internal tool clickwork uses on its own public
 surface; it exists so every deprecation emits a consistent warning
-with a pointer to the replacement.
+with a pointer to the replacement. The warning fires on the first
+*call* to the deprecated symbol (never at import time) and is
+deduplicated per symbol using a module-qualified key, so each
+deprecated name warns exactly once per process regardless of how many
+times it's invoked. Every warning message begins with a
+`clickwork:` prefix so downstream test suites can filter narrowly via
+pytest's message-field regex (for example,
+`filterwarnings = ['ignore:clickwork\\::DeprecationWarning']`).
+Filtering by the module field is not reliable here, because
+`stacklevel=2` attributes the warning to the caller's module rather
+than to `clickwork`.
 
 The 1.0 release itself may deprecate symbols that existed in 0.2.x,
 but it won't remove them in the same release. Anything removed in 1.0
@@ -234,9 +243,15 @@ those suites even for callers who aren't touching the deprecated
 surface. Warnings fire from the specific entry points that trigger
 the deprecated behavior (e.g. inside `create_cli()` once per CLI,
 or from the deprecated function itself). Callers who want to silence
-deprecations in their own test runs can add a targeted
-`filterwarnings = ["ignore::DeprecationWarning:clickwork"]` entry,
-or narrow further by message text.
+deprecations in their own test runs can add a targeted message-regex
+entry such as
+`filterwarnings = ['ignore:clickwork\\::DeprecationWarning']` (the
+second field is a regex against the warning text, and the
+`clickwork:` prefix on every message is what makes this match). The
+module-field form `ignore::DeprecationWarning:clickwork` looks
+plausible but does not actually match, because `stacklevel=2`
+attributes the warning to the caller's module rather than to
+`clickwork`.
 
 The 18-month window is deliberately generous. Enterprise and
 Linux-distribution Python environments lag upstream by years; a

--- a/docs/API_POLICY.md
+++ b/docs/API_POLICY.md
@@ -158,7 +158,7 @@ deprecated name warns exactly once per process regardless of how many
 times it's invoked. Every warning message begins with a
 `clickwork:` prefix so downstream test suites can filter narrowly via
 pytest's message-field regex (for example,
-`filterwarnings = ['ignore:clickwork\\::DeprecationWarning']`).
+`filterwarnings = ["ignore:clickwork\\::DeprecationWarning"]` (TOML double quotes are required so the `\\:` escape resolves to `\:`, the regex-escape for the `:` field separator)).
 Filtering by the module field is not reliable here, because
 `stacklevel=2` attributes the warning to the caller's module rather
 than to `clickwork`.
@@ -245,7 +245,7 @@ the deprecated behavior (e.g. inside `create_cli()` once per CLI,
 or from the deprecated function itself). Callers who want to silence
 deprecations in their own test runs can add a targeted message-regex
 entry such as
-`filterwarnings = ['ignore:clickwork\\::DeprecationWarning']` (the
+`filterwarnings = ["ignore:clickwork\\::DeprecationWarning"]` (TOML double quotes are required so the `\\:` escape resolves to `\:`, the regex-escape for the `:` field separator) (the
 second field is a regex against the warning text, and the
 `clickwork:` prefix on every message is what makes this match). The
 module-field form `ignore::DeprecationWarning:clickwork` looks

--- a/src/clickwork/_deprecated.py
+++ b/src/clickwork/_deprecated.py
@@ -1,0 +1,177 @@
+"""Internal deprecation decorator for clickwork's own public surface.
+
+Why the underscore
+------------------
+This module lives at ``clickwork._deprecated`` and is deliberately NOT
+re-exported from ``clickwork/__init__.py``. The leading underscore is a
+Python-convention marker meaning "internal; no compatibility promise."
+clickwork uses this decorator on *its own* deprecated public symbols so
+every deprecation emits a consistent, filterable warning. Plugin authors
+who want to deprecate their own commands should write their own
+``warnings.warn(..., DeprecationWarning)`` call (or a similar helper);
+importing from ``clickwork._deprecated`` is not supported. If demand
+grows for a re-exported version, we add a public re-export in a future
+minor release -- going private-first is the low-risk default.
+
+See ``docs/API_POLICY.md`` for the full deprecation runway policy (a
+symbol deprecated in 1.1 must still work in 1.2, etc.).
+
+First-call-only discipline
+--------------------------
+``DeprecationWarning`` fires **once per decorated symbol**, on the first
+call. This matters for two reasons:
+
+1. **No import-time warnings.** ``docs/API_POLICY.md`` pins this as
+   non-negotiable. Downstream test suites often run with
+   ``filterwarnings = ["error"]`` (clickwork's own pytest config does
+   exactly this). If merely importing a module that *contains* a
+   deprecated symbol raised a warning, every downstream test would fail
+   the moment the consumer upgraded clickwork -- even consumers who
+   never touched the deprecated surface. Emitting on first *call*
+   instead of at decoration time means the warning only reaches callers
+   who are actually using the doomed API.
+2. **No spam.** A deprecated helper inside a hot loop would otherwise
+   print thousands of identical messages. One warning per symbol per
+   process is enough to signal intent; the changelog and migration
+   guide carry the details.
+
+The already-warned set is keyed by ``__qualname__`` (falling back to
+``__name__``). That key is stable across calls to the *same* wrapped
+symbol but distinct across different wrapped symbols, so deprecating
+``foo`` does not suppress a later deprecation of ``bar``.
+
+Stacklevel rationale
+--------------------
+We pass ``stacklevel=2`` to ``warnings.warn``. That tells Python to
+attribute the warning to the frame **above** the wrapper, i.e. the
+caller's source line. Without it, ``python -W error`` tracebacks and
+any ``showwarning`` override would all blame this file, which is useless
+to the user: they want to see "this call on line 47 of my_script.py is
+deprecated," not "line 100 of clickwork/_deprecated.py."
+"""
+from __future__ import annotations
+
+import functools
+import inspect
+import warnings
+from typing import Any, Callable, TypeVar
+
+# ``T`` carries the decorated callable's type through the decorator so
+# static type-checkers see the original signature on the return value.
+# This is important for IDE hover / autocomplete: the user should still
+# see ``foo(a: int, b: int) -> int`` after the decorator is applied,
+# not an opaque ``Callable[..., Any]``.
+T = TypeVar("T", bound=Callable[..., Any])
+
+# Module-level set of qualified names we have already warned about.
+# Lives at module scope (not per-decorator-instance) so it survives the
+# normal call pattern of "one @deprecated(...) site, many invocations."
+# The tradeoff: this is process-wide state. If a test needs to force a
+# re-warn, it can clear this set -- but we don't expose a public reset
+# because production code should not depend on warning timing.
+_warned: set[str] = set()
+
+
+def _qualname(obj: Any) -> str:
+    """Return the most specific identifier we can for a callable.
+
+    Prefer ``__qualname__`` (which encodes class nesting, e.g.
+    ``OldWidget.__init__``) so two methods named ``__init__`` on
+    different classes don't collide in the warned-set. Fall back to
+    ``__name__`` for oddball callables (e.g. ``functools.partial``
+    objects don't have ``__qualname__``) and finally to ``repr()`` so
+    we never raise from inside a decorator.
+    """
+    return (
+        getattr(obj, "__qualname__", None)
+        or getattr(obj, "__name__", None)
+        or repr(obj)
+    )
+
+
+def deprecated(
+    since: str,
+    removed_in: str,
+    reason: str = "",
+) -> Callable[[T], T]:
+    """Mark a function, method, or class as deprecated.
+
+    Args:
+        since: The clickwork version in which the symbol was deprecated
+            (e.g. ``"1.1"``). Included verbatim in the warning message.
+        removed_in: The earliest clickwork version that may remove the
+            symbol (e.g. ``"1.2"``). Per ``docs/API_POLICY.md`` the
+            symbol must still work for at least one full minor release,
+            so this is typically ``since`` incremented by one minor.
+        reason: Human-readable guidance for the caller, usually a
+            pointer to the replacement API (e.g. ``"use bar() instead"``).
+            Optional but strongly recommended -- a bare "deprecated"
+            message is rarely actionable.
+
+    Returns:
+        A decorator that wraps the target and emits a
+        ``DeprecationWarning`` on its first call.
+
+    Examples:
+        Function:
+
+            @deprecated(since="1.1", removed_in="1.2", reason="use new_func()")
+            def old_func(): ...
+
+        Class (warning fires at instantiation, not at class reference):
+
+            @deprecated(since="1.1", removed_in="1.2", reason="use NewWidget")
+            class OldWidget: ...
+    """
+    # The warning text is templated once and reused every time we fire.
+    # Keeping the ``clickwork:`` prefix lets callers filter narrowly, e.g.
+    # ``filterwarnings = ["ignore::DeprecationWarning:clickwork"]`` in
+    # their pytest config.
+    def _build_message(qualname: str) -> str:
+        tail = f" {reason}" if reason else ""
+        return (
+            f"clickwork: {qualname} is deprecated since {since}; "
+            f"will be removed in {removed_in}.{tail}"
+        )
+
+    def decorator(target: T) -> T:
+        # Class path: wrap __init__ so the warning fires at instantiation.
+        # Wrapping the class object itself (e.g. via a factory) would
+        # break isinstance checks and subclassing, which downstream
+        # callers may rely on.
+        if inspect.isclass(target):
+            cls = target
+            original_init = cls.__init__
+            # Use the class's own qualified name as the cache key so the
+            # warning text reads "OldWidget is deprecated" rather than
+            # "OldWidget.__init__ is deprecated."
+            cache_key = _qualname(cls)
+            message = _build_message(cache_key)
+
+            @functools.wraps(original_init)
+            def new_init(self: Any, *args: Any, **kwargs: Any) -> None:
+                if cache_key not in _warned:
+                    _warned.add(cache_key)
+                    # stacklevel=2 -> blame the caller doing ``OldWidget(...)``,
+                    # not this wrapper.
+                    warnings.warn(message, DeprecationWarning, stacklevel=2)
+                original_init(self, *args, **kwargs)
+
+            cls.__init__ = new_init  # type: ignore[method-assign]
+            return cls  # type: ignore[return-value]
+
+        # Function / method path.
+        func = target
+        cache_key = _qualname(func)
+        message = _build_message(cache_key)
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if cache_key not in _warned:
+                _warned.add(cache_key)
+                warnings.warn(message, DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/src/clickwork/_deprecated.py
+++ b/src/clickwork/_deprecated.py
@@ -208,21 +208,29 @@ def deprecated(
             message = _build_message(display)
 
             @functools.wraps(original_init)
-            def new_init(self: Any, *args: Any, **kwargs: Any) -> None:
-                # Lock the check-and-add so two threads racing on a
-                # first call don't both observe ``not in _warned`` and
-                # emit duplicate warnings. ``should_warn`` latches the
-                # winner inside the lock; the losing thread sees
-                # ``False`` and silently proceeds.
-                with _warned_lock:
-                    should_warn = cache_key not in _warned
+            def new_init(self: Any, *args: Any, **kwargs: Any) -> Any:
+                # Fast-path: membership in a set is O(1), atomic for a
+                # single-expression read, and doesn't acquire the lock.
+                # Once a symbol has warned, every subsequent call skips
+                # the lock entirely -- a deprecated function in a hot
+                # loop pays nothing extra. The lock only guards the
+                # check-and-add on the first-warn window so two threads
+                # racing on the first call don't both emit a warning.
+                if cache_key not in _warned:
+                    with _warned_lock:
+                        should_warn = cache_key not in _warned
+                        if should_warn:
+                            _warned.add(cache_key)
                     if should_warn:
-                        _warned.add(cache_key)
-                if should_warn:
-                    # stacklevel=2 -> blame the caller doing ``OldWidget(...)``,
-                    # not this wrapper.
-                    warnings.warn(message, DeprecationWarning, stacklevel=2)
-                original_init(self, *args, **kwargs)
+                        # stacklevel=2 -> blame the caller doing
+                        # ``OldWidget(...)`` not this wrapper.
+                        warnings.warn(message, DeprecationWarning, stacklevel=2)
+                # Return ``original_init``'s result so a buggy
+                # ``__init__`` that returns non-None still trips
+                # Python's ``type.__call__`` TypeError (which my
+                # wrapper would otherwise silently mask by discarding
+                # the return).
+                return original_init(self, *args, **kwargs)
 
             cls.__init__ = new_init  # type: ignore[method-assign]
             return cls  # type: ignore[return-value]
@@ -235,15 +243,16 @@ def deprecated(
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            # Same lock-protected check-and-add as the class path above.
-            # Keeping both paths identical makes the "warn once per
-            # process" contract uniform under concurrency.
-            with _warned_lock:
-                should_warn = cache_key not in _warned
+            # Same fast-path + lock-on-first-warn discipline as the
+            # class path above. Once a symbol has warned, subsequent
+            # calls skip the lock entirely via the membership check.
+            if cache_key not in _warned:
+                with _warned_lock:
+                    should_warn = cache_key not in _warned
+                    if should_warn:
+                        _warned.add(cache_key)
                 if should_warn:
-                    _warned.add(cache_key)
-            if should_warn:
-                warnings.warn(message, DeprecationWarning, stacklevel=2)
+                    warnings.warn(message, DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         return wrapper  # type: ignore[return-value]

--- a/src/clickwork/_deprecated.py
+++ b/src/clickwork/_deprecated.py
@@ -171,10 +171,16 @@ def deprecated(
     # Keeping the ``clickwork:`` prefix lets callers filter narrowly by
     # matching the **message field** (the second field of pytest's
     # ``filterwarnings`` spec, which is a regex against the warning text).
-    # Example pytest config::
+    # Example ``pyproject.toml`` pytest config -- note the DOUBLE QUOTES.
+    # TOML single-quoted strings don't process backslash escapes, so
+    # ``'ignore:clickwork\\::DeprecationWarning'`` ends up as the literal
+    # six-char sequence ``clickwork\\:`` and pytest never matches the
+    # warning. Use double quotes so TOML resolves ``\\:`` to ``\:``
+    # (the regex-escape for the ``:`` field separator)::
     #
+    #     [tool.pytest.ini_options]
     #     filterwarnings = [
-    #         'ignore:clickwork\\::DeprecationWarning',
+    #         "ignore:clickwork\\::DeprecationWarning",
     #     ]
     #
     # Note: the obvious-looking ``"ignore::DeprecationWarning:clickwork"``

--- a/src/clickwork/_deprecated.py
+++ b/src/clickwork/_deprecated.py
@@ -35,10 +35,13 @@ call. This matters for two reasons:
    process is enough to signal intent; the changelog and migration
    guide carry the details.
 
-The already-warned set is keyed by ``__qualname__`` (falling back to
-``__name__``). That key is stable across calls to the *same* wrapped
-symbol but distinct across different wrapped symbols, so deprecating
-``foo`` does not suppress a later deprecation of ``bar``.
+The already-warned set is keyed by ``f"{__module__}.{__qualname__}"``
+(with safe fallbacks through ``__name__`` and ``repr()``). The module
+prefix matters: without it, two different modules each defining
+``def foo()`` would share a cache entry, so after module A's ``foo``
+fires its warning, module B's ``foo`` would be silenced for the rest
+of the process. The module-qualified key keeps them distinct while
+still being stable across repeated calls to the same symbol.
 
 Stacklevel rationale
 --------------------
@@ -61,7 +64,16 @@ from typing import Any, Callable, TypeVar
 # This is important for IDE hover / autocomplete: the user should still
 # see ``foo(a: int, b: int) -> int`` after the decorator is applied,
 # not an opaque ``Callable[..., Any]``.
-T = TypeVar("T", bound=Callable[..., Any])
+#
+# The TypeVar is **unbounded** so classes type-check as well as
+# functions. A bound of ``Callable[..., Any]`` would reject
+# ``@deprecated(...)`` on a class, because ``type`` is not a
+# ``Callable[..., Any]`` in typing semantics even though classes are
+# callable at runtime (calling a class invokes ``__init__``). Dropping
+# the bound costs a little precision on the parameter type but keeps
+# both the function- and class-decorator paths typeable from a single
+# overload, which is what users expect at call sites.
+T = TypeVar("T")
 
 # Module-level set of qualified names we have already warned about.
 # Lives at module scope (not per-decorator-instance) so it survives the
@@ -73,20 +85,40 @@ _warned: set[str] = set()
 
 
 def _qualname(obj: Any) -> str:
-    """Return the most specific identifier we can for a callable.
+    """Return the most specific display identifier we can for a callable.
 
     Prefer ``__qualname__`` (which encodes class nesting, e.g.
     ``OldWidget.__init__``) so two methods named ``__init__`` on
-    different classes don't collide in the warned-set. Fall back to
+    different classes read distinctly in the warning text. Fall back to
     ``__name__`` for oddball callables (e.g. ``functools.partial``
     objects don't have ``__qualname__``) and finally to ``repr()`` so
     we never raise from inside a decorator.
+
+    This is the **display** name that appears in the warning message.
+    It is deliberately not used as the dedup cache key -- see
+    ``_cache_key`` for that, which prefixes the module so two
+    identically-named functions in different modules don't collide.
     """
     return (
         getattr(obj, "__qualname__", None)
         or getattr(obj, "__name__", None)
         or repr(obj)
     )
+
+
+def _cache_key(obj: Any) -> str:
+    """Return the module-qualified key used to dedup warnings.
+
+    Keying on ``__qualname__`` alone is wrong: two modules each
+    defining ``def foo(): ...`` would share a cache entry, so once
+    module A's ``foo`` fires its warning, module B's ``foo`` would be
+    silenced for the rest of the process even though it's a different
+    symbol. Prefix the module (``fn.__module__``) to keep the entries
+    distinct. We still fall back through the same chain as
+    ``_qualname`` so an object missing ``__module__`` never raises.
+    """
+    module = getattr(obj, "__module__", None) or "<unknown-module>"
+    return f"{module}.{_qualname(obj)}"
 
 
 def deprecated(
@@ -124,9 +156,19 @@ def deprecated(
             class OldWidget: ...
     """
     # The warning text is templated once and reused every time we fire.
-    # Keeping the ``clickwork:`` prefix lets callers filter narrowly, e.g.
-    # ``filterwarnings = ["ignore::DeprecationWarning:clickwork"]`` in
-    # their pytest config.
+    # Keeping the ``clickwork:`` prefix lets callers filter narrowly by
+    # matching the **message field** (the second field of pytest's
+    # ``filterwarnings`` spec, which is a regex against the warning text).
+    # Example pytest config::
+    #
+    #     filterwarnings = [
+    #         'ignore:clickwork\\::DeprecationWarning',
+    #     ]
+    #
+    # Note: the obvious-looking ``"ignore::DeprecationWarning:clickwork"``
+    # (module field, 4th field) does NOT work, because ``stacklevel=2``
+    # attributes the warning to the CALLER's module, not to ``clickwork``.
+    # Filter by the ``clickwork:`` message prefix instead.
     def _build_message(qualname: str) -> str:
         tail = f" {reason}" if reason else ""
         return (
@@ -142,11 +184,16 @@ def deprecated(
         if inspect.isclass(target):
             cls = target
             original_init = cls.__init__
-            # Use the class's own qualified name as the cache key so the
-            # warning text reads "OldWidget is deprecated" rather than
+            # Display name drives the human-readable warning text so the
+            # message reads "OldWidget is deprecated" rather than
             # "OldWidget.__init__ is deprecated."
-            cache_key = _qualname(cls)
-            message = _build_message(cache_key)
+            display = _qualname(cls)
+            # Dedup key is module-qualified so two classes named
+            # ``OldWidget`` in different modules both get to warn on
+            # first instantiation instead of the second one being
+            # silently suppressed by the first's cache entry.
+            cache_key = _cache_key(cls)
+            message = _build_message(display)
 
             @functools.wraps(original_init)
             def new_init(self: Any, *args: Any, **kwargs: Any) -> None:
@@ -162,8 +209,9 @@ def deprecated(
 
         # Function / method path.
         func = target
-        cache_key = _qualname(func)
-        message = _build_message(cache_key)
+        display = _qualname(func)
+        cache_key = _cache_key(func)
+        message = _build_message(display)
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/src/clickwork/_deprecated.py
+++ b/src/clickwork/_deprecated.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import threading
 import warnings
 from typing import Any, Callable, TypeVar
 
@@ -82,6 +83,17 @@ T = TypeVar("T")
 # re-warn, it can clear this set -- but we don't expose a public reset
 # because production code should not depend on warning timing.
 _warned: set[str] = set()
+
+# Guards the check-and-add on ``_warned``. Without it, two threads
+# racing on the first call of the same deprecated symbol can both pass
+# ``cache_key not in _warned`` before either adds, so
+# ``warnings.warn(...)`` fires twice and breaks the "warn once per
+# symbol per process" contract. A plain ``threading.Lock`` is enough
+# since the critical section is a single set mutation. Cost at steady
+# state (key already in the set) is one attribute-access + one
+# lock-acquire per call, which is negligible next to the warning-emit
+# path we're avoiding.
+_warned_lock = threading.Lock()
 
 
 def _qualname(obj: Any) -> str:
@@ -197,8 +209,16 @@ def deprecated(
 
             @functools.wraps(original_init)
             def new_init(self: Any, *args: Any, **kwargs: Any) -> None:
-                if cache_key not in _warned:
-                    _warned.add(cache_key)
+                # Lock the check-and-add so two threads racing on a
+                # first call don't both observe ``not in _warned`` and
+                # emit duplicate warnings. ``should_warn`` latches the
+                # winner inside the lock; the losing thread sees
+                # ``False`` and silently proceeds.
+                with _warned_lock:
+                    should_warn = cache_key not in _warned
+                    if should_warn:
+                        _warned.add(cache_key)
+                if should_warn:
                     # stacklevel=2 -> blame the caller doing ``OldWidget(...)``,
                     # not this wrapper.
                     warnings.warn(message, DeprecationWarning, stacklevel=2)
@@ -215,8 +235,14 @@ def deprecated(
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            if cache_key not in _warned:
-                _warned.add(cache_key)
+            # Same lock-protected check-and-add as the class path above.
+            # Keeping both paths identical makes the "warn once per
+            # process" contract uniform under concurrency.
+            with _warned_lock:
+                should_warn = cache_key not in _warned
+                if should_warn:
+                    _warned.add(cache_key)
+            if should_warn:
                 warnings.warn(message, DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 

--- a/tests/unit/test_deprecated.py
+++ b/tests/unit/test_deprecated.py
@@ -93,31 +93,31 @@ def test_cache_key_is_module_qualified():
     """
     from clickwork._deprecated import deprecated
 
-    # Two decorated functions that share a qualname but live in
-    # different (synthetic) modules. ``__module__`` is what the
-    # decorator reads for the cache key, so overriding it here is the
-    # minimal way to stage the collision scenario without having to
-    # build two throwaway .py files on disk.
-    @deprecated(since="1.1", removed_in="1.2", reason="gone")
+    # _cache_key is computed at DECORATION TIME from the function's
+    # attributes as they are THEN. Mutating ``__module__`` on the
+    # resulting wrapper after decoration wouldn't change what cache key
+    # the decorator stored. To stage the collision scenario correctly,
+    # we mutate ``__module__`` BEFORE passing the function through the
+    # decorator factory. Two freshly-defined functions in this test
+    # share the Python ``__qualname__`` (both are
+    # ``test_cache_key_is_module_qualified.<locals>.collide``), so if
+    # the cache key were qualname-only they'd collide.
     def collide() -> int:
         return 1
-
-    @deprecated(since="1.1", removed_in="1.2", reason="gone")
-    def collide_b() -> int:  # different python-level name, same qualname below
-        return 2
-
-    # Force both to look like ``def collide()`` in separate modules.
-    # We set ``__module__`` BEFORE the first call so the cache key is
-    # computed against the faked module names. (The decorator reads
-    # ``__module__`` each call, so the override has to be in place at
-    # warn-time, not just at decoration time.)
     collide.__module__ = "pkg_a.sub"
-    collide_b.__module__ = "pkg_b.sub"
-    collide_b.__qualname__ = collide.__qualname__  # same short name
+    decorated_a = deprecated(since="1.1", removed_in="1.2", reason="gone")(collide)
+
+    # Redefining ``collide`` in the same scope reuses the ``__qualname__``;
+    # the point of the test is to prove that two same-qualname functions
+    # in DIFFERENT modules don't share a dedup entry.
+    def collide() -> int:  # noqa: F811 -- intentional name reuse
+        return 2
+    collide.__module__ = "pkg_b.sub"
+    decorated_b = deprecated(since="1.1", removed_in="1.2", reason="gone")(collide)
 
     # First call of module A's ``collide`` warns.
     with pytest.warns(DeprecationWarning) as record_a:
-        assert collide() == 1
+        assert decorated_a() == 1
     assert len(record_a) == 1
 
     # First call of module B's ``collide`` must ALSO warn -- a single
@@ -126,7 +126,7 @@ def test_cache_key_is_module_qualified():
     # already filled the slot and this block would raise
     # ``Failed: DID NOT WARN``.
     with pytest.warns(DeprecationWarning) as record_b:
-        assert collide_b() == 2
+        assert decorated_b() == 2
     assert len(record_b) == 1
 
 

--- a/tests/unit/test_deprecated.py
+++ b/tests/unit/test_deprecated.py
@@ -88,8 +88,11 @@ def test_cache_key_is_module_qualified():
     reuse short names across modules (very common for ``main``,
     ``run``, ``helper``, etc.).
 
-    We simulate two separate modules by flipping ``__module__`` on two
-    freshly-decorated functions with the same ``__qualname__``.
+    We simulate two separate modules by setting ``__module__`` on two
+    functions **before** decorating them (_cache_key is computed at
+    decoration time, so pre-decoration mutation is what the test needs
+    to stage the collision correctly). Both resulting wrappers share
+    the same ``__qualname__`` and differ only in ``__module__``.
     """
     from clickwork._deprecated import deprecated
 

--- a/tests/unit/test_deprecated.py
+++ b/tests/unit/test_deprecated.py
@@ -59,10 +59,13 @@ def test_function_emits_warning_on_first_call():
     # just clickwork deprecations. Because ``stacklevel=2`` attributes
     # the warning to the CALLER's module (not to ``clickwork``), the
     # correct way to filter is against the **message field** (regex),
-    # not the module field. For example, in pytest::
+    # not the module field. For example, in ``pyproject.toml`` (note
+    # DOUBLE QUOTES -- TOML single-quoted strings don't escape the
+    # backslash, which would cause the filter to miss the warning)::
     #
+    #     [tool.pytest.ini_options]
     #     filterwarnings = [
-    #         'ignore:clickwork\\::DeprecationWarning',
+    #         "ignore:clickwork\\::DeprecationWarning",
     #     ]
     #
     # The second field of that spec is a regex matched against the

--- a/tests/unit/test_deprecated.py
+++ b/tests/unit/test_deprecated.py
@@ -56,7 +56,17 @@ def test_function_emits_warning_on_first_call():
     assert len(record) == 1
     message = str(record[0].message)
     # The ``clickwork:`` prefix lets callers narrow warning filters to
-    # just clickwork deprecations (e.g. ``filterwarnings = ["ignore::DeprecationWarning:clickwork"]``).
+    # just clickwork deprecations. Because ``stacklevel=2`` attributes
+    # the warning to the CALLER's module (not to ``clickwork``), the
+    # correct way to filter is against the **message field** (regex),
+    # not the module field. For example, in pytest::
+    #
+    #     filterwarnings = [
+    #         'ignore:clickwork\\::DeprecationWarning',
+    #     ]
+    #
+    # The second field of that spec is a regex matched against the
+    # warning message; our ``clickwork:`` prefix is what makes it work.
     assert message.startswith("clickwork:")
     # The qualified name of the wrapped function appears in the message
     # so the user can grep their own code for the usage site.
@@ -64,6 +74,60 @@ def test_function_emits_warning_on_first_call():
     assert "1.1" in message
     assert "1.2" in message
     assert "use bar() instead" in message
+
+
+def test_cache_key_is_module_qualified():
+    """Two same-named functions in different modules both warn on first call.
+
+    The dedup cache key must include the defining module. If the key
+    were just ``__qualname__``, then declaring ``def foo()`` in module
+    A and also in module B would make them collide: A's first call
+    fires the warning, adds ``"foo"`` to the warned-set, and B's first
+    call is then silently suppressed even though it's a different
+    symbol. That's a correctness bug in any project that happens to
+    reuse short names across modules (very common for ``main``,
+    ``run``, ``helper``, etc.).
+
+    We simulate two separate modules by flipping ``__module__`` on two
+    freshly-decorated functions with the same ``__qualname__``.
+    """
+    from clickwork._deprecated import deprecated
+
+    # Two decorated functions that share a qualname but live in
+    # different (synthetic) modules. ``__module__`` is what the
+    # decorator reads for the cache key, so overriding it here is the
+    # minimal way to stage the collision scenario without having to
+    # build two throwaway .py files on disk.
+    @deprecated(since="1.1", removed_in="1.2", reason="gone")
+    def collide() -> int:
+        return 1
+
+    @deprecated(since="1.1", removed_in="1.2", reason="gone")
+    def collide_b() -> int:  # different python-level name, same qualname below
+        return 2
+
+    # Force both to look like ``def collide()`` in separate modules.
+    # We set ``__module__`` BEFORE the first call so the cache key is
+    # computed against the faked module names. (The decorator reads
+    # ``__module__`` each call, so the override has to be in place at
+    # warn-time, not just at decoration time.)
+    collide.__module__ = "pkg_a.sub"
+    collide_b.__module__ = "pkg_b.sub"
+    collide_b.__qualname__ = collide.__qualname__  # same short name
+
+    # First call of module A's ``collide`` warns.
+    with pytest.warns(DeprecationWarning) as record_a:
+        assert collide() == 1
+    assert len(record_a) == 1
+
+    # First call of module B's ``collide`` must ALSO warn -- a single
+    # DeprecationWarning is expected here, not zero. If the cache key
+    # weren't module-qualified, module A's earlier warn would have
+    # already filled the slot and this block would raise
+    # ``Failed: DID NOT WARN``.
+    with pytest.warns(DeprecationWarning) as record_b:
+        assert collide_b() == 2
+    assert len(record_b) == 1
 
 
 def test_only_warns_once():

--- a/tests/unit/test_deprecated.py
+++ b/tests/unit/test_deprecated.py
@@ -1,0 +1,228 @@
+"""Unit tests for clickwork._deprecated.
+
+These tests pin the contract documented in `docs/API_POLICY.md`:
+
+- `DeprecationWarning` fires on the first call to the deprecated surface,
+  NOT at import time. That discipline exists because downstream test
+  suites often run with `filterwarnings = ["error"]` (clickwork's own
+  pytest config does exactly this). An import-time warning would break
+  every downstream test, even for callers who never touch the deprecated
+  surface.
+- Subsequent calls do NOT re-warn. Deprecation warnings are informative,
+  not a spam channel.
+- `stacklevel=2` means the warning points at the caller's source line,
+  not at the decorator's internals. Without that, tracebacks and
+  ``-W error`` output would blame `_deprecated.py` instead of the real
+  culprit.
+- Decorated functions preserve their signature and docstring so tooling
+  (IDE autocomplete, Sphinx, inspect.signature) is unaffected.
+
+The test suite is wired through pytest's ``filterwarnings = ["error"]``
+(see pyproject.toml). That means **any unexpected `DeprecationWarning`
+raised during collection or a test body crashes the run**. Tests that
+intentionally exercise the warning path use
+``warnings.catch_warnings()`` or ``pytest.warns()`` to observe without
+propagating.
+"""
+from __future__ import annotations
+
+import inspect
+import warnings
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Function-decorator path
+# ---------------------------------------------------------------------------
+
+
+def test_function_emits_warning_on_first_call():
+    """First call to a @deprecated function emits DeprecationWarning.
+
+    Also pins the exact message format, including the ``clickwork:``
+    prefix that downstream consumers filter on.
+    """
+    from clickwork._deprecated import deprecated
+
+    @deprecated(since="1.1", removed_in="1.2", reason="use bar() instead")
+    def foo() -> int:
+        return 42
+
+    with pytest.warns(DeprecationWarning) as record:
+        result = foo()
+
+    assert result == 42
+    assert len(record) == 1
+    message = str(record[0].message)
+    # The ``clickwork:`` prefix lets callers narrow warning filters to
+    # just clickwork deprecations (e.g. ``filterwarnings = ["ignore::DeprecationWarning:clickwork"]``).
+    assert message.startswith("clickwork:")
+    # The qualified name of the wrapped function appears in the message
+    # so the user can grep their own code for the usage site.
+    assert "foo" in message
+    assert "1.1" in message
+    assert "1.2" in message
+    assert "use bar() instead" in message
+
+
+def test_only_warns_once():
+    """Second call to the same deprecated surface is silent.
+
+    If we warned on every call, a deprecated helper inside a tight loop
+    would drown the user's console. Once per symbol is enough to signal
+    intent; the migration guide carries the rest of the message.
+    """
+    from clickwork._deprecated import deprecated
+
+    @deprecated(since="1.1", removed_in="1.2", reason="gone soon")
+    def once_only() -> str:
+        return "ok"
+
+    # First call warns.
+    with pytest.warns(DeprecationWarning):
+        once_only()
+
+    # Second call must not warn at all. We escalate warnings to errors
+    # inside this block so an accidental second warning would surface as
+    # a test failure rather than a silent regression.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert once_only() == "ok"
+
+
+def test_import_does_not_warn():
+    """Importing / decorating must not warn -- only calling does.
+
+    This is the critical import-time guard from ``docs/API_POLICY.md``.
+    Downstream suites with ``filterwarnings = ["error"]`` would otherwise
+    crash the moment they imported clickwork, even if they never touched
+    the deprecated surface.
+    """
+    from clickwork._deprecated import deprecated
+
+    # ``simplefilter("error")`` inside the with-block means any warning
+    # raised during decoration would become an exception and fail the
+    # test. The decorator body must therefore be completely silent.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        @deprecated(since="1.1", removed_in="1.2", reason="nope")
+        def untouched() -> None:
+            return None
+
+        # Merely referencing the name must also stay silent. Only
+        # *calling* the function is the trigger.
+        _ = untouched
+        _ = untouched.__name__
+
+
+# ---------------------------------------------------------------------------
+# Class-decorator path
+# ---------------------------------------------------------------------------
+
+
+def test_class_decorator_fires_on_instantiation():
+    """@deprecated on a class warns at ``Foo()``, not at ``Foo`` reference.
+
+    The decorator installs a wrapper around ``__init__`` so the warning
+    only fires when the user actually builds an instance. Holding a
+    reference to the class (e.g. for isinstance checks, or because it's
+    a default argument) must remain silent.
+    """
+    from clickwork._deprecated import deprecated
+
+    @deprecated(since="1.1", removed_in="1.2", reason="use Bar")
+    class OldWidget:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    # Referencing the class must not warn.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ref = OldWidget  # noqa: F841
+
+    # Instantiating does warn, exactly once.
+    with pytest.warns(DeprecationWarning) as record:
+        w = OldWidget(7)
+    assert w.value == 7
+    assert len(record) == 1
+
+    # Second instantiation is silent (same once-only discipline as for
+    # functions; the cache key is the class's qualified name).
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        w2 = OldWidget(9)
+    assert w2.value == 9
+
+
+# ---------------------------------------------------------------------------
+# Metadata preservation
+# ---------------------------------------------------------------------------
+
+
+def test_preserves_signature_and_docstring():
+    """Decoration leaves inspect.signature and __doc__ intact.
+
+    ``functools.wraps`` handles this, but we pin it so a future refactor
+    that drops wraps (or rolls its own wrapper) fails loudly here.
+    """
+    from clickwork._deprecated import deprecated
+
+    @deprecated(since="1.1", removed_in="1.2", reason="x")
+    def add(a: int, b: int = 1) -> int:
+        """Add two numbers."""
+        return a + b
+
+    sig = inspect.signature(add)
+    assert list(sig.parameters) == ["a", "b"]
+    assert sig.parameters["b"].default == 1
+    # Return annotation must survive, since type-checkers and IDEs rely
+    # on it. (Because this test file uses ``from __future__ import
+    # annotations``, the annotation is stored as the string ``"int"``
+    # rather than the builtin -- that is PEP 563 behavior, not a
+    # decorator artifact. We assert on the string form, which is what
+    # the decorator actually has to preserve.)
+    assert sig.return_annotation == "int"
+    assert add.__doc__ == "Add two numbers."
+    assert add.__name__ == "add"
+    # ``__wrapped__`` is set by ``functools.wraps`` and is what lets
+    # IDEs and debuggers unwrap decorated callables.
+    assert hasattr(add, "__wrapped__")
+
+
+# ---------------------------------------------------------------------------
+# Stacklevel
+# ---------------------------------------------------------------------------
+
+
+def test_stacklevel_points_to_caller():
+    """Warning is attributed to THIS file, not to _deprecated.py.
+
+    ``stacklevel=2`` inside ``warnings.warn`` tells Python to blame the
+    frame above the wrapper. Without that, ``python -W error`` traces
+    and ``showwarning`` output would all point at clickwork's internals,
+    which is useless for the user trying to find their own call site.
+    """
+    from clickwork._deprecated import deprecated
+
+    @deprecated(since="1.1", removed_in="1.2", reason="pick a caller")
+    def target() -> None:
+        return None
+
+    # ``catch_warnings(record=True)`` captures warning objects including
+    # their ``filename`` attribute, which is what ``stacklevel`` sets.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        target()
+
+    assert len(caught) == 1
+    w = caught[0]
+    assert issubclass(w.category, DeprecationWarning)
+    # The warning's filename should be THIS test module, not _deprecated.py.
+    # We compare on basenames to avoid absolute-path brittleness across
+    # worktrees and CI runners.
+    assert w.filename.endswith("test_deprecated.py"), (
+        f"expected stacklevel=2 to attribute warning to the caller; "
+        f"got filename={w.filename!r}"
+    )


### PR DESCRIPTION
Establishes the deprecation warning mechanism the 1.0 API policy promises. New internal module `clickwork._deprecated` exposes `@deprecated(since, removed_in, reason="")` for decorating functions, methods, or classes.

## Design discipline (pinned in `docs/API_POLICY.md`)

- **First-call only** — module-level `_warned` set keyed by qualified name; no hot-loop spam.
- **Import-time silent** — decoration never emits. Non-negotiable: downstream `filterwarnings=['error']` suites would fail at `import clickwork` otherwise, even when the deprecated surface is untouched.
- **`stacklevel=2`** — warning points at the caller, not the decorator.
- **Class decorator** — wraps `__init__`, so warning fires on `Foo()` not `Foo`.
- **functools.wraps** — preserves `__name__`, `__doc__`, `__wrapped__`, `inspect.signature`.

## Warning format

```
clickwork: <qualname> is deprecated since <since>; will be removed in <removed_in>. <reason>
```

`clickwork:` prefix lets consumers target their `filterwarnings` rules.

## Not re-exported

Intentionally stays at `clickwork._deprecated` — for internal use. External callers marking their own APIs can use `warnings.warn(DeprecationWarning)` directly. Re-exporting is reversible if demand appears later.

## Test plan

- [x] 6 tests: first-call warning + format, once-only, import-silence (the critical guard), class-decorator instantiation path, signature/docstring preservation, stacklevel-points-to-caller
- [x] `mise exec -- python -m pytest tests/ -q` → 263 passed, zero warnings under `filterwarnings=['error']`

Roadmap: Wave 2a #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)