### PR TITLE
ci: auto-generated release notes config (Fixes #57)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+# Configuration for GitHub's auto-generated release notes.
+#
+# When a maintainer creates a release via the GitHub UI or `gh release create`,
+# GitHub's "Generate release notes" button groups merged PRs by their labels
+# using this file. See:
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+#
+# To make sure a PR lands in the right section, apply one of the labels listed
+# below before merging. Unlabeled PRs fall through to "Other changes".
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,12 +1,17 @@
 # Configuration for GitHub's auto-generated release notes.
 #
-# When a maintainer creates a release via the GitHub UI or `gh release create`,
-# GitHub's "Generate release notes" button groups merged PRs by their labels
-# using this file. See:
+# This file is only consulted when auto-generated notes are explicitly
+# requested. Two ways to request them:
+#   - GitHub UI: click "Generate release notes" on the Release creation form.
+#   - gh CLI: pass `--generate-notes` to `gh release create`.
+#
+# A bare `gh release create` (or the UI form without the button) uses the
+# body text you supply directly and does NOT consult this file. See:
 # https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
 #
-# To make sure a PR lands in the right section, apply one of the labels listed
-# below before merging. Unlabeled PRs fall through to "Other changes".
+# To make sure a PR lands in the right section when notes ARE generated,
+# apply one of the labels listed below before merging. Unlabeled PRs fall
+# through to "Other changes".
 changelog:
   exclude:
     labels:

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -664,9 +664,11 @@ can skip it.
 
 Release notes for clickwork itself are produced by GitHub's built-in
 auto-generated release notes feature, configured via
-[`.github/release.yml`](../.github/release.yml). When a maintainer creates a
-release via the GitHub UI or `gh release create`, GitHub groups merged PRs
-by their labels into the sections defined in that config file.
+[`.github/release.yml`](../.github/release.yml). The config is only
+consulted when auto-generated notes are explicitly requested — clicking
+"Generate release notes" in the GitHub UI's Release form, or passing
+`--generate-notes` to `gh release create`. A bare `gh release create`
+uses the body you provide directly.
 
 To make sure a PR lands in the right section, apply one of these labels
 before merging:

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -656,3 +656,35 @@ from clickwork import (
     normalize_prefix,    # Convert project name to env-var prefix
 )
 ```
+
+## Release notes
+
+This section is for clickwork maintainers cutting a release; framework users
+can skip it.
+
+Release notes for clickwork itself are produced by GitHub's built-in
+auto-generated release notes feature, configured via
+[`.github/release.yml`](../.github/release.yml). When a maintainer creates a
+release via the GitHub UI or `gh release create`, GitHub groups merged PRs
+by their labels into the sections defined in that config file.
+
+To make sure a PR lands in the right section, apply one of these labels
+before merging:
+
+| Label | Section |
+|-------|---------|
+| `enhancement` | Features |
+| `bug` | Bug fixes |
+| `documentation` | Documentation |
+| (no label, or any other label) | Other changes |
+
+PRs labeled `duplicate`, `invalid`, or `wontfix` are excluded from the notes
+entirely.
+
+Maintainers can still tweak the generated notes in the GitHub Release UI
+before publishing -- the auto-generated text is a starting point, not a
+finished artifact. This is the right place to call out breaking changes,
+highlight the most user-visible work, or add an upgrade blurb.
+
+For the underlying mechanism and full config grammar, see GitHub's docs on
+[automatically-generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes).


### PR DESCRIPTION
Adopts GitHub's built-in auto-generated release notes via `.github/release.yml`. No third-party tools.

## Category mapping

Labels verified against `gh label list` — only mapping labels that actually exist on this repo.

| Section | Labels |
|---------|--------|
| Features | `enhancement` |
| Bug fixes | `bug` |
| Documentation | `documentation` |
| Other changes | `*` (catch-all) |

Excluded: `duplicate`, `invalid`, `wontfix`.

Deliberately **not** including speculative labels (`feat`, `fix`, `docs`). None of those exist in the repo; adding phantom labels would be harmless but misleading. Follow-up PRs can extend when new labels get created.

## Docs update

New "Release notes" section at the end of `docs/GUIDE.md` explaining the flow to maintainers (label → section mapping table + cross-ref to [GitHub's docs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes)).

## publish.yml unchanged

Already triggers on `release: types: [published]` — runs AFTER release creation. Auto-generated notes fire at release creation time (`gh release create --generate-notes` or the UI button), which is exactly when we want them. Full flow is already compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)