### PR TITLE
ci: smoke-test wheel + sdist installs in fresh venv (Fixes #40)

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -35,30 +35,51 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Set up Python 3.13
-        run: uv python install 3.13
+        # WHY both install AND pin: `uv python install 3.13` downloads the
+        # interpreter into uv's managed cache but does NOT change which
+        # `python` runs when invoked bare. `uv python pin 3.13` writes
+        # `.python-version` in the repo root so every subsequent
+        # `uv run python ...` and `uv venv --python 3.13 ...` uses 3.13
+        # deterministically, regardless of what the runner image ships
+        # with by default.
+        run: |
+          uv python install 3.13
+          uv python pin 3.13
 
       - name: Build wheel and sdist
         # `uv build` produces both dist/*.whl and dist/*.tar.gz in one call.
+        # It respects the `.python-version` pin set above.
         run: uv build
 
       - name: Assert py.typed is present in the wheel
-        # Until #37 (py.typed marker) lands, this assertion FAILS. We mark
-        # it continue-on-error so this workflow can land independently of
-        # #37. Once #37 merges, the step starts passing automatically and
-        # this comment + continue-on-error can be removed to make it a
-        # hard gate.
+        # HARD GATE: py.typed landed in #66 on main, so this assertion must
+        # pass for every build. If it ever fails, the wheel shipped without
+        # the PEP 561 marker and type-checkers downstream will silently
+        # ignore clickwork's type hints -- that's a release-blocking bug.
         #
-        # See: https://github.com/qubitrenegade/clickwork/issues/37
-        continue-on-error: true
+        # WHY `uv run python` (not bare `python`): bare `python` resolves
+        # to whatever PATH points at -- on ubuntu-latest today that's 3.12,
+        # not the 3.13 we pinned above. `uv run python` honors the pin.
+        #
+        # WHY exact-path match `clickwork/py.typed` (not substring
+        # `py.typed`): a substring match would also accept a file like
+        # `foo_py.typed_bar`. We want the real marker file at its exact
+        # location inside the wheel.
+        #
+        # WHY length-1 assert on the glob: if a previous run left a stale
+        # wheel in dist/, `glob(...)[0]` would silently pick the first one
+        # lexicographically and mask the real build. Fail loudly instead.
         run: |
-          python - <<'PY'
+          uv run python - <<'PY'
           import glob
           import zipfile
 
-          whl = glob.glob("dist/*.whl")[0]
+          wheels = glob.glob("dist/*.whl")
+          assert len(wheels) == 1, f"expected exactly one wheel, found {wheels}"
+          whl = wheels[0]
           names = zipfile.ZipFile(whl).namelist()
-          assert any("py.typed" in n for n in names), (
-              f"py.typed missing from wheel: {names}"
+          assert "clickwork/py.typed" in names, (
+              f"py.typed missing: {[n for n in names if 'clickwork' in n]}"
           )
           print(f"py.typed present in {whl}")
           PY
@@ -67,8 +88,8 @@ jobs:
         # WHY a fresh venv (not `uv sync`): `uv sync` installs the project
         # in editable mode from `src/`. We need to exercise the BUILT
         # artifact, not the source tree, to catch missing-file bugs in
-        # the wheel itself. `python -m venv` creates a standalone venv
-        # that has no connection to the repo's .venv.
+        # the wheel itself. `uv venv` creates a standalone venv that has
+        # no connection to the repo's .venv.
         #
         # WHY we copy tests to a temp dir: running `pytest` from the
         # repo root would pick up `src/clickwork/` on `sys.path` (via
@@ -90,9 +111,25 @@ jobs:
         # copied tests live in /tmp/wheel-smoke-tests so parents[2]
         # points at /tmp, not the repo. Those tests are covered by
         # test.yml's editable run; here we deselect them.
+        #
+        # WHY `uv venv --python 3.13` (not `python -m venv`): bare
+        # `python` on the runner is 3.12, not the 3.13 we pinned. Passing
+        # `--python 3.13` bakes the correct interpreter into the venv so
+        # everything downstream (`pip install`, `pytest`) runs on 3.13.
+        #
+        # WHY we resolve the wheel path first (not `pip install dist/*.whl`):
+        # pip expands the glob itself and installs EVERY match. If a stale
+        # wheel from a previous build survives, pip happily installs both
+        # and one overrides the other non-deterministically. Resolve to
+        # exactly one path and fail loudly otherwise.
         run: |
-          python -m venv /tmp/wheel-smoke
-          /tmp/wheel-smoke/bin/pip install dist/*.whl pytest pytest-mock
+          WHEEL=$(ls dist/*.whl)
+          if [ "$(printf '%s\n' "$WHEEL" | wc -l)" -ne 1 ]; then
+            echo "expected exactly one wheel, got: $WHEEL"
+            exit 1
+          fi
+          uv venv --python 3.13 /tmp/wheel-smoke
+          /tmp/wheel-smoke/bin/pip install "$WHEEL" pytest pytest-mock
           cp -r tests /tmp/wheel-smoke-tests
           cat > /tmp/wheel-smoke-tests/pytest.ini <<'INI'
           [pytest]
@@ -112,13 +149,22 @@ jobs:
         run: rm -rf /tmp/wheel-smoke /tmp/wheel-smoke-tests
 
       - name: Install sdist into fresh venv and run tests
-        # Identical flow to the wheel step, but `pip install dist/*.tar.gz`
-        # forces pip to rebuild from the sdist. Catches sdist-specific
-        # packaging bugs (e.g. a file that got into the wheel via hatchling
-        # but is missing from the sdist's MANIFEST).
+        # Identical flow to the wheel step, but pointed at the .tar.gz so
+        # pip rebuilds from the sdist. Catches sdist-specific packaging
+        # bugs (e.g. a file that got into the wheel via hatchling but is
+        # missing from the sdist's MANIFEST).
+        #
+        # Same discipline as the wheel step: pin the venv to 3.13 via
+        # `uv venv --python 3.13`, and resolve the sdist glob to exactly
+        # one path so a stale tarball can't sneak in.
         run: |
-          python -m venv /tmp/wheel-smoke
-          /tmp/wheel-smoke/bin/pip install dist/*.tar.gz pytest pytest-mock
+          SDIST=$(ls dist/*.tar.gz)
+          if [ "$(printf '%s\n' "$SDIST" | wc -l)" -ne 1 ]; then
+            echo "expected exactly one sdist, got: $SDIST"
+            exit 1
+          fi
+          uv venv --python 3.13 /tmp/wheel-smoke
+          /tmp/wheel-smoke/bin/pip install "$SDIST" pytest pytest-mock
           cp -r tests /tmp/wheel-smoke-tests
           cat > /tmp/wheel-smoke-tests/pytest.ini <<'INI'
           [pytest]

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -77,7 +77,11 @@ jobs:
           wheels = glob.glob("dist/*.whl")
           assert len(wheels) == 1, f"expected exactly one wheel, found {wheels}"
           whl = wheels[0]
-          names = zipfile.ZipFile(whl).namelist()
+          # Use the ZipFile as a context manager so the file handle is
+          # released deterministically instead of waiting for GC. Matters
+          # on Windows where GC timing can leave the archive locked.
+          with zipfile.ZipFile(whl) as zf:
+              names = zf.namelist()
           assert "clickwork/py.typed" in names, (
               f"py.typed missing: {[n for n in names if 'clickwork' in n]}"
           )
@@ -144,7 +148,7 @@ jobs:
       - name: Clean up wheel venv
         # Run after the wheel test so the sdist step starts from a clean
         # slate. `if: always()` so we still reset even if the wheel tests
-        # failed -- otherwise the sdist step inherits the wheel venv.
+        # failed -- otherwise the sdist step could inherit lingering state.
         if: always()
         run: rm -rf /tmp/wheel-smoke /tmp/wheel-smoke-tests
 
@@ -156,22 +160,24 @@ jobs:
         #
         # Same discipline as the wheel step: pin the venv to 3.13 via
         # `uv venv --python 3.13`, and resolve the sdist glob to exactly
-        # one path so a stale tarball can't sneak in.
+        # one path so a stale tarball can't sneak in. Uses
+        # /tmp/sdist-smoke* (not /tmp/wheel-smoke*) so CI logs make it
+        # unambiguous which artifact is being exercised at each step.
         run: |
           SDIST=$(ls dist/*.tar.gz)
           if [ "$(printf '%s\n' "$SDIST" | wc -l)" -ne 1 ]; then
             echo "expected exactly one sdist, got: $SDIST"
             exit 1
           fi
-          uv venv --python 3.13 /tmp/wheel-smoke
-          /tmp/wheel-smoke/bin/pip install "$SDIST" pytest pytest-mock
-          cp -r tests /tmp/wheel-smoke-tests
-          cat > /tmp/wheel-smoke-tests/pytest.ini <<'INI'
+          uv venv --python 3.13 /tmp/sdist-smoke
+          /tmp/sdist-smoke/bin/pip install "$SDIST" pytest pytest-mock
+          cp -r tests /tmp/sdist-smoke-tests
+          cat > /tmp/sdist-smoke-tests/pytest.ini <<'INI'
           [pytest]
           filterwarnings =
               error
           markers =
               network: requires network access (pip install, HTTP calls)
           INI
-          cd /tmp/wheel-smoke-tests
-          /tmp/wheel-smoke/bin/python -m pytest -q -m "not network"
+          cd /tmp/sdist-smoke-tests
+          /tmp/sdist-smoke/bin/python -m pytest -q -m "not network"

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,131 @@
+name: Release smoke
+
+# WHY this workflow exists (separate from test.yml):
+# test.yml exercises the EDITABLE checkout (`uv sync` installs from `src/`).
+# That catches logic bugs but NOT packaging bugs: a wheel or sdist could be
+# missing `py.typed`, a data file, a template, or a submodule, and the
+# editable test run would still pass. A user `pip install`-ing the package
+# would then hit the missing file at runtime.
+#
+# This workflow builds the same artifacts that get published to PyPI
+# (`uv build` -> `dist/*.whl` + `dist/*.tar.gz`), installs each into a
+# FRESH venv that has no access to the source tree, and runs the test
+# suite against the installed package. A missing-file bug in the wheel
+# shows up here as a test failure before we cut a release.
+#
+# See docs/superpowers/specs/2026-04-18-clickwork-1.0-roadmap.md Wave 2b #40.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # workflow_dispatch lets the maintainer run this manually right before
+  # cutting a release, as an extra belt-and-suspenders check.
+  workflow_dispatch:
+
+jobs:
+  release-smoke:
+    name: Build + install from wheel/sdist + run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Build wheel and sdist
+        # `uv build` produces both dist/*.whl and dist/*.tar.gz in one call.
+        run: uv build
+
+      - name: Assert py.typed is present in the wheel
+        # Until #37 (py.typed marker) lands, this assertion FAILS. We mark
+        # it continue-on-error so this workflow can land independently of
+        # #37. Once #37 merges, the step starts passing automatically and
+        # this comment + continue-on-error can be removed to make it a
+        # hard gate.
+        #
+        # See: https://github.com/qubitrenegade/clickwork/issues/37
+        continue-on-error: true
+        run: |
+          python - <<'PY'
+          import glob
+          import zipfile
+
+          whl = glob.glob("dist/*.whl")[0]
+          names = zipfile.ZipFile(whl).namelist()
+          assert any("py.typed" in n for n in names), (
+              f"py.typed missing from wheel: {names}"
+          )
+          print(f"py.typed present in {whl}")
+          PY
+
+      - name: Install wheel into fresh venv and run tests
+        # WHY a fresh venv (not `uv sync`): `uv sync` installs the project
+        # in editable mode from `src/`. We need to exercise the BUILT
+        # artifact, not the source tree, to catch missing-file bugs in
+        # the wheel itself. `python -m venv` creates a standalone venv
+        # that has no connection to the repo's .venv.
+        #
+        # WHY we copy tests to a temp dir: running `pytest` from the
+        # repo root would pick up `src/clickwork/` on `sys.path` (via
+        # pyproject's `pythonpath = ["src"]`) and shadow the installed
+        # wheel. Running from /tmp/wheel-smoke-tests forces pytest to
+        # import from site-packages, which is what we want to exercise.
+        #
+        # WHY the minimal pytest.ini: the copied tests directory has no
+        # pyproject.toml, so pytest loses the `filterwarnings = error`
+        # and the `network` marker registration. We rewrite a minimal
+        # pytest.ini that preserves both so (a) unexpected warnings
+        # still fail the run and (b) the network marker doesn't trigger
+        # a PytestUnknownMarkWarning.
+        #
+        # WHY `-m "not network"`: the tests marked `network` (in
+        # tests/integration/test_sample_plugin.py) locate the repo root
+        # via Path(__file__).resolve().parents[2] and pip-install the
+        # sample-plugin fixture from there. Under the smoke test the
+        # copied tests live in /tmp/wheel-smoke-tests so parents[2]
+        # points at /tmp, not the repo. Those tests are covered by
+        # test.yml's editable run; here we deselect them.
+        run: |
+          python -m venv /tmp/wheel-smoke
+          /tmp/wheel-smoke/bin/pip install dist/*.whl pytest pytest-mock
+          cp -r tests /tmp/wheel-smoke-tests
+          cat > /tmp/wheel-smoke-tests/pytest.ini <<'INI'
+          [pytest]
+          filterwarnings =
+              error
+          markers =
+              network: requires network access (pip install, HTTP calls)
+          INI
+          cd /tmp/wheel-smoke-tests
+          /tmp/wheel-smoke/bin/python -m pytest -q -m "not network"
+
+      - name: Clean up wheel venv
+        # Run after the wheel test so the sdist step starts from a clean
+        # slate. `if: always()` so we still reset even if the wheel tests
+        # failed -- otherwise the sdist step inherits the wheel venv.
+        if: always()
+        run: rm -rf /tmp/wheel-smoke /tmp/wheel-smoke-tests
+
+      - name: Install sdist into fresh venv and run tests
+        # Identical flow to the wheel step, but `pip install dist/*.tar.gz`
+        # forces pip to rebuild from the sdist. Catches sdist-specific
+        # packaging bugs (e.g. a file that got into the wheel via hatchling
+        # but is missing from the sdist's MANIFEST).
+        run: |
+          python -m venv /tmp/wheel-smoke
+          /tmp/wheel-smoke/bin/pip install dist/*.tar.gz pytest pytest-mock
+          cp -r tests /tmp/wheel-smoke-tests
+          cat > /tmp/wheel-smoke-tests/pytest.ini <<'INI'
+          [pytest]
+          filterwarnings =
+              error
+          markers =
+              network: requires network access (pip install, HTTP calls)
+          INI
+          cd /tmp/wheel-smoke-tests
+          /tmp/wheel-smoke/bin/python -m pytest -q -m "not network"

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -140,7 +140,14 @@ jobs:
           fi
           WHEEL="${wheels[0]}"
           uv venv --python 3.13 /tmp/wheel-smoke
-          /tmp/wheel-smoke/bin/pip install "$WHEEL" pytest pytest-mock
+          # Pin pytest/pytest-mock to the SAME versions uv.lock
+          # records for the editable test.yml run. Without pins, the
+          # smoke-test venv would pick up whatever PyPI has at job
+          # start -- a new pytest release could land here before
+          # test.yml sees it, causing this job to flap on upstream
+          # changes rather than code changes. Bumping these pins
+          # should track uv.lock bumps.
+          /tmp/wheel-smoke/bin/pip install "$WHEEL" 'pytest==9.0.2' 'pytest-mock==3.15.1'
           cp -r tests /tmp/wheel-smoke-tests
           cat > /tmp/wheel-smoke-tests/pytest.ini <<'INI'
           [pytest]
@@ -182,7 +189,7 @@ jobs:
           fi
           SDIST="${sdists[0]}"
           uv venv --python 3.13 /tmp/sdist-smoke
-          /tmp/sdist-smoke/bin/pip install "$SDIST" pytest pytest-mock
+          /tmp/sdist-smoke/bin/pip install "$SDIST" 'pytest==9.0.2' 'pytest-mock==3.15.1'
           cp -r tests /tmp/sdist-smoke-tests
           cat > /tmp/sdist-smoke-tests/pytest.ini <<'INI'
           [pytest]

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -127,11 +127,18 @@ jobs:
         # and one overrides the other non-deterministically. Resolve to
         # exactly one path and fail loudly otherwise.
         run: |
-          WHEEL=$(ls dist/*.whl)
-          if [ "$(printf '%s\n' "$WHEEL" | wc -l)" -ne 1 ]; then
-            echo "expected exactly one wheel, got: $WHEEL"
+          # Use bash glob with nullglob so zero matches produce an empty
+          # array (not a literal 'dist/*.whl' string) and we can emit a
+          # clean error message. Without nullglob + the ls(1) pipeline,
+          # an empty dist/ directory would trip 'set -e' inside ls before
+          # our explicit count check ran.
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "expected exactly one wheel, got: ${wheels[*]:-<none>}"
             exit 1
           fi
+          WHEEL="${wheels[0]}"
           uv venv --python 3.13 /tmp/wheel-smoke
           /tmp/wheel-smoke/bin/pip install "$WHEEL" pytest pytest-mock
           cp -r tests /tmp/wheel-smoke-tests
@@ -164,11 +171,16 @@ jobs:
         # /tmp/sdist-smoke* (not /tmp/wheel-smoke*) so CI logs make it
         # unambiguous which artifact is being exercised at each step.
         run: |
-          SDIST=$(ls dist/*.tar.gz)
-          if [ "$(printf '%s\n' "$SDIST" | wc -l)" -ne 1 ]; then
-            echo "expected exactly one sdist, got: $SDIST"
+          # Same nullglob pattern as the wheel step -- empty dist/ must
+          # produce a readable error, not a spurious 'ls: cannot access'
+          # that trips set -e before our count check.
+          shopt -s nullglob
+          sdists=(dist/*.tar.gz)
+          if [ "${#sdists[@]}" -ne 1 ]; then
+            echo "expected exactly one sdist, got: ${sdists[*]:-<none>}"
             exit 1
           fi
+          SDIST="${sdists[0]}"
           uv venv --python 3.13 /tmp/sdist-smoke
           /tmp/sdist-smoke/bin/pip install "$SDIST" pytest pytest-mock
           cp -r tests /tmp/sdist-smoke-tests


### PR DESCRIPTION
New `.github/workflows/release-smoke.yml`: builds wheel + sdist, installs each into a fresh `/tmp` venv, runs tests against the INSTALLED package (not the editable checkout).

## Why

Normal `pytest tests/` exercises the source tree. A wheel missing `py.typed` (#37) or a data file or a module wouldn't be caught by the normal test workflow. This job catches packaging bugs BEFORE publish.

## Triggers

`push` to main, every PR, and `workflow_dispatch` (for manual verification before a release cut).

## Test selection

`-m 'not network'` — two integration tests use `Path(__file__).parents[2]` to find the repo root for `pip install` of the fixture. When tests are copied to `/tmp`, `parents[2]` is `/tmp`. Those tests are already marked `network` (they `pip install` the fixture), so the existing marker is the correct seam. Editable `test.yml` run keeps executing them (its cwd IS the repo root). No source changes to tests needed, no env-var seam added, `test.yml` untouched.

## py.typed assertion

Bridged with `continue-on-error: true` until [#37](https://github.com/qubitrenegade/clickwork/pull/66) lands. Inline comment points at the issue and instructs flipping to hard-fail post-merge. Verified locally that the assert currently fails with the expected `AssertionError`.

## Local verification

Full `uv build` + fresh-venv install + `pytest` against both wheel and sdist → 255 passed, 2 deselected (`network`), 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)