### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,133 @@ All notable changes to clickwork will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-18
+
+First stable release. The public surface is now covered by
+[`docs/API_POLICY.md`](docs/API_POLICY.md): everything in the
+documented API set is committed to semver stability, and removals
+follow a one-minor-release deprecation runway with
+`DeprecationWarning`.
+
+Numbers in parens are **issue numbers** unless explicitly noted as
+`(PR #NN)`. See [`docs/MIGRATING.md`](docs/MIGRATING.md) for the
+complete 0.2.x → 1.0 upgrade guide including before/after diffs.
+
+### Breaking
+
+- **Env-sourced config values are coerced per the schema's `type:`.**
+  `port = "8080"` with `type: int` now returns `8080` as an `int` on
+  both environment variables and TOML. Projects that caught a
+  `ConfigError` for this case or did manual `int(...)` on the result
+  can drop those workarounds. (#41)
+- **`setup_logging()` no longer attaches its own `StreamHandler` when
+  the host has already configured logging.** Host-side
+  `logging.basicConfig`, `structlog`, etc. are now preserved -- no
+  more duplicate log lines. Hosts that relied on the handler being
+  installed unconditionally should call `setup_logging(force=True)`
+  or attach their own handler. (#43)
+- **`load_config(env=...)` fails fast on an undefined env name.**
+  When the repo config file exists but has no matching
+  `[env.<name>]` section, `ConfigError` is raised naming the missing
+  env and listing the defined ones. Previously this silently
+  returned the `[default]` merge. Missing repo config file is still
+  a no-op. (#52)
+- **Python floor bumped to 3.11+.** This is a hard floor:
+  `tomllib` is now imported unconditionally from the standard
+  library. Consumers on 3.9/3.10 must upgrade Python. (#46)
+- **Click floor pinned to `>=8.2,<9`.** 0.2.0 already required
+  `click>=8.2`; 1.0 makes this explicit in metadata and caps at `<9`
+  so a future Click major doesn't break consumers without a
+  clickwork release. (#46, PR #33)
+
+### Added
+
+- **`docs/API_POLICY.md`** -- the public API surface, compatibility
+  policy, and deprecation runway. Everything re-exported from
+  `clickwork/__init__.py` and everything in the
+  `clickwork.{config,discovery,http,platform,process,testing}`
+  modules listed there is stable. Leading-underscore modules
+  (`_deprecated`, `_logging`, `_types`) are private and may change
+  without a major bump. (#36, #46, #49)
+- **`docs/GUIDE.md` "Config Precedence" section** -- explicit,
+  ordered 6-row precedence table covering every config source from
+  explicit env-var mapping (highest) through schema defaults
+  (lowest), plus worked examples and a rationale. The table is part
+  of the public 1.0 contract. (#54)
+- **`docs/MIGRATING.md`** -- the 0.2.x → 1.0 upgrade guide with
+  before/after diffs for every breaking change and a quick checklist
+  for consumers. (#56)
+- **`docs/PLUGINS.md`** -- a 15-minute walkthrough for shipping a
+  clickwork plugin on PyPI via the `clickwork.commands` entry point
+  group. (#53)
+- **`docs/SECURITY.md`** -- what clickwork defends against, what it
+  leaves to the CLI author, threat-model assumptions, and the
+  vulnerability-reporting process. Wired into GitHub's Security
+  tab via a root-level `SECURITY.md` stub. (#55)
+- **`CONTRIBUTING.md`** -- contributor setup, dev workflow, and
+  review expectations for external contributors. (#58)
+- **`strict=True` opt-in for `create_cli()` and
+  `discover_commands(...)`.** Promotes every silent-drop branch in
+  discovery (missing `cli`, import error, invalid `cli` type,
+  duplicate command names, entry-point metadata failures) to a
+  single `ClickworkDiscoveryError` aggregating all issues. Default
+  `False` preserves the 0.2.x warn-and-drop behavior. Production
+  CLIs should turn it on. (#42)
+- **`package_name=` / `version=` kwargs on `create_cli()`** install a
+  standardized `--version` flag that resolves the string via
+  `importlib.metadata` (or the explicit override) so consumers get a
+  consistent `--version` without writing their own handler. (#48)
+- **`clickwork._deprecated` decorator** for post-1.0 evolution. Wrap
+  a public symbol that should stay available for one more minor; it
+  emits `DeprecationWarning` on first use with a configurable
+  message and a pointer to the replacement. Thread-safe
+  once-per-symbol firing. (#47) (Note: `clickwork._deprecated` is a
+  private module -- its *decorator output* is public and stable, the
+  module path itself is not.)
+- **PEP 561 `py.typed` marker.** Consumers' `mypy --strict` now sees
+  clickwork's inline annotations directly; no more third-party stub
+  packages or hacks required. (#37)
+
+### Changed
+
+- **`add_global_option()` override semantics are now part of the
+  public API.** Invoking a command with an explicit flag value
+  overrides the group-level option at invocation time; docs and
+  tests pin the behavior so downstream CLIs can rely on it. (#60)
+- **Logger propagation**. Clickwork loggers now rely on standard
+  Python propagation to the host's root logger rather than attaching
+  a duplicate stderr handler. Hosts configuring logging before
+  calling clickwork see their settings honored. (#43)
+
+### CI / Release engineering
+
+- **Strict mypy gate** on `src/clickwork` with fully annotated
+  source. (#38)
+- **Ruff lint + format gate** (pinned to 0.6.9) applied to the full
+  tree. (#38)
+- **Cross-platform test matrix**: linux/macos/windows on Python
+  3.11/3.12/3.13 plus a click-latest canary. (#39)
+- **Wheel + sdist smoke test** installs the built artifacts into a
+  fresh venv and runs the suite against the installed package (#40);
+  release-smoke workflow added. (#40)
+- **Cold-start import benchmark** with a 20% regression gate, so
+  accidentally pulling `requests` or similar into the import path
+  fails CI. (#59)
+- **Auto-generated release notes** via GitHub's release-notes
+  config; reviewers curate from there rather than hand-writing from
+  the commit list. (#57)
+
+### Docs
+
+- **LLM_REFERENCE.md "Common Footguns"** section collecting every
+  gotcha that external reviewers and auto-review tools have caught
+  on clickwork PRs (rewritten throughout the 1.0 cycle).
+- **GUIDE.md "Testing commands with clickwork.testing"** section
+  consolidated the testing story.
+- **README.md** rebuilt around the documented public surface with
+  direct links to `GUIDE`, `API_POLICY`, `PLUGINS`, `SECURITY`, and
+  `MIGRATING`.
+
 ## [0.2.0] - 2026-04-18
 
 A broad expansion of the framework closing 12 issues (#4-#17), plus one
@@ -100,5 +227,6 @@ Footguns" section and GUIDE "Testing commands" subsection.
   redacts all env values (secret-sourced as `<redacted>`, other env
   entries as `<set>`) from the single INFO-level log line. (#11)
 
+[1.0.0]: https://github.com/qubitrenegade/clickwork/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/qubitrenegade/clickwork/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/qubitrenegade/clickwork/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,14 @@ complete 0.2.x → 1.0 upgrade guide including before/after diffs.
 - **Python floor bumped to 3.11+.** This is a hard floor:
   `tomllib` is now imported unconditionally from the standard
   library. Consumers on 3.9/3.10 must upgrade Python. (#46)
-- **Click floor pinned to `>=8.2,<9`.** 0.2.0 already required
-  `click>=8.2`; 1.0 makes this explicit in metadata and caps at `<9`
-  so a future Click major doesn't break consumers without a
-  clickwork release. (#46, PR #33)
+- **Click floor pinned to `>=8.2`, no upper bound.** 0.2.0 already
+  required `click>=8.2`; 1.0 keeps the floor and explicitly declines
+  to cap at `<9` because a speculative major-version cap creates a
+  dependency-resolution ratchet -- the day Click ships a new major,
+  any resolver trying to install clickwork alongside a package that
+  has already moved to the new major would see an unsolvable
+  constraint. See `docs/API_POLICY.md` "Click version range" for the
+  full rationale. (#46, PR #33)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,14 @@ complete 0.2.x → 1.0 upgrade guide including before/after diffs.
   public API.** Invoking a command with an explicit flag value
   overrides the group-level option at invocation time; docs and
   tests pin the behavior so downstream CLIs can rely on it. (#60)
+- **`setup_logging()` re-invocation is a stable 1.0 contract.**
+  Calling `setup_logging()` a second (or Nth) time in the same
+  process is idempotent with respect to handler count -- the
+  framework never stacks a duplicate clickwork-owned handler -- and
+  always updates the logger's level live (so `verbose=0` then
+  `verbose=1` moves output from WARNING to INFO under both
+  standalone and host-configured roots). Long-running hosts and
+  test suites that re-enter the CLI can now rely on this. (#60)
 - **Logger propagation**. Clickwork loggers now rely on standard
   Python propagation to the host's root logger rather than attaching
   a duplicate stderr handler. Hosts configuring logging before

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickwork"
-version = "0.2.0"
+version = "1.0.0"
 description = "Reusable CLI framework for project automation"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -10,7 +10,7 @@ authors = [
 ]
 keywords = ["cli", "click", "plugin", "framework", "command-line"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",

--- a/src/clickwork/__init__.py
+++ b/src/clickwork/__init__.py
@@ -25,7 +25,8 @@ Public API:
     testing           - Submodule exposing run_cli() + make_test_cli() helpers
 """
 
-__version__ = "1.0.0"
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _metadata_version
 
 # WHY ``testing`` is imported here alongside ``http`` / ``platform``: all
 # three are advertised as importable both as ``clickwork.<name>`` and as
@@ -47,6 +48,21 @@ from clickwork.discovery import ClickworkDiscoveryError
 from clickwork.global_options import add_global_option
 from clickwork.http import HttpError, delete, get, post, put
 from clickwork.platform import platform_dispatch
+
+# Single source of truth: derive the runtime version from the installed
+# package metadata so pyproject.toml is authoritative and we can't drift
+# the two again (this bit us during the 1.0 cut -- pyproject said 1.0.0,
+# __init__ still said 0.2.0, and --version reported the stale value).
+# PackageNotFoundError covers the "running from an uninstalled source
+# checkout" edge case -- shouldn't happen for ordinary consumers, but
+# falling back to "0+unknown" keeps `clickwork.__version__` available
+# instead of raising on import.
+try:
+    __version__ = _metadata_version("clickwork")
+except _PackageNotFoundError:  # pragma: no cover - editable/uninstalled checkout
+    __version__ = "0+unknown"
+
+del _metadata_version, _PackageNotFoundError
 
 __all__ = [
     "create_cli",

--- a/src/clickwork/__init__.py
+++ b/src/clickwork/__init__.py
@@ -25,7 +25,7 @@ Public API:
     testing           - Submodule exposing run_cli() + make_test_cli() helpers
 """
 
-__version__ = "0.2.0"
+__version__ = "1.0.0"
 
 # WHY ``testing`` is imported here alongside ``http`` / ``platform``: all
 # three are advertised as importable both as ``clickwork.<name>`` and as

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -460,6 +460,16 @@ class TestSetupLoggingReinvocationContract:
         host's root handler. Calling ``setup_logging()`` a second time
         in this state must NOT flip-flop -- it must stay at zero
         clickwork-owned StreamHandlers.
+
+        Also asserts the "live level update" half of the re-invocation
+        contract holds under host-configured root: the named logger's
+        level must reflect the SECOND call's verbosity, so
+        ``setup_logging(verbose=0)`` then ``setup_logging(verbose=1)``
+        leaves the logger at INFO even though no handler is owned.
+        Without this assertion the test would pass if a future
+        refactor returned early before ``logger.setLevel`` under the
+        host-configured branch -- a silent behaviour change that
+        breaks the 1.0 contract.
         """
         # Install a fake "host" root handler so ``_host_root_is_configured()``
         # returns True.
@@ -483,6 +493,15 @@ class TestSetupLoggingReinvocationContract:
         assert owned_streams == [], (
             "host-configured re-invocation must not attach a "
             f"clickwork-owned StreamHandler; got: {owned_streams}"
+        )
+        # Live level update: second call was ``verbose=1`` -> INFO.
+        # verbose=0 would have left it at WARNING; if the level doesn't
+        # actually update under host-configured root, this assertion
+        # catches the regression.
+        assert logger.level == logging.INFO, (
+            "host-configured re-invocation must still update the logger's "
+            f"level on the second call; expected INFO (verbose=1), got "
+            f"{logging.getLevelName(logger.level)} ({logger.level})"
         )
 
     def test_reinvocation_evicts_stream_handler_when_host_configures_after(self, reset_logging):

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ wheels = [
 
 [[package]]
 name = "clickwork"
-version = "0.2.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

First stable release of clickwork. Cuts v1.0.0 with:

- `version = \"1.0.0\"` in pyproject.toml
- Trove classifier bumped to `Development Status :: 5 - Production/Stable`
- CHANGELOG.md entry documenting every breaking change, addition, and CI tightening since 0.2.0

## 1.0 scope (24 issues closed)

- **Breaking**: env-sourced config coercion (#41), logger host-preservation (#43), fail-fast undefined env (#52), Python 3.11+ floor (#46), Click 8.2+ pin (#46, PR #33).
- **Public API policy**: docs/API_POLICY.md with semver commitments + deprecation runway (#36, #46, #49).
- **Docs**: MIGRATING.md (#56), PLUGINS.md (#53), SECURITY.md (#55), CONTRIBUTING.md (#58), GUIDE.md Config Precedence table (#54), API_POLICY.md (#36 etc.).
- **Features**: strict discovery (#42), --version flag (#48), _deprecated decorator (#47), py.typed marker (#37), add_global_option docs (#60).
- **CI**: strict mypy (#38), ruff 0.6.9 (#38), cross-platform matrix (#39), wheel/sdist smoke (#40), cold-start benchmark (#59), auto release notes (#57).

## Validation

- 336/336 tests pass locally on main + this bump.
- orbit-admin runtime validated against 1.0 RC — clean (#44).
- All Wave 1–4 PRs (19 PRs) through Copilot review cycles and merged.

## Test plan

- [x] `pytest` green on release branch
- [x] orbit-admin runtime sanity-checked against 1.0 RC
- [ ] CI (mypy, ruff, multi-OS, click-edge) green on PR
- [ ] Wheel + sdist smoke passes
- [ ] User approves release cut — tagging + GitHub release triggers PyPI trusted-publisher flow

After merge: tag `v1.0.0`, `gh release create v1.0.0` to trigger publish.yml, then approve the `pypi` environment deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)