### PR TITLE
feat: standardized --version flag for create_cli consumers (Fixes #48)

### DIFF
--- a/docs/API_POLICY.md
+++ b/docs/API_POLICY.md
@@ -77,6 +77,10 @@ as the symbol surface.
   Wave 4 issue #54) for the precedence table.
 - Global flag names installed by `create_cli()` (`--verbose`, `--quiet`,
   `--dry-run`, `--env`, `--yes`). Removing or renaming one is breaking.
+  `--version` / `-V` is also reserved at this level, but is only
+  installed when the caller passes `version=` or `package_name=` to
+  `create_cli()`; its presence is opt-in so existing CLIs opt in at
+  their own cadence.
 
 ## Private and unstable
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -99,7 +99,9 @@ python my-tool.py greet --help
 ```
 
 You get `--verbose`, `--quiet`, `--dry-run`, `--env`, and `--yes` for
-free. Every command inherits these global flags.
+free. Every command inherits these global flags. Pass `version=` or
+`package_name=` to `create_cli()` to also install `--version` / `-V`
+(see "Version flag" below).
 
 ## Using the Context
 
@@ -638,6 +640,21 @@ Highest priority wins:
 | `--dry-run` | Preview actions without executing |
 | `--env NAME` | Select config environment |
 | `--yes` / `-y` | Skip confirmation prompts |
+| `--version` / `-V` | Print the CLI's version string and exit (only installed if `create_cli()` receives `version=` or `package_name=`) |
+
+### Version flag
+
+`create_cli()` accepts two kwargs that opt into a `--version` / `-V`
+flag on the resulting group:
+
+- `version="1.2.3"` — the literal string to print.
+- `package_name="your-pypi-name"` — resolve via
+  `importlib.metadata.version(...)` at `create_cli()` call time; a
+  missing distribution raises `ValueError` so typos fail loud.
+
+When both are set, `version=` wins. When neither is set, `--version`
+is NOT installed so existing clickwork consumers see no change on
+upgrade.
 
 ### Public API
 

--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -16,6 +16,7 @@ Plugin authors call this once in their entry point script:
 from __future__ import annotations
 
 import functools
+import importlib.metadata
 import os
 import sys
 from pathlib import Path
@@ -197,6 +198,8 @@ def create_cli(
     *,
     description: str | None = None,
     enable_parent_package_imports: bool = False,
+    version: str | None = None,
+    package_name: str | None = None,
 ) -> click.Group:
     """Create a Click CLI group with global flags and plugin discovery.
 
@@ -210,6 +213,11 @@ def create_cli(
       --dry-run       (flag -- preview without executing)
       --env           (string -- select config environment)
       --yes / -y      (flag -- skip confirmation prompts)
+
+    If ``version`` or ``package_name`` is provided, the CLI also gains
+    ``-V`` / ``--version`` at the root level (wired via
+    :func:`click.version_option`). When neither kwarg is set, no
+    version flag is installed -- existing callers see no change.
 
     Args:
         name: CLI name (e.g., "orbit-admin"). Used for config paths and logging.
@@ -244,10 +252,70 @@ def create_cli(
             don't stack duplicate entries (known limitation: the dedup
             does not normalize *existing* ``sys.path`` entries that were
             added via relative/unresolved spellings elsewhere).
+        version: Explicit version string (e.g. ``"1.2.3"``). If provided,
+            it is used verbatim as the value displayed by ``--version``.
+            Takes precedence over ``package_name`` when both are set.
+        package_name: Installed distribution name to auto-resolve the
+            version from via :func:`importlib.metadata.version`. Only
+            used when ``version`` is ``None``. Raises ``ValueError`` at
+            ``create_cli()`` call time if the named distribution is not
+            installed -- we prefer failing loud to silently omitting the
+            flag, since a misspelled package name would otherwise go
+            unnoticed until someone happened to run ``--version``.
 
     Returns:
         A configured Click group with all discovered commands registered.
+
+    Raises:
+        ValueError: If ``package_name`` is provided (and ``version`` is
+            ``None``) but the named distribution cannot be found by
+            :mod:`importlib.metadata`.
+
+    Example:
+        Explicit version string::
+
+            cli = create_cli(name="orbit-admin", version="1.2.3")
+
+        Auto-resolve from the installing package's metadata::
+
+            cli = create_cli(name="orbit-admin", package_name="orbit-admin")
     """
+
+    # Resolve the version string to display via --version, if any.
+    #
+    # Three cases:
+    #   1. ``version`` is set -> use it verbatim. Wins over package_name.
+    #   2. ``version`` is None and ``package_name`` is set -> look it up
+    #      via importlib.metadata. PackageNotFoundError is wrapped as
+    #      ValueError so the caller gets a loud, actionable error at
+    #      create_cli() time instead of a silent "no --version flag".
+    #   3. Both None -> no --version flag is installed at all. This is
+    #      the default and preserves behaviour for pre-#48 callers.
+    #
+    # WHY eagerly resolve (instead of letting click.version_option do it
+    # at --version invocation time via its own ``package_name=``): Click
+    # only consults importlib.metadata when the user actually runs
+    # ``--version``. A typo in ``package_name`` would go undetected until
+    # someone hits that code path (possibly in production). Eager
+    # resolution at create_cli() call time surfaces the error at CLI
+    # construction, which is always exercised on startup.
+    resolved_version: str | None = None
+    if version is not None:
+        resolved_version = version
+    elif package_name is not None:
+        try:
+            resolved_version = importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError as e:
+            # Re-raise as ValueError with a message that names both the
+            # missing distribution and the ``create_cli`` context, so
+            # stack traces point at the real problem (a wrong
+            # package_name=) rather than the internal metadata lookup.
+            raise ValueError(
+                f"create_cli(package_name={package_name!r}) could not resolve a version: "
+                f"distribution {package_name!r} is not installed. "
+                "Pass an explicit version= string, or ensure the package name matches "
+                "the distribution name on PyPI / in pyproject.toml's [project] table."
+            ) from e
 
     # Optionally make commands_dir's parent package importable.
     #
@@ -463,6 +531,36 @@ def create_cli(
         # Attach the CliContext to Click's ctx.obj so all subcommands can
         # receive it via @click.pass_obj or @pass_cli_context.
         ctx.obj = cli_ctx
+
+    # Install --version / -V if a version string was resolved above.
+    #
+    # WHY this lives here (after the @click.group decorator ran, before
+    # discover_commands): click.version_option() returns a decorator that
+    # wraps a Command. We already have the decorated group object
+    # ``cli_group``, so applying the decorator in-place (``cli_group =
+    # click.version_option(...)(cli_group)``) installs the option on the
+    # exact group we're about to return. Doing this after command
+    # discovery would also work, but grouping all group-level option
+    # wiring in one place keeps the factory's structure easier to read.
+    #
+    # WHY we pass the already-resolved string (not package_name) to
+    # click.version_option: Click would otherwise defer the
+    # importlib.metadata lookup until --version is actually invoked --
+    # see the resolution block at the top of this function for why we
+    # want the error surfaced at construction time instead.
+    #
+    # WHY prog_name=name: without it, Click derives the prog name from
+    # the command's invocation path (e.g. ``python -m orbit_admin``),
+    # which is rarely what the end user expects. Forcing ``name`` makes
+    # ``--version`` output read ``<cli-name>, version <version>`` no
+    # matter how the CLI was launched.
+    if resolved_version is not None:
+        cli_group = click.version_option(
+            resolved_version,
+            "-V",
+            "--version",
+            prog_name=name,
+        )(cli_group)
 
     # Discover and register commands from the commands directory and/or
     # installed entry points, depending on the discovery_mode setting.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -404,8 +404,11 @@ class TestVersionFlag:
         WHY: a caller who passes both is almost certainly doing
         something deliberate (e.g. injecting a CI-computed version
         string). Silently preferring the metadata lookup would surprise
-        them. The rule is simple and local: if ``version`` is truthy,
-        skip the metadata path entirely.
+        them. The rule is simple and local: if ``version is not None``,
+        skip the metadata path entirely. The check is ``is not None``
+        specifically -- an empty ``version=""`` still wins over
+        ``package_name=``, because the caller explicitly chose to
+        suppress the resolved version in favour of an empty string.
         """
         from clickwork.cli import create_cli
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -316,6 +316,173 @@ class TestCreateCli:
         assert received["bucket"] == "from-config"
 
 
+class TestVersionFlag:
+    """create_cli(version=..., package_name=...) wires up --version (issue #48).
+
+    WHY this class exists: pre-#48, every clickwork consumer had to
+    reinvent ``--version`` with their own ``@click.version_option`` or a
+    custom callback. Standardizing the pattern inside ``create_cli()``
+    means consumers opt in once and get consistent output
+    (``<name>, version <version>``), consistent flag spellings
+    (``-V`` / ``--version``), and consistent behaviour around
+    auto-resolution from installed package metadata.
+
+    Design decisions pinned by these tests (per the issue and the 1.0
+    roadmap Wave 2a #48 entry):
+
+    - Two kwargs: ``version=`` (literal string) and ``package_name=``
+      (distribution name for ``importlib.metadata.version()`` lookup).
+    - Explicit ``version=`` wins when both are set.
+    - Both unset means NO ``--version`` flag is installed -- silently
+      adding one would be a behaviour change for every 0.x consumer.
+    - A bad ``package_name=`` raises ``ValueError`` at construction
+      time, not at ``--version`` invocation time. Loud > quiet.
+    """
+
+    def test_version_flag_emits_literal_version_string(self, tmp_path: Path):
+        """create_cli(version=...) must expose --version with that exact string.
+
+        WHY: the explicit-string path is the simplest/most common case.
+        Consumers who already know their version (read from
+        ``__version__``, fed in at packaging time, etc.) can pass it
+        straight through without any indirection.
+        """
+        from clickwork.cli import create_cli
+
+        cli = create_cli(name="test-cli", commands_dir=tmp_path, version="9.9.9")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        # Click's default version message is "<prog>, version <version>".
+        # We pin both halves because prog_name=name was part of the
+        # design decision (users should not see the import path).
+        assert "9.9.9" in result.output
+        assert "test-cli" in result.output
+
+    def test_version_short_flag_dash_big_v_works(self, tmp_path: Path):
+        """-V must work as a short alias for --version.
+
+        WHY a dedicated test: it's easy to accidentally bind
+        ``click.version_option(version)`` without the short flag, and
+        that drift wouldn't be caught by the long-flag test above.
+        Pinning -V separately protects the documented CLI surface.
+        """
+        from clickwork.cli import create_cli
+
+        cli = create_cli(name="test-cli", commands_dir=tmp_path, version="1.2.3")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["-V"])
+        assert result.exit_code == 0
+        assert "1.2.3" in result.output
+
+    def test_version_auto_resolves_from_package_name(self, tmp_path: Path):
+        """package_name= should auto-resolve via importlib.metadata.
+
+        WHY we test against ``clickwork`` itself: it's guaranteed to be
+        installed in the dev environment (editable install driven by
+        uv/pyproject), and its version matches
+        ``importlib.metadata.version('clickwork')``. Using a real
+        installed distribution keeps the test honest about the
+        ``importlib.metadata`` integration instead of mocking the lookup.
+        """
+        import importlib.metadata
+
+        from clickwork.cli import create_cli
+
+        expected_version = importlib.metadata.version("clickwork")
+        cli = create_cli(
+            name="test-cli", commands_dir=tmp_path, package_name="clickwork"
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert expected_version in result.output
+
+    def test_version_wins_over_package_name_when_both_set(self, tmp_path: Path):
+        """Explicit version= must override any package_name= lookup.
+
+        WHY: a caller who passes both is almost certainly doing
+        something deliberate (e.g. injecting a CI-computed version
+        string). Silently preferring the metadata lookup would surprise
+        them. The rule is simple and local: if ``version`` is truthy,
+        skip the metadata path entirely.
+        """
+        from clickwork.cli import create_cli
+
+        cli = create_cli(
+            name="test-cli",
+            commands_dir=tmp_path,
+            version="override-9.9.9",
+            package_name="clickwork",  # would resolve to 0.2.0 or similar
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "override-9.9.9" in result.output
+        # Guard against the metadata value leaking through. We don't
+        # hard-code the real clickwork version here because the dev
+        # environment's version bumps over time; asserting the
+        # override substring is present AND the output line is short
+        # enough to contain only one version is enough to pin the
+        # precedence rule.
+        import importlib.metadata
+        real_version = importlib.metadata.version("clickwork")
+        if real_version != "override-9.9.9":  # sanity: they're different
+            assert real_version not in result.output, (
+                "Both version= and package_name= were passed, but the "
+                "package_name lookup appears to have leaked into the "
+                "output -- version= must take precedence."
+            )
+
+    def test_no_version_flag_when_neither_arg_provided(self, tmp_path: Path):
+        """When neither kwarg is provided, --version must not exist.
+
+        WHY this is a regression guard, not just a "behaviour" test:
+        silently installing --version for every 0.x consumer would
+        shadow any --version they already implemented via custom
+        Click decorators (e.g. orbit-admin's legacy version handler
+        before it migrates to clickwork's built-in). Keeping the flag
+        opt-in means existing consumers see zero behaviour change.
+        """
+        from clickwork.cli import create_cli
+
+        cli = create_cli(name="test-cli", commands_dir=tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        # Click reports "no such option: --version" as a UsageError.
+        # UsageError exit code is 2; the important signal is non-zero
+        # plus the error message in stderr.
+        assert result.exit_code != 0
+        # Click formats unknown options as "no such option: --version"
+        # (newer Click) or similar. We look for the core phrase.
+        assert "no such option" in result.output.lower() or "--version" in result.output
+
+    def test_package_name_not_installed_raises_clear_error(self, tmp_path: Path):
+        """A bogus package_name must raise ValueError at create_cli() time.
+
+        WHY eager validation: if we silently omitted the --version
+        flag on PackageNotFoundError, a typo like
+        ``package_name="click_work"`` (underscore vs hyphen) would
+        go undetected until a user ran ``--version`` and got a
+        confusing "no such option" error. Raising at construction
+        time pins the error to the caller's stack frame where the
+        typo lives.
+
+        We also check the message names the bogus distribution so
+        debugging is straightforward -- a wrapped PackageNotFoundError
+        with no context would be less useful than the original.
+        """
+        from clickwork.cli import create_cli
+
+        bogus_name = "definitely-not-an-installed-package-xyz"
+        with pytest.raises(ValueError, match=bogus_name):
+            create_cli(
+                name="test-cli",
+                commands_dir=tmp_path,
+                package_name=bogus_name,
+            )
+
+
 class TestEnableParentPackageImports:
     """create_cli(enable_parent_package_imports=True) inserts commands_dir.parent.parent into sys.path.
 


### PR DESCRIPTION
Two new keyword-only kwargs on `create_cli()`:

- `version: str | None = None` — used verbatim.
- `package_name: str | None = None` — resolves via `importlib.metadata.version(package_name)` when `version` is `None`.

When both are `None` (current default), no `--version` flag is added. When either is set, the group gets `click.version_option(version, '-V', '--version', prog_name=name)`.

**Precedence:** explicit `version=` wins over `package_name=`.

## Error handling

`importlib.metadata.PackageNotFoundError` is caught at `create_cli()` time and re-raised as `ValueError` naming the failing distribution. Chose eager validation over Click's built-in lazy resolution so typos (`click_work` vs `clickwork`) fail at construction instead of silently hiding until a user runs `--version` in production.

## Test plan

- [x] 6 tests: literal string, `-V` short alias, auto-resolve via `package_name='clickwork'`, explicit-wins precedence, no-flag default, bogus-package ValueError
- [x] `mise exec -- python -m pytest tests/ -q` → 263 passed

Roadmap: Wave 2a #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)