### PR TITLE
test: mixed directory + entry-point discovery with local-wins shadowing (Fixes #51)

### DIFF
--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -422,9 +422,12 @@ class TestMixedDiscovery:
         Creates a tiny FakeEntryPoint whose ``.load()`` returns ``command``,
         then monkeypatches ``importlib.metadata.entry_points`` to return a
         list containing that one entry point when queried for the
-        ``clickwork.commands`` group (and an empty list for any other group,
-        so unrelated lookups elsewhere in the interpreter are not affected).
+        ``clickwork.commands`` group. Queries for every other group are
+        forwarded to the real ``importlib.metadata.entry_points`` via the
+        snapshot we captured before patching, so unrelated lookups (e.g.
+        ``console_scripts``) keep working during the test.
         """
+        import importlib.metadata
 
         class FakeEntryPoint:
             # Matches the shape importlib.metadata.EntryPoint exposes: a
@@ -439,18 +442,21 @@ class TestMixedDiscovery:
         ep = FakeEntryPoint()
         ep.name = name
 
-        def _fake_entry_points(*, group: str | None = None):
-            # Only surface the stub for the clickwork group so the patch
-            # can't accidentally pollute unrelated metadata queries.
-            if group == "clickwork.commands":
+        # Capture the real function BEFORE monkeypatching so the fallback
+        # doesn't recurse into itself once the patch is live.
+        real_entry_points = importlib.metadata.entry_points
+
+        def _fake_entry_points(*args, **kwargs):
+            # Replace the clickwork group with just our stub EP; forward
+            # anything else straight through to the real implementation so
+            # the patch only affects the code path under test.
+            if kwargs.get("group") == "clickwork.commands":
                 return [ep]
-            return []
+            return real_entry_points(*args, **kwargs)
 
         monkeypatch.setattr("importlib.metadata.entry_points", _fake_entry_points)
 
-    def test_local_command_shadows_installed_entry_point(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_local_command_shadows_installed_entry_point(self, tmp_path: Path, monkeypatch) -> None:
         """Local directory command must win over a same-named entry point.
 
         Stubs ``importlib.metadata.entry_points`` to return a fake EP
@@ -545,9 +551,7 @@ class TestMixedDiscovery:
         assert result.exit_code == 0
         assert result.output.strip() == "installed-solo"
 
-    def test_dev_mode_ignores_entry_points(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_dev_mode_ignores_entry_points(self, tmp_path: Path, monkeypatch) -> None:
         """Dev mode must not include entry-point commands.
 
         Pins the mode-isolation contract for ``discovery_mode="dev"``:
@@ -590,9 +594,7 @@ class TestMixedDiscovery:
         # Entry-point command must be ABSENT -- dev mode never loads it.
         assert "ep-only" not in commands
 
-    def test_installed_mode_ignores_directory(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_installed_mode_ignores_directory(self, tmp_path: Path, monkeypatch) -> None:
         """Installed mode must not include directory commands.
 
         Symmetric counterpart to the dev-mode test: even when a valid
@@ -630,9 +632,7 @@ class TestMixedDiscovery:
         # the directory even when commands_dir points at a valid one.
         assert "dir-cmd" not in commands
 
-    def test_shadowing_is_logged_at_info_level(
-        self, tmp_path: Path, monkeypatch, caplog
-    ) -> None:
+    def test_shadowing_is_logged_at_info_level(self, tmp_path: Path, monkeypatch, caplog) -> None:
         """The shadowing event must be announced on the clickwork logger at INFO.
 
         Pins the "informational, not silent" contract. Operators need to
@@ -681,6 +681,8 @@ class TestMixedDiscovery:
             f"from the clickwork logger mentioning the command name 'collide'; "
             f"got records: {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
         )
+
+
 class TestStrictDiscovery:
     """strict=True promotes every silent-drop branch to a raise.
 

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -447,13 +447,15 @@ class TestMixedDiscovery:
     ) -> None:
         """Local directory command must win over a same-named entry point.
 
-        Installs a fake entry point named "shared" whose command echoes
-        "installed-won", then plants a local ``commands/shared.py`` file
-        whose command echoes "local-won". After ``discover_commands(mode="auto")``,
-        the returned dict's "shared" entry must be the local one, verified
-        by actually invoking it and checking the output string. This is
-        the load-bearing assertion: if the merge order ever flipped, the
-        output would change to "installed-won" and the test would fail.
+        Stubs ``importlib.metadata.entry_points`` to return a fake EP
+        named ``shared`` whose command echoes ``installed-won``, then
+        plants a file at ``<tmp_path>/shared.py`` whose command echoes
+        ``local-won``. After ``discover_commands(commands_dir=tmp_path,
+        discovery_mode="auto")``, the returned dict's ``"shared"``
+        entry must be the local one, verified by actually invoking it
+        and checking the output string. If the merge order ever flipped,
+        the output would change to ``installed-won`` and the test would
+        fail.
         """
         from clickwork.discovery import discover_commands
 

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -485,14 +485,13 @@ class TestMixedDiscovery:
         commands = discover_commands(commands_dir=tmp_path, discovery_mode="auto")
 
         assert "shared" in commands
-        # Identity check: the returned command must NOT be the installed
-        # one. This catches the subtle case where both ended up in the
-        # dict but the installed reference was held somewhere else.
-        assert commands["shared"] is not installed_shared
-
-        # Output check: invoke the merged command and confirm the local
-        # version's stdout text, not the installed version's. This is the
-        # end-to-end proof of shadowing from the caller's perspective.
+        # Note: identity comparison against ``installed_shared`` is
+        # unreliable here because ``discover_commands_from_entrypoints``
+        # wraps entry-point targets in a ``LazyEntryPointCommand`` proxy,
+        # so ``commands['shared']`` would not be ``is installed_shared``
+        # even in the broken shadowing case. The load-bearing assertion
+        # is the output check below -- invoking the merged command MUST
+        # print the local version's text, not the installed version's.
         runner = CliRunner()
         result = runner.invoke(commands["shared"], [])
         assert result.exit_code == 0

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -380,3 +380,295 @@ class TestEntrypoints:
         assert "hello" in commands
         assert commands["hello"] is not installed
         assert "shadows installed plugin command" in caplog.text
+
+
+class TestMixedDiscovery:
+    """Mixed directory + entry-point discovery in auto mode.
+
+    Pins the contract for Wave-3 issue #51: when auto-mode merges commands
+    from both the local ``commands/`` directory and entry-point-installed
+    plugins, the LOCAL command wins on name collisions. The installed
+    command is silently dropped from the returned dict (though it can
+    still be imported directly by whoever wants to bypass shadowing).
+
+    WHY these tests exist as a dedicated class: the shadowing semantics
+    are intentional behaviour, not an accident of how the dict happens to
+    merge. Collapsing them into one-off asserts in another class risks
+    someone "fixing" the merge order later and breaking dev ergonomics
+    without noticing. Keeping the contract in a single named class makes
+    the policy obvious to future readers.
+
+    Pattern note: these tests stub ``importlib.metadata.entry_points``
+    at module scope -- that's the same hook ``discover_commands_from_entrypoints``
+    calls at runtime, so stubbing it exercises the real code path (no
+    monkeypatching of the discovery helpers themselves). This mirrors
+    the pattern already used by ``TestEntrypoints.test_discovers_entrypoint_without_loading_it``.
+    """
+
+    @staticmethod
+    def _stub_entry_points(
+        monkeypatch,
+        name: str,
+        command: click.Command,
+    ) -> None:
+        """Install a fake entry-point named ``name`` returning ``command``.
+
+        Creates a tiny FakeEntryPoint whose ``.load()`` returns ``command``,
+        then monkeypatches ``importlib.metadata.entry_points`` to return a
+        list containing that one entry point when queried for the
+        ``clickwork.commands`` group (and an empty list for any other group,
+        so unrelated lookups elsewhere in the interpreter are not affected).
+        """
+
+        class FakeEntryPoint:
+            # Matches the shape importlib.metadata.EntryPoint exposes: a
+            # ``.name`` attribute and a ``.load()`` method. That's all
+            # discover_commands_from_entrypoints and LazyEntryPointCommand
+            # actually use from the real EntryPoint API.
+            name = ""
+
+            def load(self) -> click.Command:
+                return command
+
+        ep = FakeEntryPoint()
+        ep.name = name
+
+        def _fake_entry_points(*, group: str | None = None):
+            # Only surface the stub for the clickwork group so the patch
+            # can't accidentally pollute unrelated metadata queries.
+            if group == "clickwork.commands":
+                return [ep]
+            return []
+
+        monkeypatch.setattr("importlib.metadata.entry_points", _fake_entry_points)
+
+    def test_local_command_shadows_installed_entry_point(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Local directory command must win over a same-named entry point.
+
+        Installs a fake entry point named "shared" whose command echoes
+        "installed-won", then plants a local ``commands/shared.py`` file
+        whose command echoes "local-won". After ``discover_commands(mode="auto")``,
+        the returned dict's "shared" entry must be the local one, verified
+        by actually invoking it and checking the output string. This is
+        the load-bearing assertion: if the merge order ever flipped, the
+        output would change to "installed-won" and the test would fail.
+        """
+        from clickwork.discovery import discover_commands
+
+        @click.command(name="shared")
+        def installed_shared() -> None:
+            # The installed-side command that we EXPECT to be shadowed.
+            # If this message ever appears in the test output, the
+            # shadowing contract has broken.
+            click.echo("installed-won")
+
+        self._stub_entry_points(monkeypatch, "shared", installed_shared)
+
+        # Plant a local commands/shared.py that exports a Click command
+        # with the SAME NAME ("shared"). The discovery code keys on the
+        # Click command's ``.name`` attribute, so the module filename
+        # alone isn't enough to collide -- the exported cli object's
+        # name must match. Here @click.command() defaults name="shared"
+        # from the function name, which is what we want.
+        (tmp_path / "shared.py").write_text(
+            "import click\n\n"
+            "@click.command()\n"
+            "def shared() -> None:\n"
+            "    click.echo('local-won')\n\n"
+            "cli = shared\n"
+        )
+
+        commands = discover_commands(commands_dir=tmp_path, discovery_mode="auto")
+
+        assert "shared" in commands
+        # Identity check: the returned command must NOT be the installed
+        # one. This catches the subtle case where both ended up in the
+        # dict but the installed reference was held somewhere else.
+        assert commands["shared"] is not installed_shared
+
+        # Output check: invoke the merged command and confirm the local
+        # version's stdout text, not the installed version's. This is the
+        # end-to-end proof of shadowing from the caller's perspective.
+        runner = CliRunner()
+        result = runner.invoke(commands["shared"], [])
+        assert result.exit_code == 0
+        assert result.output.strip() == "local-won"
+
+    def test_installed_command_wins_when_no_local_conflicts(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Without a same-named local file, the installed entry point is kept.
+
+        Pins the "don't over-shadow" half of the contract: shadowing only
+        kicks in on name collision. When the local directory has nothing
+        to shadow with, the installed command must appear in the merged
+        dict AND be invocable.
+        """
+        from clickwork.discovery import discover_commands
+
+        @click.command(name="solo")
+        def installed_solo() -> None:
+            # Name "solo" deliberately does not collide with any local file.
+            click.echo("installed-solo")
+
+        self._stub_entry_points(monkeypatch, "solo", installed_solo)
+
+        # Create an empty commands dir -- exists so auto mode activates
+        # directory scanning, but has no files so nothing collides.
+        # WHY the dir must exist: discover_commands() only enables the
+        # directory branch in auto mode when ``commands_dir.is_dir()``
+        # returns True. An empty existing dir exercises the "both
+        # mechanisms active, no collisions" path, which is the case we
+        # actually want to pin here.
+        commands_dir = tmp_path / "commands"
+        commands_dir.mkdir()
+
+        commands = discover_commands(commands_dir=commands_dir, discovery_mode="auto")
+
+        assert "solo" in commands
+
+        # Invoke via CliRunner to confirm the lazy proxy loads and runs
+        # the installed command end-to-end, not just that it's in the dict.
+        runner = CliRunner()
+        result = runner.invoke(commands["solo"], [])
+        assert result.exit_code == 0
+        assert result.output.strip() == "installed-solo"
+
+    def test_dev_mode_ignores_entry_points(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Dev mode must not include entry-point commands.
+
+        Pins the mode-isolation contract for ``discovery_mode="dev"``:
+        even when a plugin is installed and its entry point is visible
+        via ``importlib.metadata``, dev mode skips the entry-point
+        mechanism entirely and returns directory commands only.
+
+        Note on naming: the task brief called this mode "directory", but
+        the actual enum value accepted by discover_commands is "dev" --
+        see discovery.py's docstring for the canonical names. The test
+        uses the real value.
+        """
+        from clickwork.discovery import discover_commands
+
+        @click.command(name="ep-only")
+        def installed_cmd() -> None:
+            click.echo("installed")
+
+        self._stub_entry_points(monkeypatch, "ep-only", installed_cmd)
+
+        # Plant a local command with a DIFFERENT name so the two sources
+        # don't collide -- we want to see them side-by-side to confirm
+        # that only the directory one survives, not just that one wins.
+        # NB: we pass name="local-cmd" explicitly because Click auto-derives
+        # a command name from the function and its normalisation rules
+        # (underscores -> hyphens, trims ``_cmd`` / ``_command`` suffixes)
+        # are surprising. Being explicit pins the dict key we assert on.
+        (tmp_path / "local_cmd.py").write_text(
+            "import click\n\n"
+            "@click.command(name='local-cmd')\n"
+            "def local_cmd() -> None:\n"
+            "    click.echo('local')\n\n"
+            "cli = local_cmd\n"
+        )
+
+        commands = discover_commands(commands_dir=tmp_path, discovery_mode="dev")
+
+        # Local command is present.
+        assert "local-cmd" in commands
+        # Entry-point command must be ABSENT -- dev mode never loads it.
+        assert "ep-only" not in commands
+
+    def test_installed_mode_ignores_directory(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Installed mode must not include directory commands.
+
+        Symmetric counterpart to the dev-mode test: even when a valid
+        ``commands/`` directory exists with working command files,
+        ``discovery_mode="installed"`` returns entry-point commands only.
+
+        Note on naming: the task brief called this mode "entrypoint", but
+        the actual enum value is "installed". See discovery.py for the
+        canonical names.
+        """
+        from clickwork.discovery import discover_commands
+
+        @click.command(name="ep-cmd")
+        def installed_cmd() -> None:
+            click.echo("installed")
+
+        self._stub_entry_points(monkeypatch, "ep-cmd", installed_cmd)
+
+        # Plant a local file that dev/auto mode would pick up. Installed
+        # mode must ignore it completely. Name is pinned explicitly to
+        # avoid Click's auto-normalisation surprising the assertion.
+        (tmp_path / "dir_cmd.py").write_text(
+            "import click\n\n"
+            "@click.command(name='dir-cmd')\n"
+            "def dir_cmd() -> None:\n"
+            "    click.echo('local')\n\n"
+            "cli = dir_cmd\n"
+        )
+
+        commands = discover_commands(commands_dir=tmp_path, discovery_mode="installed")
+
+        # Entry-point command is present.
+        assert "ep-cmd" in commands
+        # Directory command must be ABSENT -- installed mode never scans
+        # the directory even when commands_dir points at a valid one.
+        assert "dir-cmd" not in commands
+
+    def test_shadowing_is_logged_at_info_level(
+        self, tmp_path: Path, monkeypatch, caplog
+    ) -> None:
+        """The shadowing event must be announced on the clickwork logger at INFO.
+
+        Pins the "informational, not silent" contract. Operators need to
+        see WHEN a local file is shadowing an installed plugin so stale
+        dev files don't invisibly hide the packaged behaviour. The log
+        level is deliberately INFO (not WARNING) because shadowing is a
+        normal, expected occurrence during dev -- but it must still be
+        visible when INFO logging is enabled.
+        """
+        from clickwork.discovery import discover_commands
+
+        @click.command(name="collide")
+        def installed_cmd() -> None:
+            click.echo("installed")
+
+        self._stub_entry_points(monkeypatch, "collide", installed_cmd)
+
+        (tmp_path / "collide.py").write_text(
+            "import click\n\n"
+            "@click.command()\n"
+            "def collide() -> None:\n"
+            "    click.echo('local')\n\n"
+            "cli = collide\n"
+        )
+
+        # caplog.at_level scoped to the clickwork logger -- the same logger
+        # used by discovery.py (logger = logging.getLogger("clickwork")).
+        # Scoping to the named logger avoids capturing unrelated INFO logs
+        # from other libraries that might fire during the discovery pass.
+        with caplog.at_level("INFO", logger="clickwork"):
+            discover_commands(commands_dir=tmp_path, discovery_mode="auto")
+
+        # Find the specific shadowing record. We look for INFO level AND
+        # the load-bearing phrase, so an accidental WARNING-level log or
+        # a different message wouldn't satisfy this assertion.
+        matching = [
+            r
+            for r in caplog.records
+            if r.name == "clickwork"
+            and r.levelname == "INFO"
+            and "shadows installed plugin command" in r.getMessage()
+            and "collide" in r.getMessage()
+        ]
+        assert matching, (
+            "expected an INFO-level 'shadows installed plugin command' log "
+            f"from the clickwork logger mentioning the command name 'collide'; "
+            f"got records: {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+        )

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -468,7 +468,9 @@ class TestMixedDiscovery:
 
         self._stub_entry_points(monkeypatch, "shared", installed_shared)
 
-        # Plant a local commands/shared.py that exports a Click command
+        # Plant a local file at <tmp_path>/shared.py (we pass
+        # commands_dir=tmp_path below; the test's "commands directory"
+        # IS tmp_path, flat-file-discovery-style) that exports a Click command
         # with the SAME NAME ("shared"). The discovery code keys on the
         # Click command's ``.name`` attribute, so the module filename
         # alone isn't enough to collide -- the exported cli object's


### PR DESCRIPTION
Pins the auto-mode discovery semantics where local commands shadow same-named installed-plugin commands. 5 new tests under `TestMixedDiscovery` in `tests/unit/test_discovery.py`.

## Tests

| Test | Pins |
|------|------|
| `test_local_command_shadows_installed_entry_point` | local wins; invoked command prints 'local-won' not 'installed-won' |
| `test_installed_command_wins_when_no_local_conflicts` | entry-point-only survives + is invocable via lazy proxy |
| `test_dev_mode_ignores_entry_points` | `discovery_mode='dev'` returns directory-only |
| `test_installed_mode_ignores_directory` | `discovery_mode='installed'` returns entry-point-only |
| `test_shadowing_is_logged_at_info_level` | `logger.info('Local command X shadows ...')` at INFO level under 'clickwork' |

## Notes

- Issue said 'directory' / 'entrypoint' mode names; actual enum values are 'dev' and 'installed'. Test names use the real names; inline comments explain.
- Stubs `importlib.metadata.entry_points` via monkeypatch (mirrors the `FakeEntryPoint` pattern already used by `TestEntrypoints`).
- No source changes — the shadowing log message already exists at `discovery.py:511`.

## Test plan

- [x] `mise exec -- python -m pytest tests/ -q` → 312 passed (was 307, +5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)