### PR TITLE
ci: Ruff lint + format CI gate + format existing code (Fixes #38 lint half)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,12 +20,15 @@ jobs:
         run: uv python install 3.13
 
       - name: Ruff lint
-        # `uvx` resolves ruff on demand so we don't need to pin it as a dev
-        # dependency. Configuration still comes from pyproject.toml.
-        run: uvx ruff check .
+        # Pin Ruff to an exact version so CI remains stable across future
+        # upstream releases. A new Ruff can introduce rules or change format
+        # output and break PRs that didn't touch code. Bumping this pin is a
+        # deliberate, reviewed change in its own PR. Configuration still
+        # comes from pyproject.toml.
+        run: uvx --from ruff==0.6.9 ruff check .
 
       - name: Ruff format check
-        # Always run the formatter check even if `ruff check` fails, so a single
-        # CI run surfaces every class of issue at once.
+        # Always run the formatter check even if `ruff check` fails, so a
+        # single CI run surfaces every class of issue at once.
         if: always()
-        run: uvx ruff format --check .
+        run: uvx --from ruff==0.6.9 ruff format --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ruff:
+    name: Ruff (lint + format)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Ruff lint
+        # `uvx` resolves ruff on demand so we don't need to pin it as a dev
+        # dependency. Configuration still comes from pyproject.toml.
+        run: uvx ruff check .
+
+      - name: Ruff format check
+        # Always run the formatter check even if `ruff check` fails, so a single
+        # CI run surfaces every class of issue at once.
+        if: always()
+        run: uvx ruff format --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,22 @@ filterwarnings = [
 markers = [
     "network: requires network access (pip install, HTTP calls)",
 ]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+# Conservative initial rule selection. Expand in follow-up PRs once the
+# project settles into a house style.
+#   E, W  — pycodestyle errors + warnings
+#   F     — pyflakes (undefined names, unused imports, etc.)
+#   B     — flake8-bugbear (likely bugs)
+#   I     — isort (import ordering)
+#   UP    — pyupgrade (modern Python idioms)
+select = ["E", "F", "W", "B", "I", "UP"]
+ignore = []
+
+[tool.ruff.format]
+# Use ruff's defaults. Don't set quote-style / indent-style unless/until the
+# project adopts an explicit house style.

--- a/src/clickwork/__init__.py
+++ b/src/clickwork/__init__.py
@@ -30,7 +30,13 @@ __version__ = "0.2.0"
 # resolution (which doesn't fire until the user imports the submodule
 # explicitly somewhere else first).
 from clickwork import http, platform, testing
-from clickwork._types import CliContext, CliProcessError, PrerequisiteError, Secret, normalize_prefix
+from clickwork._types import (
+    CliContext,
+    CliProcessError,
+    PrerequisiteError,
+    Secret,
+    normalize_prefix,
+)
 from clickwork.cli import create_cli, pass_cli_context
 from clickwork.config import ConfigError, load_config
 from clickwork.global_options import add_global_option

--- a/src/clickwork/_logging.py
+++ b/src/clickwork/_logging.py
@@ -10,6 +10,7 @@ The verbosity mapping:
   - -vv (verbose=2): DEBUG -- implementation details
   - --quiet: ERROR -- only failures
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/clickwork/_types.py
+++ b/src/clickwork/_types.py
@@ -9,6 +9,7 @@ Four types are defined here:
   - PrerequisiteError : raised when a required tool is missing or not authenticated
   - CliContext        : dataclass threaded through Click's ctx.obj to every command
 """
+
 from __future__ import annotations
 
 import logging
@@ -16,10 +17,10 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-
 # ---------------------------------------------------------------------------
 # Secret
 # ---------------------------------------------------------------------------
+
 
 class Secret:
     """An opaque wrapper that prevents accidental logging of sensitive values.
@@ -139,7 +140,7 @@ class Secret:
 
     # --- safe copy semantics ---
 
-    def __copy__(self) -> "Secret":
+    def __copy__(self) -> Secret:
         """Return a new Secret wrapping the same value.
 
         copy.copy() calls __copy__ when available. We return a new Secret
@@ -150,7 +151,7 @@ class Secret:
         """
         return Secret(self._value)
 
-    def __deepcopy__(self, memo: dict) -> "Secret":
+    def __deepcopy__(self, memo: dict) -> Secret:
         """Return a new Secret wrapping the same value (deep copy is shallow here).
 
         copy.deepcopy() follows __deepcopy__. Strings are immutable, so a
@@ -169,6 +170,7 @@ class Secret:
 # ---------------------------------------------------------------------------
 # CliProcessError
 # ---------------------------------------------------------------------------
+
 
 class CliProcessError(Exception):
     """A subprocess failure wrapped with enough context to act on.
@@ -220,6 +222,7 @@ class CliProcessError(Exception):
 # PrerequisiteError
 # ---------------------------------------------------------------------------
 
+
 class PrerequisiteError(Exception):
     """Raised when a required tool is missing or not authenticated.
 
@@ -237,6 +240,7 @@ class PrerequisiteError(Exception):
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
 
 def normalize_prefix(name: str) -> str:
     """Convert a project/CLI name to a shell-safe env-var prefix.
@@ -258,6 +262,7 @@ def normalize_prefix(name: str) -> str:
 # ---------------------------------------------------------------------------
 # CliContext
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class CliContext:
@@ -335,17 +340,23 @@ class CliContext:
     # concrete implementations before dispatching to command handlers.
 
     run: Callable[..., subprocess.CompletedProcess | None] | None = field(
-        default=None, repr=False, compare=False,
+        default=None,
+        repr=False,
+        compare=False,
     )
     """Run a command, inheriting stdio. Raises CliProcessError on failure."""
 
     capture: Callable[..., str] | None = field(
-        default=None, repr=False, compare=False,
+        default=None,
+        repr=False,
+        compare=False,
     )
     """Run a command and return stripped stdout as a string."""
 
     require: Callable[..., None] | None = field(
-        default=None, repr=False, compare=False,
+        default=None,
+        repr=False,
+        compare=False,
     )
     """Assert that a binary exists on PATH, raising PrerequisiteError if not.
 
@@ -359,22 +370,30 @@ class CliContext:
     """
 
     confirm: Callable[..., bool] | None = field(
-        default=None, repr=False, compare=False,
+        default=None,
+        repr=False,
+        compare=False,
     )
     """Prompt the user for confirmation unless --yes is set."""
 
     confirm_destructive: Callable[..., bool] | None = field(
-        default=None, repr=False, compare=False,
+        default=None,
+        repr=False,
+        compare=False,
     )
     """Like confirm, but adds extra warnings for irreversible operations."""
 
     run_with_confirm: Callable[..., subprocess.CompletedProcess | None] | None = field(
-        default=None, repr=False, compare=False,
+        default=None,
+        repr=False,
+        compare=False,
     )
     """Confirm then run: wraps confirm() + run() in a single call."""
 
     run_with_secrets: Callable[..., subprocess.CompletedProcess | None] | None = field(
-        default=None, repr=False, compare=False,
+        default=None,
+        repr=False,
+        compare=False,
     )
     """Run a subprocess with secrets delivered via env (and optionally stdin).
 

--- a/src/clickwork/cli.py
+++ b/src/clickwork/cli.py
@@ -13,6 +13,7 @@ Plugin authors call this once in their entry point script:
     from clickwork import create_cli
     cli = create_cli(name="orbit-admin", commands_dir=Path(__file__).parent / "commands")
 """
+
 from __future__ import annotations
 
 import functools
@@ -29,12 +30,18 @@ from clickwork.config import ConfigError, load_config
 from clickwork.discovery import discover_commands
 from clickwork.process import (
     capture as _capture,
+)
+from clickwork.process import (
     run as _run,
+)
+from clickwork.process import (
     run_with_confirm as _run_with_confirm,
+)
+from clickwork.process import (
     run_with_secrets as _run_with_secrets,
 )
-from clickwork.prompts import confirm as _confirm, confirm_destructive as _confirm_destructive
-
+from clickwork.prompts import confirm as _confirm
+from clickwork.prompts import confirm_destructive as _confirm_destructive
 
 # Exit codes per spec:
 # 0 = success
@@ -126,9 +133,7 @@ class MutuallyExclusive(click.Option):
         for other in self._mutually_exclusive:
             other_value = opts.get(other)
             if current_value and other_value:
-                raise click.UsageError(
-                    f"--{self.name} and --{other} are mutually exclusive."
-                )
+                raise click.UsageError(f"--{self.name} and --{other} are mutually exclusive.")
         return super().handle_parse_result(ctx, opts, args)
 
 
@@ -154,6 +159,7 @@ def pass_cli_context(f):
         def deploy(ctx: CliContext) -> None:
             ctx.run(["kubectl", "apply", "-f", "manifests/"])
     """
+
     @click.pass_context
     @functools.wraps(f)
     def wrapper(click_ctx, *args, **kwargs):
@@ -185,6 +191,7 @@ def pass_cli_context(f):
                 "a CLI created by clickwork.create_cli()."
             )
         return f(cli_ctx, *args, **kwargs)
+
     return wrapper
 
 
@@ -298,7 +305,8 @@ def create_cli(
     # This is the standard Click pattern for parameterised group factories.
     @click.group(name=name, help=group_help)
     @click.option(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         count=True,
         # count=True means -v gives 1, -vv gives 2, etc.
         # We map these to INFO / DEBUG in setup_logging().
@@ -307,7 +315,8 @@ def create_cli(
         mutually_exclusive=["quiet"],
     )
     @click.option(
-        "--quiet", "-q",
+        "--quiet",
+        "-q",
         is_flag=True,
         default=False,
         help="Suppress non-error output.",
@@ -329,7 +338,8 @@ def create_cli(
         help="Select config environment (e.g., staging, production).",
     )
     @click.option(
-        "--yes", "-y",
+        "--yes",
+        "-y",
         is_flag=True,
         default=False,
         help="Skip confirmation prompts.",
@@ -436,14 +446,16 @@ def create_cli(
         # cli_ctx's flags. This keeps the logic single-sourced in process.py
         # (confirmation + execution + dry-run + signal forwarding) while still
         # letting ctx.run_with_confirm(cmd, msg) work without extra args.
-        cli_ctx.run_with_confirm = lambda cmd, msg, env=None, *, stdin_text=None, stdin_bytes=None: _run_with_confirm(
-            cmd,
-            msg,
-            yes=cli_ctx.yes,
-            dry_run=cli_ctx.dry_run,
-            env=env,
-            stdin_text=stdin_text,
-            stdin_bytes=stdin_bytes,
+        cli_ctx.run_with_confirm = lambda cmd, msg, env=None, *, stdin_text=None, stdin_bytes=None: (  # noqa: E501
+            _run_with_confirm(
+                cmd,
+                msg,
+                yes=cli_ctx.yes,
+                dry_run=cli_ctx.dry_run,
+                env=env,
+                stdin_text=stdin_text,
+                stdin_bytes=stdin_bytes,
+            )
         )
 
         # run_with_secrets: safety-focused wrapper for subprocesses that
@@ -452,12 +464,14 @@ def create_cli(
         # and accepts ``env=`` as a non-secret passthrough, matching the shape
         # of the other bindings above. secrets / stdin_secret are keyword-only
         # at the helper level; we mirror that here.
-        cli_ctx.run_with_secrets = lambda cmd, *, secrets, stdin_secret=None, env=None: _run_with_secrets(
-            cmd,
-            secrets=secrets,
-            stdin_secret=stdin_secret,
-            dry_run=cli_ctx.dry_run,
-            env=env,
+        cli_ctx.run_with_secrets = lambda cmd, *, secrets, stdin_secret=None, env=None: (
+            _run_with_secrets(
+                cmd,
+                secrets=secrets,
+                stdin_secret=stdin_secret,
+                dry_run=cli_ctx.dry_run,
+                env=env,
+            )
         )
 
         # Attach the CliContext to Click's ctx.obj so all subcommands can

--- a/src/clickwork/config.py
+++ b/src/clickwork/config.py
@@ -15,16 +15,17 @@ Schema validation (optional) ensures required keys exist, types match,
 and secrets don't leak into repo config. User config with loose permissions
 is refused (not just warned) to prevent secret leakage.
 """
+
 from __future__ import annotations
 
 import os
 import shlex
 import stat
 import sys
-from pathlib import Path
 
 # tomllib is stdlib in Python 3.11+. No external dependency needed.
 import tomllib
+from pathlib import Path
 
 from clickwork._types import Secret, normalize_prefix
 
@@ -118,6 +119,7 @@ def _load_toml_from_bytes(data: bytes) -> dict:
     # tomllib.loads() requires a str, but tomllib.load() requires a binary
     # IO object.  We use an in-memory BytesIO so no second open() is needed.
     import io
+
     return tomllib.load(io.BytesIO(data))
 
 
@@ -367,7 +369,7 @@ def load_env_file(path: Path) -> dict[str, str]:
         # We match 'export ' with a trailing space to avoid eating the
         # 'export' portion of a legitimate key like 'exportKEY=v'.
         if line.startswith("export "):
-            line = line[len("export "):].lstrip()
+            line = line[len("export ") :].lstrip()
 
         # Split on the *first* '=' only. Values may legitimately contain
         # '=' (e.g., base64-encoded tokens), so str.partition is safer than
@@ -384,9 +386,7 @@ def load_env_file(path: Path) -> dict[str, str]:
             # assignment, echoing raw_line would leak it into logs/CI
             # output. Just the line number is enough for the caller to
             # open the file and find the bad line.
-            raise ConfigError(
-                f"{path}: line {lineno}: malformed entry (no '=' separator)"
-            )
+            raise ConfigError(f"{path}: line {lineno}: malformed entry (no '=' separator)")
 
         # Keys are trimmed; values are *not* trimmed beyond outer whitespace.
         # We already stripped the whole line above, so key.strip() on top of
@@ -400,9 +400,7 @@ def load_env_file(path: Path) -> dict[str, str]:
         # (Same no-raw-line policy as the separator error above -- don't
         # echo the bad line because it may contain secrets.)
         if not key:
-            raise ConfigError(
-                f"{path}: line {lineno}: empty key (missing name before '=')"
-            )
+            raise ConfigError(f"{path}: line {lineno}: empty key (missing name before '=')")
 
         # Strip leading whitespace from the value before looking for
         # quotes. Common dotenv forms like ``KEY = value`` or
@@ -434,8 +432,7 @@ def load_env_file(path: Path) -> dict[str, str]:
         # This matches the behaviour users expect from a minimal dotenv
         # parser, without pulling in the full shell-quoting rules.
         if len(value) >= 2 and (
-            (value[0] == '"' and value[-1] == '"')
-            or (value[0] == "'" and value[-1] == "'")
+            (value[0] == '"' and value[-1] == '"') or (value[0] == "'" and value[-1] == "'")
         ):
             value = value[1:-1]
 
@@ -532,9 +529,9 @@ def load_config(
     # dict.update() means the last write wins, so we apply layers in order
     # from lowest to highest priority.
     config: dict = {}
-    config.update(user_config)   # Layer 4: lowest priority
+    config.update(user_config)  # Layer 4: lowest priority
     config.update(repo_default)  # Layer 3: overrides user
-    config.update(repo_env)      # Layer 2: overrides default
+    config.update(repo_env)  # Layer 2: overrides default
 
     # Track which keys came from repo config so the secret check can
     # identify values that should never live in a git-tracked file.
@@ -587,7 +584,6 @@ def load_config(
     # then defaults (fill missing values), then type check, then required check.
     if schema:
         for key, key_schema in schema.items():
-
             # Secret check: keys tagged secret=True must not appear in repo
             # config. Repo config is checked into git and visible to anyone
             # with repo access. Secrets must live in user config or env vars.

--- a/src/clickwork/discovery.py
+++ b/src/clickwork/discovery.py
@@ -16,6 +16,7 @@ The discovery_mode parameter controls which are active:
   commands_dir exists. Local commands shadow installed ones on name
   conflicts (with an info log).
 """
+
 from __future__ import annotations
 
 import hashlib

--- a/src/clickwork/global_options.py
+++ b/src/clickwork/global_options.py
@@ -46,11 +46,13 @@ Design choices worth reading before changing this file:
    Flags get simpler treatment: any truthy occurrence wins via OR, because
    the flag's presence is itself the signal regardless of the default.
 """
+
 from __future__ import annotations
 
 from typing import Any
 
 import click
+
 # NOTE on the click.core import: at the project's declared minimum
 # Click version (``click>=8.2`` per pyproject.toml) ``ParameterSource``
 # lives at ``click.core.ParameterSource`` and is NOT re-exported to
@@ -338,9 +340,7 @@ def add_global_option(
     # probe gives us the actual set of strings Click will register on
     # each command, matching how ``existing.opts`` / ``secondary_opts``
     # is populated on already-installed options.
-    new_flag_strings = set(getattr(probe, "opts", ())) | set(
-        getattr(probe, "secondary_opts", ())
-    )
+    new_flag_strings = set(getattr(probe, "opts", ())) | set(getattr(probe, "secondary_opts", ()))
 
     # Walk the command tree and install a FRESH click.Option on every level.
     # WHY a fresh instance per level: click.Option objects are stateful

--- a/src/clickwork/http.py
+++ b/src/clickwork/http.py
@@ -63,6 +63,7 @@ pattern::
     except URLError:
         ...  # network/transport issue -- retry, fail over, etc.
 """
+
 from __future__ import annotations
 
 import base64
@@ -74,7 +75,6 @@ import urllib.request
 
 from clickwork._types import Secret
 
-
 # ---------------------------------------------------------------------------
 # JSONValue recursive alias
 # ---------------------------------------------------------------------------
@@ -84,15 +84,7 @@ from clickwork._types import Secret
 # JSON contract visible in signatures rather than hiding it behind ``Any``.
 # Callers that need a concrete type (e.g., a dict) should narrow at the
 # call site with ``isinstance`` or ``typing.cast``.
-JSONValue = (
-    dict[str, "JSONValue"]
-    | list["JSONValue"]
-    | str
-    | int
-    | float
-    | bool
-    | None
-)
+JSONValue = dict[str, "JSONValue"] | list["JSONValue"] | str | int | float | bool | None
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +101,7 @@ logger = logging.getLogger("clickwork.http")
 # ---------------------------------------------------------------------------
 # HttpError
 # ---------------------------------------------------------------------------
+
 
 class HttpError(Exception):
     """Raised when the server returns a non-2xx response.
@@ -177,6 +170,7 @@ class HttpError(Exception):
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     """urllib redirect handler that refuses to follow 3xx responses.
@@ -306,9 +300,7 @@ def _sanitize_url_for_log(url: str) -> str:
     # params aren't credential-carrying the way query strings are, and
     # the path-level semantics still go out on the wire, so the log
     # should show the same shape.
-    return urllib.parse.urlunparse(
-        (parts.scheme, host_and_port, parts.path, parts.params, "", "")
-    )
+    return urllib.parse.urlunparse((parts.scheme, host_and_port, parts.path, parts.params, "", ""))
 
 
 def _check_allowed_hosts(url: str, allowed_hosts: list[str] | None) -> None:
@@ -396,9 +388,7 @@ def _check_allowed_hosts(url: str, allowed_hosts: list[str] | None) -> None:
     hostname_lower = parts.hostname.lower()
     allowed_lower = {h.lower() for h in allowed_hosts}
     if hostname_lower not in allowed_lower:
-        raise ValueError(
-            f"Host {parts.hostname!r} is not in allowed_hosts={allowed_hosts!r}."
-        )
+        raise ValueError(f"Host {parts.hostname!r} is not in allowed_hosts={allowed_hosts!r}.")
 
 
 def _unwrap_secret(value: str | Secret) -> str:
@@ -463,7 +453,7 @@ def _build_headers(
             auth_attached = True
         elif basic_auth is not None:
             user, pw = basic_auth
-            credentials = f"{user}:{_unwrap_secret(pw)}".encode("utf-8")
+            credentials = f"{user}:{_unwrap_secret(pw)}".encode()
             encoded = base64.b64encode(credentials).decode("ascii")
             merged["Authorization"] = f"Basic {encoded}"
             auth_attached = True
@@ -596,7 +586,9 @@ def _headers_to_dict(raw_headers) -> dict[str, str]:
     return dict(raw_headers)
 
 
-def _parse_response_body(body: bytes, content_type: str | None, parse_json: bool) -> JSONValue | bytes:
+def _parse_response_body(
+    body: bytes, content_type: str | None, parse_json: bool
+) -> JSONValue | bytes:
     """Decode a raw response body according to the parse_json + Content-Type rules.
 
     See the module docstring for the full policy. Used in two places: the
@@ -650,6 +642,7 @@ def _parse_response_body(body: bytes, content_type: str | None, parse_json: bool
 # ---------------------------------------------------------------------------
 # Shared core
 # ---------------------------------------------------------------------------
+
 
 def _send(
     method: str,
@@ -712,7 +705,10 @@ def _send(
     # wrong for PUT and DELETE, and for a GET-with-body edge case. Passing
     # ``method`` explicitly removes the ambiguity.
     request = urllib.request.Request(
-        url, data=body_bytes, method=method, headers=merged_headers,
+        url,
+        data=body_bytes,
+        method=method,
+        headers=merged_headers,
     )
 
     # WHY we install an opener that REFUSES HTTP redirects (3xx). urllib's
@@ -760,11 +756,11 @@ def _send(
         # and any buffering on err.fp.
         try:
             err_body_raw = err.read() if err.fp is not None else b""
-            err_content_type = (
-                err.headers.get("Content-Type") if err.headers is not None else None
-            )
+            err_content_type = err.headers.get("Content-Type") if err.headers is not None else None
             err_response_body = _parse_response_body(
-                err_body_raw, err_content_type, parse_json,
+                err_body_raw,
+                err_content_type,
+                parse_json,
             )
             err_headers = _headers_to_dict(err.headers)
         finally:
@@ -817,6 +813,7 @@ def _send(
 # Public methods (thin wrappers around _send)
 # ---------------------------------------------------------------------------
 
+
 def get(
     url: str,
     *,
@@ -857,7 +854,8 @@ def get(
         urllib.error.URLError: On transport failures (timeout, DNS, etc.).
     """
     return _send(
-        "GET", url,
+        "GET",
+        url,
         allowed_hosts=allowed_hosts,
         bearer_token=bearer_token,
         basic_auth=basic_auth,
@@ -896,7 +894,8 @@ def post(
               and must supply their own Content-Type if appropriate).
     """
     return _send(
-        "POST", url,
+        "POST",
+        url,
         body=body,
         allowed_hosts=allowed_hosts,
         bearer_token=bearer_token,
@@ -920,7 +919,8 @@ def put(
 ) -> JSONValue | bytes:
     """Issue an HTTP PUT. See :func:`get` / :func:`post` for shared kwargs."""
     return _send(
-        "PUT", url,
+        "PUT",
+        url,
         body=body,
         allowed_hosts=allowed_hosts,
         bearer_token=bearer_token,
@@ -949,7 +949,8 @@ def delete(
     than forcing a different signature.
     """
     return _send(
-        "DELETE", url,
+        "DELETE",
+        url,
         body=body,
         allowed_hosts=allowed_hosts,
         bearer_token=bearer_token,

--- a/src/clickwork/platform.py
+++ b/src/clickwork/platform.py
@@ -13,6 +13,7 @@ find_repo_root() walks up from a starting directory looking for .git as
 either a directory (normal repo) or a file (worktree/submodule). Falls back
 to `git rev-parse --show-toplevel` if the walk fails.
 """
+
 from __future__ import annotations
 
 import functools
@@ -237,6 +238,7 @@ def platform_dispatch(
         to define the signature and carry the Click decorator stack. All
         real work happens in the selected per-OS impl.
         """
+
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             impl, error_message, platform_name = _select_impl(dispatch_kwargs)
@@ -247,6 +249,7 @@ def platform_dispatch(
             # arguments flow straight through to the per-OS impl with the
             # same names the decorated function declared.
             return impl(*args, **kwargs)
+
         return wrapper
 
     return decorator

--- a/src/clickwork/prereqs.py
+++ b/src/clickwork/prereqs.py
@@ -10,6 +10,7 @@ This catches missing/misconfigured tools early -- before the command does
 any work -- instead of failing cryptically when a subprocess call fails
 halfway through a deploy.
 """
+
 from __future__ import annotations
 
 import logging
@@ -51,26 +52,26 @@ def require(binary: str, authenticated: bool = False) -> None:
     """
     if shutil.which(binary) is None:
         raise PrerequisiteError(
-            f"Required tool '{binary}' is not installed or not on PATH. "
-            f"Install it and try again."
+            f"Required tool '{binary}' is not installed or not on PATH. Install it and try again."
         )
 
     if authenticated:
         auth_cmd = AUTH_CHECKS.get(binary)
         if auth_cmd is None:
             logger.warning(
-                "No auth check known for '%s'. "
-                "Skipping authentication verification.",
+                "No auth check known for '%s'. Skipping authentication verification.",
                 binary,
             )
             return
 
         try:
             subprocess.run(
-                auth_cmd, capture_output=True, check=True, shell=False,
+                auth_cmd,
+                capture_output=True,
+                check=True,
+                shell=False,
             )
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as exc:
             raise PrerequisiteError(
-                f"'{binary}' is not authenticated. "
-                f"Run the appropriate login command and try again."
-            )
+                f"'{binary}' is not authenticated. Run the appropriate login command and try again."
+            ) from exc

--- a/src/clickwork/process.py
+++ b/src/clickwork/process.py
@@ -16,6 +16,7 @@ Signal handling: when the user presses Ctrl-C, the framework forwards SIGINT to
 the child process, waits for it to exit, then re-raises KeyboardInterrupt so the
 caller sees the interruption only after the child has had a chance to clean up.
 """
+
 from __future__ import annotations
 
 import logging
@@ -147,10 +148,7 @@ def _wait_with_signal_forwarding(proc: subprocess.Popen) -> int:
         raise
 
 
-
-def _validate_stdin_params(
-    stdin_text: str | None, stdin_bytes: bytes | None
-) -> None:
+def _validate_stdin_params(stdin_text: str | None, stdin_bytes: bytes | None) -> None:
     """Enforce mutual exclusivity between stdin_text and stdin_bytes.
 
     WHY two separate kwargs instead of one polymorphic stdin=str|bytes:
@@ -279,7 +277,7 @@ def run(
     # subprocess.run() has no hook for signal interception.
     try:
         proc = subprocess.Popen(cmd, **popen_kwargs)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         # The binary doesn't exist. This is a user/environment error (like
         # PrerequisiteError), not a framework bug. Surface it as exit code 1
         # via CliProcessError with an actionable message.
@@ -287,7 +285,7 @@ def run(
             subprocess.CalledProcessError(
                 returncode=127, cmd=cmd, stderr=f"Command not found: {cmd[0]}"
             )
-        )
+        ) from exc
 
     # If we opened a stdin pipe, write the payload and close it so the child
     # sees EOF and can proceed. We do this BEFORE _wait_with_signal_forwarding
@@ -382,9 +380,7 @@ def run(
 
     returncode = _wait_with_signal_forwarding(proc)
     if returncode != 0:
-        raise CliProcessError(
-            subprocess.CalledProcessError(returncode=returncode, cmd=cmd)
-        )
+        raise CliProcessError(subprocess.CalledProcessError(returncode=returncode, cmd=cmd))
     return subprocess.CompletedProcess(cmd, returncode)
 
 
@@ -420,18 +416,22 @@ def capture(
 
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, check=True, env=full_env,
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            env=full_env,
             shell=False,
         )
         return result.stdout.strip()
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         # Same treatment as run(): missing binary is a user/environment
         # error (exit 1), not a framework bug (exit 2).
         raise CliProcessError(
             subprocess.CalledProcessError(
                 returncode=127, cmd=cmd, stderr=f"Command not found: {cmd[0]}"
             )
-        )
+        ) from exc
     except subprocess.CalledProcessError as e:
         raise CliProcessError(e) from e
 
@@ -541,7 +541,7 @@ def _validate_no_secret_in_argv(cmd: list[str | Secret]) -> None:
             raise ValueError(
                 f"cmd[{idx}] is a Secret instance. Do not place secrets "
                 "in argv (visible in `ps` output). Pass them via "
-                "`secrets={...}` (env) or `stdin_secret=\"NAME\"` (stdin) instead."
+                '`secrets={...}` (env) or `stdin_secret="NAME"` (stdin) instead.'
             )
 
 
@@ -784,7 +784,7 @@ def run_with_secrets(
         raise TypeError(
             f"stdin_secret must be a str (or None); got "
             f"{type(stdin_secret).__name__}. Pass the KEY name from "
-            "your ``secrets={}`` dict, e.g. stdin_secret=\"TOKEN\"."
+            'your ``secrets={}`` dict, e.g. stdin_secret="TOKEN".'
         )
 
     # 6. stdin_secret must resolve to a key in ``secrets``. Done BEFORE
@@ -804,9 +804,7 @@ def run_with_secrets(
     # (run, _format_cmd) get the concrete list[str] they expect.
     plain_cmd: list[str] = list(cmd)  # type: ignore[arg-type]
 
-    stdin_display = (
-        f"<redacted:{stdin_secret}>" if stdin_secret is not None else "<none>"
-    )
+    stdin_display = f"<redacted:{stdin_secret}>" if stdin_secret is not None else "<none>"
 
     # 7. Dry-run short-circuit. Docstring promises dry_run does not
     # pull secret values into memory. Honouring that means bailing out

--- a/src/clickwork/prompts.py
+++ b/src/clickwork/prompts.py
@@ -9,6 +9,7 @@ Safety rules:
 - Non-TTY stdin (piped, redirected) auto-denies to prevent hangs
 - Default answer is always "no" (safe default)
 """
+
 from __future__ import annotations
 
 import sys

--- a/src/clickwork/testing.py
+++ b/src/clickwork/testing.py
@@ -81,6 +81,7 @@ default ``CliRunner()`` configuration (where streams were mixed unless
 ``mix_stderr=False`` was passed explicitly). Flooring at 8.2 gets us
 out of documenting that conditional behaviour.
 """
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ Provides a CliContext factory so tests don't need to construct one with
 7 positional args every time. Fixtures are added incrementally as modules
 are built.
 """
+
 import logging
 
 import pytest
@@ -17,6 +18,7 @@ def make_cli_context():
         def test_something(make_cli_context):
             ctx = make_cli_context(dry_run=True)
     """
+
     def _factory(**overrides):
         from clickwork._types import CliContext
 

--- a/tests/fixtures/sample-plugin/src/sample_commands/hello.py
+++ b/tests/fixtures/sample-plugin/src/sample_commands/hello.py
@@ -7,6 +7,7 @@ This command group shows:
 - Using require() for prerequisite checks
 - Using run()/capture() for subprocess execution
 """
+
 import click
 
 

--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -4,10 +4,10 @@ These tests create real CLI instances with real command files on disk,
 invoke them, and verify the full output. No mocking -- this catches
 integration issues between modules.
 """
+
 from pathlib import Path
 
 from click.testing import CliRunner
-import pytest
 
 from clickwork.cli import create_cli
 

--- a/tests/integration/test_sample_plugin.py
+++ b/tests/integration/test_sample_plugin.py
@@ -8,6 +8,7 @@ Marked ``network`` because pip install needs to download build dependencies
 (hatchling) from PyPI. Skip with ``pytest -m "not network"`` in sandboxed
 or offline environments.
 """
+
 import subprocess
 import sys
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,13 +10,14 @@ Test structure:
 - TestFrameworkErrorHandling: tests that unhandled exceptions exit with code 2
 - TestPassCliContextDecorator: tests the @pass_cli_context decorator
 """
+
+import sys
 from pathlib import Path
 from unittest.mock import patch
-import sys
 
 import click
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
 
 
 class TestCreateCli:
@@ -97,7 +98,6 @@ class TestCreateCli:
         The CliContext carries all of that from the group callback.
         """
         from clickwork.cli import create_cli
-        from clickwork._types import CliContext
 
         received_ctx = {}
 
@@ -317,7 +317,7 @@ class TestCreateCli:
 
 
 class TestEnableParentPackageImports:
-    """create_cli(enable_parent_package_imports=True) inserts commands_dir.parent.parent into sys.path.
+    """enable_parent_package_imports=True inserts commands_dir.parent.parent into sys.path.
 
     WHY this feature exists: plugin authors want their command files to be able
     to ``from tools.lib.X import Y`` without having to add sys.path boilerplate
@@ -615,8 +615,8 @@ class TestConvenienceMethods:
         ctx-level forwarding shape, mirroring the symmetry of
         test_ctx_run_forwards_stdin_text / test_ctx_run_with_confirm_forwards_stdin_text.
         """
-        from clickwork.cli import create_cli
         from clickwork._types import Secret
+        from clickwork.cli import create_cli
 
         received = {}
 
@@ -778,8 +778,8 @@ class TestFrameworkErrorHandling:
         framework bug. Exit code 1 tells CI it's a fixable configuration
         error, not an internal failure.
         """
-        from clickwork.cli import create_cli
         from clickwork._types import PrerequisiteError
+        from clickwork.cli import create_cli
 
         @click.command()
         @click.pass_obj
@@ -885,9 +885,7 @@ class TestClickExceptionHandling:
         assert "myfile.txt" in result.output
         assert "file not found" in result.output
 
-    def test_generic_click_exception_exits_1_without_internal_prefix(
-        self, tmp_path: Path
-    ):
+    def test_generic_click_exception_exits_1_without_internal_prefix(self, tmp_path: Path):
         """A plain click.ClickException should exit 1 with Click's own format.
 
         WHY: Plugin authors sometimes raise ClickException directly to signal
@@ -927,8 +925,8 @@ class TestPassCliContextDecorator:
         remembering to call ensure_object(). It also gives a clear error
         if the command is somehow invoked outside a create_cli() harness.
         """
-        from clickwork.cli import create_cli, pass_cli_context
         from clickwork._types import CliContext
+        from clickwork.cli import create_cli, pass_cli_context
 
         received = {}
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,6 +12,7 @@ Key behaviors tested:
 - Schema validation (required keys, types, defaults)
 - Secret safety (refuse secrets in repo config)
 """
+
 import sys
 from pathlib import Path
 
@@ -38,8 +39,7 @@ class TestLoadTomlConfig:
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text(
-            '[default]\nbucket = "staging"\n\n'
-            '[env.production]\nbucket = "prod"\n'
+            '[default]\nbucket = "staging"\n\n[env.production]\nbucket = "prod"\n'
         )
 
         config = load_config(
@@ -79,6 +79,7 @@ class TestLoadTomlConfig:
     def test_user_config_merged_below_repo(self, tmp_path: Path):
         """User config has lowest priority -- repo config overrides it."""
         import os
+
         from clickwork.config import load_config
 
         repo_config = tmp_path / "repo" / ".test-cli.toml"
@@ -106,9 +107,7 @@ class TestLoadTomlConfig:
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text(
-            '[default]\n'
-            'cloudflare.account_id = "abc123"\n'
-            'r2.bucket = "releases-staging"\n'
+            '[default]\ncloudflare.account_id = "abc123"\nr2.bucket = "releases-staging"\n'
         )
 
         config = load_config(
@@ -182,8 +181,7 @@ class TestEnvVarResolution:
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text(
-            '[default]\nbucket = "default-bucket"\n\n'
-            '[env.staging]\nbucket = "staging-bucket"\n'
+            '[default]\nbucket = "default-bucket"\n\n[env.staging]\nbucket = "staging-bucket"\n'
         )
 
         monkeypatch.setenv("TEST_CLI_ENV", "staging")
@@ -200,7 +198,7 @@ class TestSchemaValidation:
     """Config schema validates required keys, types, and defaults."""
 
     def test_required_key_missing_raises(self, tmp_path: Path):
-        from clickwork.config import load_config, ConfigError
+        from clickwork.config import ConfigError, load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text("[default]\n")
@@ -235,7 +233,7 @@ class TestSchemaValidation:
 
     def test_secret_in_repo_config_raises(self, tmp_path: Path):
         """Keys tagged secret=True must not appear in repo config."""
-        from clickwork.config import load_config, ConfigError
+        from clickwork.config import ConfigError, load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text('[default]\napi_token = "should-not-be-here"\n')
@@ -253,7 +251,7 @@ class TestSchemaValidation:
 
     def test_type_mismatch_raises(self, tmp_path: Path):
         """Values that don't match the declared type should raise ConfigError."""
-        from clickwork.config import load_config, ConfigError
+        from clickwork.config import ConfigError, load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text('[default]\nport = "not-a-number"\n')
@@ -318,8 +316,8 @@ class TestSecretWrapping:
         Wrapping in Secret() ensures str(value) returns '***' so accidental
         logging of ctx.config['api_token'] never exposes the real credential.
         """
-        from clickwork.config import load_config
         from clickwork._types import Secret
+        from clickwork.config import load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text("[default]\n")
@@ -343,8 +341,9 @@ class TestSecretWrapping:
     def test_secret_from_user_config_is_wrapped(self, tmp_path: Path):
         """A secret-tagged value from user config should also be a Secret."""
         import os
-        from clickwork.config import load_config
+
         from clickwork._types import Secret
+        from clickwork.config import load_config
 
         repo_config = tmp_path / ".test-cli.toml"
         repo_config.write_text("[default]\n")
@@ -369,8 +368,8 @@ class TestSecretWrapping:
 
     def test_non_secret_value_stays_plain_string(self, tmp_path: Path):
         """Values without secret: True should remain plain strings."""
-        from clickwork.config import load_config
         from clickwork._types import Secret
+        from clickwork.config import load_config
 
         config_file = tmp_path / ".test-cli.toml"
         config_file.write_text('[default]\nbucket = "my-bucket"\n')
@@ -427,14 +426,17 @@ class TestEnvVarDottedKeys:
         assert config["new_key"] == "from-env"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Unix permission model does not apply on Windows")
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Unix permission model does not apply on Windows"
+)
 class TestUserConfigPermissions:
     """User config file permissions are checked for safety."""
 
     def test_world_readable_config_is_refused(self, tmp_path: Path):
         """User config readable by others should raise ConfigError."""
         import os
-        from clickwork.config import load_config, ConfigError
+
+        from clickwork.config import ConfigError, load_config
 
         user_config = tmp_path / "config.toml"
         user_config.write_text('token = "secret"\n')
@@ -453,6 +455,7 @@ class TestUserConfigPermissions:
     def test_owner_only_config_passes(self, tmp_path: Path):
         """User config with 0o600 permissions should load fine."""
         import os
+
         from clickwork.config import load_config
 
         user_config = tmp_path / "config.toml"
@@ -485,7 +488,8 @@ class TestUserConfigPermissions:
         check back to read-only without a loud test failure.
         """
         import os
-        from clickwork.config import load_config, ConfigError
+
+        from clickwork.config import ConfigError, load_config
 
         user_config = tmp_path / "config.toml"
         user_config.write_text('token = "secret"\n')
@@ -522,6 +526,7 @@ class TestLoadEnvFile:
     def test_load_env_file_parses_simple_key_value(self, tmp_path: Path):
         """The simplest case: one KEY=VALUE line produces one dict entry."""
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -536,6 +541,7 @@ class TestLoadEnvFile:
         """A leading 'export ' (shell-style) is stripped so the same file
         works with both ``source .env`` and load_env_file()."""
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -557,6 +563,7 @@ class TestLoadEnvFile:
         test failure rather than a silent content bug.
         """
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -581,10 +588,11 @@ class TestLoadEnvFile:
         literal quoted form of the token.
         """
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
-        env_file.write_text('KEY = "wrapped"\nK2=   \'singly\'\n')
+        env_file.write_text("KEY = \"wrapped\"\nK2=   'singly'\n")
         os.chmod(env_file, 0o600)
 
         assert load_env_file(env_file) == {"KEY": "wrapped", "K2": "singly"}
@@ -598,6 +606,7 @@ class TestLoadEnvFile:
         space, or a human-readable prefix) and must survive.
         """
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -610,6 +619,7 @@ class TestLoadEnvFile:
         """Values wrapped in double quotes have the quotes stripped so
         spaces and other whitespace-adjacent characters survive parsing."""
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -623,6 +633,7 @@ class TestLoadEnvFile:
         purposes of this minimal parser -- the grammar deliberately does
         not distinguish shell's 'literal vs interpolated' semantics."""
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -638,6 +649,7 @@ class TestLoadEnvFile:
         supported" section for the full anti-feature list (variable
         substitution, inline comments, heredocs, etc.)."""
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -649,6 +661,7 @@ class TestLoadEnvFile:
     def test_load_env_file_skips_blank_lines(self, tmp_path: Path):
         """Blank lines (whitespace-only or empty) are harmless and ignored."""
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -660,6 +673,7 @@ class TestLoadEnvFile:
     def test_load_env_file_handles_multiple_keys(self, tmp_path: Path):
         """Multiple KEY=VALUE lines produce multiple dict entries."""
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"
@@ -692,7 +706,8 @@ class TestLoadEnvFile:
         group/other have the read bit set.
         """
         import os
-        from clickwork.config import load_env_file, ConfigError
+
+        from clickwork.config import ConfigError, load_env_file
 
         env_file = tmp_path / ".env"
         env_file.write_text("K=v\n")
@@ -716,7 +731,8 @@ class TestLoadEnvFile:
         tamper-resistance without any test failing.
         """
         import os
-        from clickwork.config import load_env_file, ConfigError
+
+        from clickwork.config import ConfigError, load_env_file
 
         env_file = tmp_path / ".env"
         env_file.write_text("K=v\n")
@@ -733,7 +749,8 @@ class TestLoadEnvFile:
         than silently dropping or misinterpreting. The error message must
         name the 1-based line number so the caller can locate the problem."""
         import os
-        from clickwork.config import load_env_file, ConfigError
+
+        from clickwork.config import ConfigError, load_env_file
 
         env_file = tmp_path / ".env"
         # Line 1: valid. Line 2: malformed (no '='). Line 3: valid.
@@ -752,7 +769,8 @@ class TestLoadEnvFile:
         so the caller can fix the bad line immediately.
         """
         import os
-        from clickwork.config import load_env_file, ConfigError
+
+        from clickwork.config import ConfigError, load_env_file
 
         env_file = tmp_path / ".env"
         # Line 1: valid. Line 2: empty key. Line 3: valid.
@@ -769,7 +787,8 @@ class TestLoadEnvFile:
         don't miss the bad case.
         """
         import os
-        from clickwork.config import load_env_file, ConfigError
+
+        from clickwork.config import ConfigError, load_env_file
 
         env_file = tmp_path / ".env"
         env_file.write_text("export =value\n")
@@ -788,6 +807,7 @@ class TestLoadEnvFile:
         semantics should use 'sh -c "set -a; source .env; env"' instead.
         """
         import os
+
         from clickwork.config import load_env_file
 
         env_file = tmp_path / ".env"

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -14,11 +14,11 @@ lightweight Click proxies so startup and unrelated commands don't import every
 installed plugin up front. The real command object loads on invocation, and on
 `--help` when Click asks for command metadata.
 """
+
 from pathlib import Path
 
 import click
 from click.testing import CliRunner
-import pytest
 
 
 class TestDirectoryScanning:
@@ -169,8 +169,9 @@ class TestNamespaceIsolation:
         scan gets the cached first helper from sys.modules -- silently
         loading the wrong code.
         """
-        from clickwork.discovery import discover_commands_from_dir
         from click.testing import CliRunner
+
+        from clickwork.discovery import discover_commands_from_dir
 
         # Create two directories each with a helper.py exporting 'cli'.
         dir_a = tmp_path / "a"
@@ -216,11 +217,7 @@ class TestDiscoveryMode:
 
         cmd_file = tmp_path / "hello.py"
         cmd_file.write_text(
-            "import click\n\n"
-            "@click.command()\n"
-            "def hello():\n"
-            "    click.echo('hi')\n\n"
-            "cli = hello\n"
+            "import click\n\n@click.command()\ndef hello():\n    click.echo('hi')\n\ncli = hello\n"
         )
 
         commands = discover_commands(
@@ -235,11 +232,7 @@ class TestDiscoveryMode:
         commands_dir = tmp_path / "commands"
         commands_dir.mkdir()
         (commands_dir / "status.py").write_text(
-            "import click\n\n"
-            "@click.command()\n"
-            "def status():\n"
-            "    pass\n\n"
-            "cli = status\n"
+            "import click\n\n@click.command()\ndef status():\n    pass\n\ncli = status\n"
         )
 
         commands = discover_commands(
@@ -260,11 +253,7 @@ class TestDiscoveryMode:
         commands_dir = tmp_path / "commands"
         commands_dir.mkdir()
         (commands_dir / "status.py").write_text(
-            "import click\n\n"
-            "@click.command()\n"
-            "def status():\n"
-            "    pass\n\n"
-            "cli = status\n"
+            "import click\n\n@click.command()\ndef status():\n    pass\n\ncli = status\n"
         )
 
         called = {"entry_points": False}
@@ -302,11 +291,7 @@ class TestDiscoveryMode:
         commands_dir = tmp_path / "commands"
         commands_dir.mkdir()
         (commands_dir / "local.py").write_text(
-            "import click\n\n"
-            "@click.command()\n"
-            "def local():\n"
-            "    pass\n\n"
-            "cli = local\n"
+            "import click\n\n@click.command()\ndef local():\n    pass\n\ncli = local\n"
         )
 
         # In installed mode, the directory should be ignored
@@ -369,7 +354,9 @@ class TestEntrypoints:
         assert result.exit_code == 0
         assert result.output.strip() == "bar:alice"
 
-    def test_local_command_shadows_installed_with_info_log(self, tmp_path: Path, monkeypatch, caplog):
+    def test_local_command_shadows_installed_with_info_log(
+        self, tmp_path: Path, monkeypatch, caplog
+    ):
         """When auto mode finds the same name in both sources, local wins.
 
         WHY: during dev you want to iterate on a local copy of a command
@@ -385,11 +372,7 @@ class TestEntrypoints:
         )
 
         (tmp_path / "hello.py").write_text(
-            "import click\n\n"
-            "@click.command()\n"
-            "def hello():\n"
-            "    pass\n\n"
-            "cli = hello\n"
+            "import click\n\n@click.command()\ndef hello():\n    pass\n\ncli = hello\n"
         )
 
         with caplog.at_level("INFO", logger="clickwork"):

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -21,6 +21,7 @@ These tests build minimal inline Click CLIs to keep each test focused on the
 parsing/merge behaviour of add_global_option itself. A single end-of-file
 integration test confirms it also works with ``clickwork.create_cli()``.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -404,6 +405,7 @@ class TestAddGlobalOptionEntryPointPropagation:
         """A plugin command loaded via entry point sees ctx.find_root().meta['json']."""
         import click
         from click.testing import CliRunner
+
         from clickwork.discovery import discover_commands_from_entrypoints
 
         captured: dict = {}
@@ -474,6 +476,7 @@ class TestAddGlobalOptionEntryPointPropagation:
         """
         import click
         from click.testing import CliRunner
+
         from clickwork.discovery import discover_commands_from_entrypoints
 
         class FakeEntryPoint:
@@ -519,9 +522,7 @@ class TestAddGlobalOptionEntryPointPropagation:
         assert "plugin-cmd" in result.output
         assert "--json" in result.output
 
-    def test_global_option_flag_collision_on_nested_subcommand_raises(
-        self, monkeypatch
-    ) -> None:
+    def test_global_option_flag_collision_on_nested_subcommand_raises(self, monkeypatch) -> None:
         """Collision on a nested subcommand of a loaded group also raises.
 
         WHY this test exists: the runtime check walks the LOADED command's
@@ -537,6 +538,7 @@ class TestAddGlobalOptionEntryPointPropagation:
         """
         import click
         from click.testing import CliRunner
+
         from clickwork.discovery import discover_commands_from_entrypoints
 
         class FakeEntryPoint:
@@ -581,8 +583,7 @@ class TestAddGlobalOptionEntryPointPropagation:
             f"got exit={result.exit_code}, output={result.output!r}"
         )
         assert "sub" in result.output, (
-            f"Error message must name the colliding subcommand path; got "
-            f"output={result.output!r}"
+            f"Error message must name the colliding subcommand path; got output={result.output!r}"
         )
         assert "--json" in result.output
 

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -40,20 +40,20 @@ around the custom no-redirect opener; patching it gives tests a
 single, stable seam (see ``clickwork.http._dispatch_request`` for
 why the custom opener exists).
 """
+
 from __future__ import annotations
 
 import base64
-import json
 import logging
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_response(
     *,
@@ -116,7 +116,7 @@ def _capture_request() -> tuple[MagicMock, list]:
         # Record (request, kwargs) so tests can inspect both the Request
         # payload and the timeout that urlopen received.
         captured.append((req, kwargs))
-        return _make_response(body=b'{}', content_type="application/json")
+        return _make_response(body=b"{}", content_type="application/json")
 
     mock.side_effect = _side_effect
     return mock, captured
@@ -125,6 +125,7 @@ def _capture_request() -> tuple[MagicMock, list]:
 # ---------------------------------------------------------------------------
 # GET: response parsing
 # ---------------------------------------------------------------------------
+
 
 class TestGetResponseParsing:
     """Response body decoding rules: JSON auto-parse vs raw bytes."""
@@ -147,7 +148,8 @@ class TestGetResponseParsing:
         from clickwork import http
 
         resp = _make_response(
-            body=b'{"ok": true}', content_type="application/json; charset=utf-8",
+            body=b'{"ok": true}',
+            content_type="application/json; charset=utf-8",
         )
         with patch("clickwork.http._dispatch_request", return_value=resp):
             result = http.get("https://example.com/api")
@@ -188,7 +190,8 @@ class TestGetResponseParsing:
         from clickwork import http
 
         resp = _make_response(
-            body=b'not really json', content_type="application/jsonx",
+            body=b"not really json",
+            content_type="application/jsonx",
         )
         with patch("clickwork.http._dispatch_request", return_value=resp):
             result = http.get("https://example.com/api")
@@ -200,6 +203,7 @@ class TestGetResponseParsing:
 # ---------------------------------------------------------------------------
 # Auth handling
 # ---------------------------------------------------------------------------
+
 
 class TestAuthHeaders:
     """bearer_token / basic_auth / explicit headers precedence."""
@@ -252,8 +256,12 @@ class TestAuthHeaders:
         from clickwork._types import Secret
 
         mock, captured = _capture_request()
-        with patch("clickwork.http._dispatch_request", mock), caplog.at_level(
-            logging.DEBUG, logger="clickwork.http",
+        with (
+            patch("clickwork.http._dispatch_request", mock),
+            caplog.at_level(
+                logging.DEBUG,
+                logger="clickwork.http",
+            ),
         ):
             http.get("https://example.com/api", bearer_token=Secret("supertok"))
 
@@ -275,8 +283,12 @@ class TestAuthHeaders:
         from clickwork._types import Secret
 
         mock, captured = _capture_request()
-        with patch("clickwork.http._dispatch_request", mock), caplog.at_level(
-            logging.DEBUG, logger="clickwork.http",
+        with (
+            patch("clickwork.http._dispatch_request", mock),
+            caplog.at_level(
+                logging.DEBUG,
+                logger="clickwork.http",
+            ),
         ):
             http.get(
                 "https://example.com/api",
@@ -296,6 +308,7 @@ class TestAuthHeaders:
 # Logging / redaction
 # ---------------------------------------------------------------------------
 
+
 class TestLoggingRedaction:
     """Log lines must redact auth material; never leak tokens."""
 
@@ -303,8 +316,12 @@ class TestLoggingRedaction:
         from clickwork import http
 
         mock = MagicMock(return_value=_make_response(body=b"{}"))
-        with patch("clickwork.http._dispatch_request", mock), caplog.at_level(
-            logging.DEBUG, logger="clickwork.http",
+        with (
+            patch("clickwork.http._dispatch_request", mock),
+            caplog.at_level(
+                logging.DEBUG,
+                logger="clickwork.http",
+            ),
         ):
             http.get("https://example.com/api", bearer_token="topsecret")
 
@@ -319,13 +336,15 @@ class TestLoggingRedaction:
 # Error handling
 # ---------------------------------------------------------------------------
 
+
 class TestHttpError:
     """Non-2xx responses become HttpError; transport errors propagate."""
 
     def test_get_raises_http_error_on_non_2xx(self):
         """404 with JSON body -> HttpError with parsed body + all attrs."""
-        from clickwork import http
         from urllib.error import HTTPError
+
+        from clickwork import http
 
         # urllib hands non-2xx responses to us via HTTPError, which has
         # a read()-able file-like body and a headers object. We build one
@@ -351,8 +370,9 @@ class TestHttpError:
         }
 
     def test_get_http_error_body_kept_as_bytes_when_not_json(self):
-        from clickwork import http
         from urllib.error import HTTPError
+
+        from clickwork import http
 
         err = HTTPError(
             url="https://example.com/api",
@@ -373,6 +393,7 @@ class TestHttpError:
 # ---------------------------------------------------------------------------
 # Allowlist
 # ---------------------------------------------------------------------------
+
 
 class TestAllowedHosts:
     """Per-call URL allowlist preflight."""
@@ -473,8 +494,7 @@ class TestAllowedHosts:
 
         def _urlopen_must_not_run(*args, **kwargs):
             raise AssertionError(
-                "urlopen was called despite hostless URL; the guard "
-                "should have rejected it first."
+                "urlopen was called despite hostless URL; the guard should have rejected it first."
             )
 
         with patch("clickwork.http._dispatch_request", side_effect=_urlopen_must_not_run):
@@ -550,6 +570,7 @@ class TestAllowedHosts:
 # Empty / malformed body handling
 # ---------------------------------------------------------------------------
 
+
 class TestEmptyBodyHandling:
     """204/empty-body responses with JSON Content-Type don't crash."""
 
@@ -567,7 +588,9 @@ class TestEmptyBodyHandling:
         from clickwork import http
 
         resp = _make_response(
-            status=204, body=b"", content_type="application/json",
+            status=204,
+            body=b"",
+            content_type="application/json",
         )
         with patch("clickwork.http._dispatch_request", return_value=resp):
             result = http.get("https://example.com/api")
@@ -580,7 +603,8 @@ class TestEmptyBodyHandling:
         from clickwork import http
 
         resp = _make_response(
-            body=b"   \n\t  ", content_type="application/json",
+            body=b"   \n\t  ",
+            content_type="application/json",
         )
         with patch("clickwork.http._dispatch_request", return_value=resp):
             result = http.get("https://example.com/api")
@@ -830,6 +854,7 @@ class TestRedirectsDisabled:
     def test_3xx_redirect_raises_http_error_instead_of_following(self):
         """A 302 with Location to another host must raise HttpError, not follow."""
         import urllib.error
+
         from clickwork import http
 
         # Build a urllib HTTPError carrying the 302 status + Location header,
@@ -885,6 +910,7 @@ class TestHttpErrorMessageSanitization:
     def test_http_error_url_attribute_is_sanitized(self):
         """HttpError.url strips userinfo and query string."""
         import urllib.error
+
         from clickwork import http
 
         def _raise_404(req, *args, **kwargs):
@@ -917,7 +943,6 @@ class TestHttpErrorMessageSanitization:
 
 
 class TestTimeout:
-
     def test_timeout_forwarded_to_urlopen(self):
         from clickwork import http
 
@@ -932,6 +957,7 @@ class TestTimeout:
 # ---------------------------------------------------------------------------
 # post / put / delete sanity
 # ---------------------------------------------------------------------------
+
 
 class TestBodyMethods:
     """post/put/delete round-trip JSON bodies correctly."""

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -5,9 +5,8 @@ verbosity levels driven by CLI flags, and automatic color detection. It's the
 first thing the CLI sets up, so it must be reliable and have no side effects
 when imported.
 """
-import logging
 
-import pytest
+import logging
 
 
 class TestSetupLogging:

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -10,6 +10,7 @@ per-OS implementation at call time. Tests monkeypatch ``sys.platform`` to
 the strings clickwork's ``is_linux``/``is_macos``/``is_windows`` helpers
 check for: ``"linux"``, ``"darwin"``, and (importantly) ``"win32"``.
 """
+
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -316,6 +317,7 @@ class TestPlatformDispatchViaClickRunner:
         Patches ``sys.platform`` to ``"linux"`` before invocation.
         """
         from click.testing import CliRunner
+
         from clickwork.cli import create_cli, pass_cli_context
         from clickwork.platform import platform_dispatch
 
@@ -343,7 +345,9 @@ class TestPlatformDispatchViaClickRunner:
             windows=_windows_up,
             macos=_macos_up,
         )
-        def runner_up(ctx, name): ...  # body intentionally empty -- platform_dispatch never calls it
+        def runner_up(
+            ctx, name
+        ): ...  # body intentionally empty -- platform_dispatch never calls it
 
         cmd_dir = tmp_path / "commands"
         cmd_dir.mkdir()

--- a/tests/unit/test_prereqs.py
+++ b/tests/unit/test_prereqs.py
@@ -5,6 +5,7 @@ Optionally require("gh", authenticated=True) to also verify auth status.
 The framework checks before the command runs and fails fast with a clear
 message if something is missing or not authenticated.
 """
+
 import subprocess
 from unittest.mock import patch
 
@@ -22,15 +23,15 @@ class TestRequire:
             require("fake-tool")
 
     def test_raises_for_missing_binary(self):
-        from clickwork.prereqs import require
         from clickwork._types import PrerequisiteError
+        from clickwork.prereqs import require
 
         with pytest.raises(PrerequisiteError):
             require("definitely-not-a-real-binary-xyz123")
 
     def test_error_message_names_the_binary(self):
-        from clickwork.prereqs import require
         from clickwork._types import PrerequisiteError
+        from clickwork.prereqs import require
 
         with pytest.raises(PrerequisiteError, match="missing-tool-abc"):
             require("missing-tool-abc")
@@ -41,10 +42,12 @@ class TestRequireAuthenticated:
 
     def test_auth_check_passes_when_command_succeeds(self):
         """When the auth check command exits 0, require() should pass."""
-        from clickwork.prereqs import require, AUTH_CHECKS
+        from clickwork.prereqs import AUTH_CHECKS, require
 
-        with patch("shutil.which", return_value="/usr/bin/fake"), \
-             patch("subprocess.run") as mock_run:
+        with (
+            patch("shutil.which", return_value="/usr/bin/fake"),
+            patch("subprocess.run") as mock_run,
+        ):
             mock_run.return_value = subprocess.CompletedProcess([], 0)
             # Register a fake auth check for testing.
             AUTH_CHECKS["fake-tool"] = ["fake-tool", "auth", "status"]
@@ -55,11 +58,13 @@ class TestRequireAuthenticated:
 
     def test_auth_check_fails_when_command_errors(self):
         """When the auth check command fails, require() should raise."""
-        from clickwork.prereqs import require, AUTH_CHECKS
         from clickwork._types import PrerequisiteError
+        from clickwork.prereqs import AUTH_CHECKS, require
 
-        with patch("shutil.which", return_value="/usr/bin/fake"), \
-             patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, ["fake"])):
+        with (
+            patch("shutil.which", return_value="/usr/bin/fake"),
+            patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, ["fake"])),
+        ):
             AUTH_CHECKS["fake-tool"] = ["fake-tool", "auth", "status"]
             try:
                 with pytest.raises(PrerequisiteError, match="not authenticated"):

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -14,10 +14,10 @@ instances, get version). The key design decisions tested here:
 8. run_with_confirm() prompts before executing destructive commands
 9. On Ctrl-C, run() forwards SIGINT to the child and waits before re-raising
 """
-import sys
-import subprocess
+
 import signal
-from unittest.mock import patch, MagicMock
+import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -32,8 +32,8 @@ class TestRun:
         assert result.returncode == 0
 
     def test_raises_cli_process_error_on_failure(self):
-        from clickwork.process import run
         from clickwork._types import CliProcessError
+        from clickwork.process import run
 
         with pytest.raises(CliProcessError) as exc_info:
             run([sys.executable, "-c", "import sys; sys.exit(1)"])
@@ -88,14 +88,14 @@ class TestRun:
         assert proc.wait.call_count == 2
 
     def test_missing_binary_raises_cli_process_error(self):
-        """A nonexistent binary should raise CliProcessError (exit 1), not FileNotFoundError (exit 2).
+        """A nonexistent binary should raise CliProcessError (exit 1), not FileNotFoundError.
 
         WHY: a missing binary is a user/environment error, not a framework bug.
         Without this catch, the framework's wrapped_invoke handler classifies it
         as an unhandled exception and exits with code 2, which is misleading.
         """
-        from clickwork.process import run
         from clickwork._types import CliProcessError
+        from clickwork.process import run
 
         with pytest.raises(CliProcessError, match="Command not found"):
             run(["definitely-not-a-real-binary-xyz123"])
@@ -227,8 +227,8 @@ class TestCapture:
         assert output.strip() == "hello world"
 
     def test_raises_on_failure(self):
-        from clickwork.process import capture
         from clickwork._types import CliProcessError
+        from clickwork.process import capture
 
         with pytest.raises(CliProcessError):
             capture([sys.executable, "-c", "import sys; sys.exit(1)"])
@@ -260,8 +260,8 @@ class TestCapture:
         Same policy as run(): missing binary is exit 1 (user error), not
         exit 2 (framework bug).
         """
-        from clickwork.process import capture
         from clickwork._types import CliProcessError
+        from clickwork.process import capture
 
         with pytest.raises(CliProcessError, match="Command not found"):
             capture(["definitely-not-a-real-binary-xyz123"])
@@ -271,8 +271,9 @@ class TestRunWithConfirm:
     """run_with_confirm() prompts before executing destructive commands."""
 
     def test_executes_when_confirmed(self):
-        from clickwork.process import run_with_confirm
         from unittest.mock import patch
+
+        from clickwork.process import run_with_confirm
 
         # Patch the imported binding in the process module so the already-
         # resolved _prompt_confirm name is replaced for this test.
@@ -285,8 +286,9 @@ class TestRunWithConfirm:
             assert result.returncode == 0
 
     def test_skips_when_denied(self):
-        from clickwork.process import run_with_confirm
         from unittest.mock import patch
+
+        from clickwork.process import run_with_confirm
 
         # Patch the imported binding in the process module so the already-
         # resolved _prompt_confirm name is replaced for this test.
@@ -393,8 +395,8 @@ class TestRunWithSecrets:
         leaking the secret, and an error message that echoes .get() back
         would undermine that.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         secret = Secret("supersecret-leaky")
         with pytest.raises(ValueError) as exc_info:
@@ -418,8 +420,8 @@ class TestRunWithSecrets:
         themselves is error-prone. Giving ``secrets=`` its own channel
         makes the "this is sensitive" signal visible at each call site.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         # Child reads the env var we claim to have set and exits 0 iff
         # the value matches -- we assert exit code here. The companion
@@ -447,8 +449,8 @@ class TestRunWithSecrets:
         guaranteeing Secret.get() was called and the value was placed
         into env under the right key.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         run_with_secrets(
             [
@@ -471,8 +473,8 @@ class TestRunWithSecrets:
         env -- that's intentional; some tools read from one channel, some
         from the other, and the caller shouldn't have to pick.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         run_with_secrets(
             [
@@ -495,8 +497,9 @@ class TestRunWithSecrets:
         ``<redacted>`` is the canonical placeholder.
         """
         import logging
-        from clickwork.process import run_with_secrets
+
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         # caplog captures records from the clickwork logger. INFO level
         # so the helper's own info-level message is retained.
@@ -520,9 +523,7 @@ class TestRunWithSecrets:
         # which has no 'v' -- or inside words like "secrets" / "env" /
         # "delegate". For safety, grep for "=v" which would be the shape
         # of a leaked "K=v" pair.)
-        assert "=v" not in all_log_text, (
-            f"Secret value leaked into log: {all_log_text!r}"
-        )
+        assert "=v" not in all_log_text, f"Secret value leaked into log: {all_log_text!r}"
 
     def test_run_with_secrets_does_not_leak_non_secret_env_values(self, caplog):
         """Non-secret env values ALSO redacted (tightened after Copilot PR #28).
@@ -541,8 +542,9 @@ class TestRunWithSecrets:
         log output.
         """
         import logging
-        from clickwork.process import run_with_secrets
+
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         accidental_plaintext = "ghp_totallyNotWrappedInSecret_12345"
 
@@ -575,8 +577,8 @@ class TestRunWithSecrets:
         child process. Raising early with a ValueError makes the mistake
         obvious. The error message must NOT leak any secret value.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         # Case 1: secrets dict is empty.
         with pytest.raises(ValueError) as exc_info:
@@ -606,8 +608,8 @@ class TestRunWithSecrets:
         output would defeat the purpose (and could leak the secret to
         the child even if we never read its output).
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         with patch("subprocess.Popen") as mock_popen:
             result = run_with_secrets(
@@ -630,8 +632,8 @@ class TestRunWithSecrets:
         tracks every .get() call; the assertion is that it was called
         ZERO times.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         unwrap_count = {"count": 0}
 
@@ -672,8 +674,9 @@ class TestRunWithSecrets:
         the offending index instead of a mysterious "command did the
         wrong thing" bug at runtime.
         """
-        from clickwork.process import run_with_secrets
         from pathlib import Path
+
+        from clickwork.process import run_with_secrets
 
         with pytest.raises(TypeError) as exc_info:
             run_with_secrets(
@@ -684,7 +687,11 @@ class TestRunWithSecrets:
         # locate the bad arg without a traceback hunt.
         assert "cmd[1]" in str(exc_info.value)
         # Mention the type so the fix (str(path)) is obvious.
-        assert "PosixPath" in str(exc_info.value) or "WindowsPath" in str(exc_info.value) or "Path" in str(exc_info.value)
+        assert (
+            "PosixPath" in str(exc_info.value)
+            or "WindowsPath" in str(exc_info.value)
+            or "Path" in str(exc_info.value)
+        )
 
     def test_run_with_secrets_rejects_non_str_env_value_before_unwrap(self):
         """Non-str env values must raise BEFORE any Secret.get() runs.
@@ -696,8 +703,8 @@ class TestRunWithSecrets:
         touch" promise: no Secret ever gets unwrapped on a call that
         was doomed anyway. The Spy-Secret counter pins that.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         unwrap_count = {"count": 0}
 
@@ -729,8 +736,8 @@ class TestRunWithSecrets:
 
     def test_run_with_secrets_rejects_non_str_env_key(self):
         """Non-str env keys also rejected up front (same rationale)."""
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         with pytest.raises(TypeError, match="env keys must be str"):
             run_with_secrets(
@@ -749,8 +756,8 @@ class TestRunWithSecrets:
         far from the real cause. Validate key types up front so the
         Secret.get() never happens on the bad call.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
         with pytest.raises(TypeError) as exc_info:
             run_with_secrets(
@@ -817,15 +824,17 @@ class TestRunWithSecrets:
         key in both env and secrets -- the secrets value is what the
         call was set up to deliver.
         """
-        from clickwork.process import run_with_secrets
         from clickwork._types import Secret
+        from clickwork.process import run_with_secrets
 
+        # Inline Python snippet kept on one line so the child shell invocation
+        # stays self-contained; noqa since E501 isn't worth splitting a string
+        # literal argument here.
+        snippet = (
+            "import os, sys; sys.stdout.write(os.environ['REGION'] + ':' + os.environ['TOKEN'])"
+        )
         run_with_secrets(
-            [
-                sys.executable,
-                "-c",
-                "import os, sys; sys.stdout.write(os.environ['REGION'] + ':' + os.environ['TOKEN'])",
-            ],
+            [sys.executable, "-c", snippet],
             secrets={"TOKEN": Secret("t")},
             env={"REGION": "us-east-1"},
         )

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -6,9 +6,8 @@ needs to handle three cases:
 2. Non-TTY (CI/piped): auto-deny (safe default) unless --yes
 3. --yes flag: auto-confirm everything (for scripted use)
 """
-from unittest.mock import patch
 
-import pytest
+from unittest.mock import patch
 
 
 class TestConfirm:
@@ -30,22 +29,28 @@ class TestConfirm:
     def test_user_types_y(self):
         from clickwork.prompts import confirm
 
-        with patch("clickwork.prompts._is_tty", return_value=True), \
-             patch("builtins.input", return_value="y"):
+        with (
+            patch("clickwork.prompts._is_tty", return_value=True),
+            patch("builtins.input", return_value="y"),
+        ):
             assert confirm("Continue?", yes=False) is True
 
     def test_user_types_n(self):
         from clickwork.prompts import confirm
 
-        with patch("clickwork.prompts._is_tty", return_value=True), \
-             patch("builtins.input", return_value="n"):
+        with (
+            patch("clickwork.prompts._is_tty", return_value=True),
+            patch("builtins.input", return_value="n"),
+        ):
             assert confirm("Continue?", yes=False) is False
 
     def test_empty_input_defaults_to_no(self):
         from clickwork.prompts import confirm
 
-        with patch("clickwork.prompts._is_tty", return_value=True), \
-             patch("builtins.input", return_value=""):
+        with (
+            patch("clickwork.prompts._is_tty", return_value=True),
+            patch("builtins.input", return_value=""),
+        ):
             assert confirm("Continue?", yes=False) is False
 
 
@@ -60,14 +65,18 @@ class TestConfirmDestructive:
     def test_requires_full_yes(self):
         from clickwork.prompts import confirm_destructive
 
-        with patch("clickwork.prompts._is_tty", return_value=True), \
-             patch("builtins.input", return_value="yes"):
+        with (
+            patch("clickwork.prompts._is_tty", return_value=True),
+            patch("builtins.input", return_value="yes"),
+        ):
             assert confirm_destructive("Drop database?", yes=False) is True
 
     def test_y_is_not_enough(self):
         """'y' doesn't count for destructive -- must type full 'yes'."""
         from clickwork.prompts import confirm_destructive
 
-        with patch("clickwork.prompts._is_tty", return_value=True), \
-             patch("builtins.input", return_value="y"):
+        with (
+            patch("clickwork.prompts._is_tty", return_value=True),
+            patch("builtins.input", return_value="y"),
+        ):
             assert confirm_destructive("Drop database?", yes=False) is False

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -11,6 +11,7 @@ convention in isolation. That way a future refactor of the helpers produces a
 single focused failure, instead of a wall of broken assertions that all
 collapse into the same root cause.
 """
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -6,16 +6,17 @@ Each test class covers one exported type: Secret, CliProcessError, CliContext.
 Run with:
     uv run pytest tests/unit/test_types.py -v
 """
+
 import copy
 import pickle
 import subprocess
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Secret
 # ---------------------------------------------------------------------------
+
 
 class TestSecret:
     """Verify that Secret wraps a string and keeps it out of every repr path."""
@@ -97,10 +98,13 @@ class TestSecret:
 # CliProcessError
 # ---------------------------------------------------------------------------
 
+
 class TestCliProcessError:
     """Verify CliProcessError wraps CalledProcessError cleanly."""
 
-    def _make_cpe(self, returncode: int = 1, cmd: str = "git status", stderr: str = "fatal: not a git repo"):
+    def _make_cpe(
+        self, returncode: int = 1, cmd: str = "git status", stderr: str = "fatal: not a git repo"
+    ):
         # Helper to construct a CalledProcessError -- CalledProcessError takes
         # (returncode, cmd, output, stderr) positional args.
         return subprocess.CalledProcessError(
@@ -146,6 +150,7 @@ class TestCliProcessError:
 # ---------------------------------------------------------------------------
 # CliContext
 # ---------------------------------------------------------------------------
+
 
 class TestCliContext:
     """Verify CliContext construction, config access, and callable fields."""


### PR DESCRIPTION
Adds `.github/workflows/lint.yml` running `ruff check .` and `ruff format --check .` on every push to main + every PR. Both block merge on failure.

## Config

`[tool.ruff]` with `line-length = 100`, `target-version = "py311"`. Rules: `E, F, W, B, I, UP` (pycodestyle errors + pyflakes + warnings + bugbear + isort + pyupgrade). No ignores.

## Scope

- 1 new file: `.github/workflows/lint.yml`
- `pyproject.toml`: 3 new config sections (`[tool.ruff]`, `[tool.ruff.lint]`, `[tool.ruff.format]`)
- Format pass: 29 files reformatted (whitespace/style)
- Lint pass: 87 auto-fixes + 7 manual (B904 chaining in 2 files, E501 line-length in 3 tests, 1 unavoidable `# noqa: E501` on a kwarg-heavy lambda signature in `cli.py`)

## Test plan

- [x] `mise exec -- uvx ruff check .` → 0 violations
- [x] `mise exec -- uvx ruff format --check .` → 0 diff
- [x] `mise exec -- python -m pytest tests/ -q` → 257 passed

Type-check (mypy) is a separate PR ([Wave 2b #38b](https://github.com/qubitrenegade/clickwork/issues/38)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)