### PR TITLE
feat: document + test add_global_option override semantics (part of #60)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -805,15 +805,15 @@ add_global_option(cli, "--region", default=None, help="Target region.")
 
 # Step 3: attach the overriding subcommand. Its own --region wins
 # inside its scope; `status` above still sees the global via
-# ctx.meta because it was attached before add_global_option ran.
+# ctx.find_root().meta because it was attached before add_global_option ran.
 @cli.command("deploy")
 @click.option("--region", default="us-east-1", help="Deploy target.")
 @click.pass_context
 def deploy(ctx: click.Context, region: str) -> None:
     # `region` here is the subcommand's own kwarg -- "us-east-1" by
     # default, or whatever the user passed after "deploy" on the CLI.
-    # The global's ctx.meta["region"] reflects the ROOT-level parse
-    # only; it is NOT touched by the inner --region.
+    # The global's ctx.find_root().meta["region"] reflects the
+    # ROOT-level parse only; it is NOT touched by the inner --region.
     click.echo(f"deploying to {region}")
 ```
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -769,11 +769,17 @@ global's merge callback does not run there. Outside that subcommand
 root group level), the global remains active and continues to populate
 `ctx.find_root().meta`.
 
-**The pattern:** call `add_global_option` **first**, then attach the
-overriding subcommand. `add_global_option` takes a call-time snapshot
-of the command tree — commands attached after it runs do NOT get the
-global installed on them, so the subcommand's own `--env` owns the flag
-inside its scope.
+**The pattern:** `add_global_option` takes a call-time snapshot of the
+command tree — only commands attached BEFORE the call get the global
+installed on them. Commands attached AFTER the call don't. So the
+right ordering is:
+
+1. Attach every subcommand that SHOULD inherit the global (or that
+   simply doesn't care about the flag).
+2. Call `add_global_option`.
+3. Attach the overriding subcommand(s) — these won't get the global
+   installed, so their own `@click.option("--region", ...)` owns the
+   flag inside their scope.
 
 ```python
 import click
@@ -781,14 +787,25 @@ from clickwork import create_cli, add_global_option
 
 cli = create_cli(name="myapp", commands_dir=None)
 
-# Install the global FIRST. create_cli already installs framework
-# builtins (--verbose, --quiet, --dry-run, --env, --yes); add any
-# plugin-owned globals here. Pick a name that does NOT collide with
-# the framework builtins -- we use --region in this example.
+# Step 1: attach subcommands that should inherit the global.
+@cli.command("status")
+@click.pass_context
+def status(ctx: click.Context) -> None:
+    # --region is accessible via ctx.find_root().meta because the
+    # global was installed on this subcommand (step 2 ran after the
+    # attachment).
+    region = ctx.find_root().meta.get("region")
+    click.echo(f"status for {region!r}")
+
+# Step 2: install the global AFTER every inheriting subcommand is
+# attached. Pick a name that does NOT collide with create_cli's
+# framework builtins (--verbose, --quiet, --dry-run, --env, --yes) --
+# we use --region in this example.
 add_global_option(cli, "--region", default=None, help="Target region.")
 
-# Now attach an overriding subcommand. Its own --region wins inside
-# its scope; other subcommands still see the global via ctx.meta.
+# Step 3: attach the overriding subcommand. Its own --region wins
+# inside its scope; `status` above still sees the global via
+# ctx.meta because it was attached before add_global_option ran.
 @cli.command("deploy")
 @click.option("--region", default="us-east-1", help="Deploy target.")
 @click.pass_context
@@ -800,13 +817,13 @@ def deploy(ctx: click.Context, region: str) -> None:
     click.echo(f"deploying to {region}")
 ```
 
-The **reverse order** — subcommand declares `--env` **first**, then
-`add_global_option(cli, "--env", ...)` is called — is rejected at
-install time with `ValueError` naming the colliding flag string. That
-failure mode is deliberate: silently picking a winner would make
-override behaviour order-dependent. If you hit this error, either
-rename one side or reorder your setup so `add_global_option` runs
-before the overriding subcommand is attached.
+The **reverse order** — subcommand declares `--region` **first**, then
+`add_global_option(cli, "--region", ...)` is called — is rejected at
+install time with `ValueError` naming the colliding flag string (e.g.
+`--region`). That failure mode is deliberate: silently picking a
+winner would make override behaviour order-dependent. If you hit this
+error, either rename one side or reorder your setup so
+`add_global_option` runs before the overriding subcommand is attached.
 
 ### Version flag
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -753,6 +753,61 @@ Highest priority wins:
 | `--yes` / `-y` | Skip confirmation prompts |
 | `--version` / `-V` | Print the CLI's version string and exit (only installed if `create_cli()` receives `version=` or `package_name=`) |
 
+### Overriding a global option in a subcommand
+
+`add_global_option(cli, "--flag", ...)` installs the same option on the
+root group AND every subcommand that exists at call time, so users can
+pass the flag at any level. Occasionally a single subcommand needs to
+reclaim a flag name for different semantics — for example, a plugin
+subcommand that wants its own `--env` with a plugin-specific default
+instead of the framework's `--env` that selects the config environment.
+
+**The rule:** inside the overriding subcommand's scope, the subcommand's
+option wins — the value flows into that subcommand's own kwarg, and the
+global's merge callback does not run there. Outside that subcommand
+(i.e. on other subcommands that did NOT redeclare the flag, or at the
+root group level), the global remains active and continues to populate
+`ctx.find_root().meta`.
+
+**The pattern:** call `add_global_option` **first**, then attach the
+overriding subcommand. `add_global_option` takes a call-time snapshot
+of the command tree — commands attached after it runs do NOT get the
+global installed on them, so the subcommand's own `--env` owns the flag
+inside its scope.
+
+```python
+import click
+from clickwork import create_cli, add_global_option
+
+cli = create_cli(name="myapp", commands_dir=None)
+
+# Install the global FIRST. create_cli already installs framework
+# builtins (--verbose, --quiet, --dry-run, --env, --yes); add any
+# plugin-owned globals here. Pick a name that does NOT collide with
+# the framework builtins -- we use --region in this example.
+add_global_option(cli, "--region", default=None, help="Target region.")
+
+# Now attach an overriding subcommand. Its own --region wins inside
+# its scope; other subcommands still see the global via ctx.meta.
+@cli.command("deploy")
+@click.option("--region", default="us-east-1", help="Deploy target.")
+@click.pass_context
+def deploy(ctx: click.Context, region: str) -> None:
+    # `region` here is the subcommand's own kwarg -- "us-east-1" by
+    # default, or whatever the user passed after "deploy" on the CLI.
+    # The global's ctx.meta["region"] reflects the ROOT-level parse
+    # only; it is NOT touched by the inner --region.
+    click.echo(f"deploying to {region}")
+```
+
+The **reverse order** — subcommand declares `--env` **first**, then
+`add_global_option(cli, "--env", ...)` is called — is rejected at
+install time with `ValueError` naming the colliding flag string. That
+failure mode is deliberate: silently picking a winner would make
+override behaviour order-dependent. If you hit this error, either
+rename one side or reorder your setup so `add_global_option` runs
+before the overriding subcommand is attached.
+
 ### Version flag
 
 `create_cli()` accepts two kwargs that opt into a `--version` / `-V`

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -588,6 +588,231 @@ class TestAddGlobalOptionEntryPointPropagation:
         assert "--json" in result.output
 
 
+class TestOverrideSemantics:
+    """A plugin subcommand can override a global option within its own scope.
+
+    The pattern: call ``add_global_option(cli, "--env", ...)`` FIRST, THEN
+    attach a subcommand that itself declares ``@click.option("--env", ...)``.
+
+    This works naturally because ``add_global_option`` takes a CALL-TIME
+    SNAPSHOT of the command tree (see the module docstring in
+    ``clickwork/global_options.py``). Commands attached after the snapshot
+    are NOT instrumented with the global option, so:
+
+      - Inside the overriding subcommand's scope, Click only sees the
+        subcommand's OWN ``--env`` declaration, and the subcommand's handler
+        receives ``--env=foo`` via its own kwarg. ``ctx.meta['env']`` stays
+        untouched by that subcommand's parse (no global callback runs there).
+      - On other subcommands (those that DID exist at snapshot time and
+        didn't redeclare ``--env``), the global is installed normally and
+        continues to write through to ``ctx.find_root().meta['env']``.
+
+    The reverse order -- subcommand declares ``--env`` FIRST, then caller
+    invokes ``add_global_option(cli, "--env", ...)`` -- is caught at install
+    time by the conflict-detection guard and raises ``ValueError``. That
+    failure mode is pinned in ``TestAddGlobalOptionGuards`` above; this
+    class only exercises the supported override direction.
+    """
+
+    def test_subcommand_option_overrides_global_in_its_scope(self) -> None:
+        """Subcommand's own --env wins inside its own scope.
+
+        When the global is installed BEFORE the overriding subcommand is
+        attached, the global is not applied to that subcommand (snapshot
+        semantics). The subcommand's own option then owns the ``--env``
+        flag inside its scope: ``--env=foo`` passed after the subcommand
+        name flows into the subcommand's own kwarg, NOT through the
+        global's merge-callback (which doesn't run for this subcommand).
+
+        Concrete assertion:
+
+          - Subcommand's own kwarg receives ``"foo"``.
+          - ``ctx.meta['env']`` is still the ROOT-level resolution (which
+            is the global's Click default, ``None``, since the caller did
+            not pass ``--env`` BEFORE the subcommand name). The value
+            ``"foo"`` must NOT appear in meta; that would indicate the
+            global's callback intercepted the inner ``--env``, which is
+            exactly the shadowing we're verifying against.
+        """
+        # Capture what the subcommand sees -- its own kwarg AND the root
+        # meta dict (so we can assert meta was NOT written-through).
+        captured: dict[str, object] = {}
+
+        @click.group()
+        def root() -> None:
+            """Root group."""
+
+        # Install the global option FIRST so the snapshot sees only the
+        # empty group. The overriding subcommand is attached next.
+        add_global_option(root, "--env", default=None, help="Global env flag.")
+
+        @root.command("override-cmd")
+        @click.option("--env", default="override-default", help="Override env.")
+        @click.pass_context
+        def override_cmd(ctx: click.Context, env: str) -> None:
+            """Subcommand with its own --env that shadows the global."""
+            captured["own_env"] = env
+            # Also snapshot what the ROOT meta holds. The global's
+            # callback ran at the ROOT-GROUP level before Click descended
+            # into the subcommand, so the meta slot reflects that root
+            # parse -- NOT the subcommand's inner --env. That's exactly
+            # the isolation we want.
+            captured["meta_env"] = ctx.find_root().meta.get("env")
+            # And capture the ParameterSource at the subcommand level.
+            # The SUBCOMMAND's own --env should report COMMANDLINE (the
+            # user typed it); it must NOT report DEFAULT (which would
+            # indicate the global consumed the flag and the subcommand's
+            # option only saw its fallback).
+            captured["sub_env_source"] = ctx.get_parameter_source("env")
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["override-cmd", "--env=foo"])
+
+        assert result.exit_code == 0, result.output
+        # Primary assertion: subcommand's own kwarg received the value the
+        # user typed AFTER the subcommand name. The global didn't swallow it.
+        assert captured["own_env"] == "foo"
+        # Negative assertion: the global's meta slot must NOT contain the
+        # subcommand's inner ``--env`` value. If the global had intercepted
+        # the inner flag, meta_env would be "foo"; the correct behaviour
+        # leaves meta at the root-level resolution (here: the Click default
+        # ``None``, because no ``--env`` was passed BEFORE the subcommand).
+        assert captured["meta_env"] != "foo", (
+            "Global --env callback intercepted the subcommand's inner "
+            f"--env=foo; got ctx.meta['env']={captured['meta_env']!r}. The "
+            "subcommand's own option should own --env inside its scope."
+        )
+        # ParameterSource check: the subcommand's own option saw the value
+        # from the command line (COMMANDLINE), not from its fallback
+        # default (DEFAULT). Importing here keeps the top of the test
+        # file free of a ParameterSource dependency that only one test
+        # needs.
+        from click.core import ParameterSource
+
+        assert captured["sub_env_source"] == ParameterSource.COMMANDLINE, (
+            "Subcommand's own --env should have reported COMMANDLINE "
+            f"(user typed --env=foo); got {captured['sub_env_source']!r}. "
+            "A DEFAULT source here would mean the global's merge-callback "
+            "swallowed the flag before the subcommand's option saw it."
+        )
+
+    def test_global_option_still_active_on_non_overriding_subcommands(self) -> None:
+        """Other subcommands (that don't redeclare --env) still see the global.
+
+        WHY this matters: overriding in one subcommand must NOT break the
+        global elsewhere. The snapshot captures whichever subcommands exist
+        at install time, so those continue to have the global option
+        installed and the merge callback still writes through to root meta.
+        """
+        captured: dict[str, object] = {}
+
+        @click.group()
+        def root() -> None:
+            """Root group."""
+
+        # Attach the non-overriding subcommand BEFORE the snapshot so it
+        # gets the global installed on it. This is the "normal" path.
+        @root.command("plain-cmd")
+        @click.pass_context
+        def plain_cmd(ctx: click.Context) -> None:
+            """A subcommand that doesn't touch --env."""
+            captured["meta_env"] = ctx.find_root().meta.get("env")
+
+        add_global_option(root, "--env", default=None, help="Global env flag.")
+
+        # Also attach an overriding subcommand AFTER the snapshot. This
+        # one is not exercised in this test -- its presence just confirms
+        # the two patterns coexist without the snapshot erroring out.
+        @root.command("override-cmd")
+        @click.option("--env", default="override-default")
+        def override_cmd(env: str) -> None:  # pragma: no cover - unused
+            """Unused overrider; keeps the coexistence shape realistic."""
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["--env=bar", "plain-cmd"])
+
+        assert result.exit_code == 0, result.output
+        # Global option fired as normal on the non-overriding subcommand.
+        assert captured["meta_env"] == "bar"
+
+    def test_override_help_text_comes_from_subcommand(self) -> None:
+        """--help for the overriding subcommand shows the subcommand's text.
+
+        WHY this matters: users reading ``cli override-cmd --help`` need to
+        see the subcommand's own description for ``--env``, not the global
+        one. Because the global isn't installed on the post-snapshot
+        subcommand, Click only knows about the subcommand's declaration
+        here, so the help output naturally reflects the override.
+
+        We assert on a distinctive substring rather than an exact match so
+        Click's help-text layout changes don't break the test.
+        """
+
+        @click.group()
+        def root() -> None:
+            """Root group."""
+
+        add_global_option(
+            root,
+            "--env",
+            default=None,
+            help="GLOBAL-ENV-HELP-TEXT",
+        )
+
+        @root.command("override-cmd")
+        @click.option("--env", default="d", help="SUBCOMMAND-ENV-HELP-TEXT")
+        def override_cmd(env: str) -> None:  # pragma: no cover - help-only invoke
+            """Overriding subcommand (body unused in help-only test)."""
+
+        runner = CliRunner()
+        result = runner.invoke(root, ["override-cmd", "--help"])
+
+        assert result.exit_code == 0, result.output
+        # The subcommand's help text is what appears. The global's help
+        # text must NOT leak into this subcommand's help because the
+        # global was never installed on it.
+        assert "SUBCOMMAND-ENV-HELP-TEXT" in result.output
+        assert "GLOBAL-ENV-HELP-TEXT" not in result.output, (
+            "Global option's help text leaked into overriding subcommand's "
+            f"--help output; got:\n{result.output}"
+        )
+
+    def test_install_after_manual_option_raises_clean_error(self) -> None:
+        """The REVERSE order is rejected loudly at install time.
+
+        This pins the only "clean failure mode" for override scenarios:
+        if a subcommand declared ``--env`` BEFORE ``add_global_option`` ran,
+        the install-time conflict guard raises ``ValueError`` with a
+        message that names the colliding flag string.
+
+        WHY we pin this: it's the only codepath through which a caller gets
+        a deterministic, actionable error for a collision. If a future
+        refactor accidentally loosened this to "silently install and pick
+        one winner", overrides could become order-dependent landmines --
+        this test would then start failing and force the refactor author
+        to reconsider.
+
+        (The SUPPORTED override direction -- add_global_option first, then
+        attach the overriding subcommand -- is exercised by the other three
+        tests in this class.)
+        """
+        import pytest
+
+        @click.group()
+        def root() -> None:
+            """Root group."""
+
+        @root.command("override-cmd")
+        @click.option("--env", default="d")
+        def override_cmd(env: str) -> None:  # pragma: no cover - install-only
+            """Subcommand that claims --env before the global is installed."""
+
+        # Install-time conflict: the subcommand already owns --env, and
+        # ``add_global_option`` refuses to silently coexist.
+        with pytest.raises(ValueError, match="Cannot install global option"):
+            add_global_option(root, "--env", default=None)
+
+
 class TestAddGlobalOptionIntegration:
     """End-to-end check that add_global_option composes with create_cli()."""
 

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -608,7 +608,7 @@ class TestOverrideSemantics:
 
       - Inside the overriding subcommand's scope, Click only sees the
         subcommand's OWN ``--env`` declaration, and the subcommand's handler
-        receives ``--env=foo`` via its own kwarg. ``ctx.meta['env']`` stays
+        receives ``--env=foo`` via its own kwarg. ``ctx.find_root().meta['env']`` stays
         untouched by that subcommand's parse (no global callback runs there).
       - On other subcommands (those that DID exist at snapshot time and
         didn't redeclare ``--env``), the global is installed normally and
@@ -634,7 +634,7 @@ class TestOverrideSemantics:
         Concrete assertion:
 
           - Subcommand's own kwarg receives ``"foo"``.
-          - ``ctx.meta['env']`` is still the ROOT-level resolution (which
+          - ``ctx.find_root().meta['env']`` is still the root-level resolution (which
             is the global's Click default, ``None``, since the caller did
             not pass ``--env`` BEFORE the subcommand name). The value
             ``"foo"`` must NOT appear in meta; that would indicate the
@@ -690,7 +690,7 @@ class TestOverrideSemantics:
         assert captured["meta_env"] is None, (
             "Global --env meta slot should still be None at the root "
             f"(no --env passed before the subcommand); got "
-            f"ctx.meta['env']={captured['meta_env']!r}. Any non-None "
+            f"ctx.find_root().meta['env']={captured['meta_env']!r}. Any non-None "
             "value means the global's callback ran on the subcommand "
             "parse, which would be a regression of the override "
             "contract."

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -591,8 +591,15 @@ class TestAddGlobalOptionEntryPointPropagation:
 class TestOverrideSemantics:
     """A plugin subcommand can override a global option within its own scope.
 
-    The pattern: call ``add_global_option(cli, "--env", ...)`` FIRST, THEN
-    attach a subcommand that itself declares ``@click.option("--env", ...)``.
+    The pattern (matches ``docs/GUIDE.md`` "Overriding a global option in a
+    subcommand"):
+
+      1. Attach every subcommand that SHOULD inherit the global (or
+         simply doesn't care about the flag).
+      2. Call ``add_global_option(cli, "--env", ...)``.
+      3. Attach the overriding subcommand, whose own
+         ``@click.option("--env", ...)`` will own the flag inside its
+         scope because it wasn't in the snapshot.
 
     This works naturally because ``add_global_option`` takes a CALL-TIME
     SNAPSHOT of the command tree (see the module docstring in
@@ -672,15 +679,21 @@ class TestOverrideSemantics:
         # Primary assertion: subcommand's own kwarg received the value the
         # user typed AFTER the subcommand name. The global didn't swallow it.
         assert captured["own_env"] == "foo"
-        # Negative assertion: the global's meta slot must NOT contain the
-        # subcommand's inner ``--env`` value. If the global had intercepted
-        # the inner flag, meta_env would be "foo"; the correct behaviour
-        # leaves meta at the root-level resolution (here: the Click default
-        # ``None``, because no ``--env`` was passed BEFORE the subcommand).
-        assert captured["meta_env"] != "foo", (
-            "Global --env callback intercepted the subcommand's inner "
-            f"--env=foo; got ctx.meta['env']={captured['meta_env']!r}. The "
-            "subcommand's own option should own --env inside its scope."
+        # Positive assertion on the root meta slot: the global's meta slot
+        # must equal the root-level default (``None`` here, because no
+        # ``--env`` was passed BEFORE the subcommand). Asserting on the
+        # exact value (rather than a weaker ``!= "foo"``) catches the
+        # subtle regression where the global's callback runs and writes
+        # something OTHER than ``"foo"`` (e.g. a merged or empty value) --
+        # either would indicate the global leaked into the subcommand's
+        # scope.
+        assert captured["meta_env"] is None, (
+            "Global --env meta slot should still be None at the root "
+            f"(no --env passed before the subcommand); got "
+            f"ctx.meta['env']={captured['meta_env']!r}. Any non-None "
+            "value means the global's callback ran on the subcommand "
+            "parse, which would be a regression of the override "
+            "contract."
         )
         # ParameterSource check: the subcommand's own option saw the value
         # from the command line (COMMANDLINE), not from its fallback

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -808,8 +808,14 @@ class TestOverrideSemantics:
             """Subcommand that claims --env before the global is installed."""
 
         # Install-time conflict: the subcommand already owns --env, and
-        # ``add_global_option`` refuses to silently coexist.
-        with pytest.raises(ValueError, match="Cannot install global option"):
+        # ``add_global_option`` refuses to silently coexist. The match
+        # regex asserts BOTH the error-type prefix AND the colliding
+        # flag string so a future refactor that changes the message
+        # (e.g. drops the flag name) surfaces here.
+        with pytest.raises(
+            ValueError,
+            match=r"Cannot install global option.*--env",
+        ):
             add_global_option(root, "--env", default=None)
 
 


### PR DESCRIPTION
The existing `add_global_option` already supports subcommand-wins override semantics — the snapshot-at-call-time design means if `add_global_option` runs BEFORE the overriding subcommand is attached, the subcommand's own `@click.option('--env', ...)` owns the flag inside its scope.

This PR pins the behavior with tests and documents it in GUIDE.md. No code changes to `global_options.py`.

## Tests

New `TestOverrideSemantics` class (4 tests in `tests/unit/test_global_options.py`):

- `test_subcommand_option_overrides_global_in_its_scope` — subcommand kwarg receives `--env=foo` AND `ctx.get_parameter_source('env') == COMMANDLINE` (not DEFAULT, which would mean the global swallowed the flag)
- `test_global_option_still_active_on_non_overriding_subcommands` — a sibling subcommand attached before snapshot still receives the global via `ctx.meta`
- `test_override_help_text_comes_from_subcommand` — `cli subcmd --help` shows the subcommand's help text
- `test_install_after_manual_option_raises_clean_error` — reverse-order pin: subcommand declares `--env` first → `add_global_option` raises `ValueError` via the existing conflict-detection guard

## Docs

New 'Overriding a global option in a subcommand' section in `docs/GUIDE.md` under Global Flags. Explains when/why, the rule, and the 'add_global_option first, then attach the subcommand' pattern with a `--region` code snippet.

## Scope notes for #60

- **#60a** (`setup_logging` re-invocation idempotency) — already covered by [#69](https://github.com/qubitrenegade/clickwork/pull/69) (`test_stderr_handler_marker_survives_setup_logging_reinvocation`).
- **#60c** (sigstore + signed tags) — spun off to [#61](https://github.com/qubitrenegade/clickwork/issues/61) for 1.0.x patch.
- **#60b** (this PR) — `add_global_option` override semantics.

Once this lands, #60 can close with pointers to #69 and #61.

## Test plan

- [x] `mise exec -- python -m pytest tests/ -q` → 311 passed (was 307, +4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)