### PR TITLE
feat: pin setup_logging re-invocation contract (part of #60)

### DIFF
--- a/docs/API_POLICY.md
+++ b/docs/API_POLICY.md
@@ -82,6 +82,20 @@ as the symbol surface.
   installed when the caller passes `version=` or `package_name=` to
   `create_cli()`; its presence is opt-in so existing CLIs opt in at
   their own cadence.
+- The re-invocation semantics of `setup_logging()` — called internally
+  by `create_cli()` on every CLI invocation. Re-invocation in the same
+  process (test suites that drive a CLI via `CliRunner` multiple times,
+  long-running hosts that import a clickwork CLI module repeatedly) is
+  **idempotent for handler identity and live for level**: a second call
+  never stacks a duplicate clickwork-owned handler, but a second call
+  with a different `verbose` / `quiet` argument DOES update the level
+  on both the logger and the clickwork-owned handler. Changing either
+  half of this contract — stacking a duplicate, or making the second
+  call a no-op that ignores the new verbosity — is a major-version
+  break. The identity check relies on a private `_clickwork_owned`
+  marker attribute on the handler; the marker itself is an
+  implementation detail (underscore-prefixed) and is not part of the
+  public surface.
 
 ## Private and unstable
 

--- a/src/clickwork/_logging.py
+++ b/src/clickwork/_logging.py
@@ -115,6 +115,23 @@ def setup_logging(
     The public signature is unchanged from 0.2, so 0.2-era call sites
     continue to work -- only the side effects differ.
 
+    On repeated invocation (issue #60 item 1): ``setup_logging()`` is
+    idempotent with respect to handler attachment and live with respect
+    to level. Calling it a second (or Nth) time in the same process --
+    which happens routinely in test suites that exercise a CLI via
+    ``CliRunner``, and in long-running hosts that import a clickwork CLI
+    module more than once -- will NEVER stack a duplicate
+    clickwork-owned handler. Instead, the function finds any existing
+    handler it previously attached via the ``_clickwork_owned`` marker
+    attribute and reuses it in place. The second call IS still
+    meaningful, not a no-op: it updates the verbosity level on both the
+    logger and the clickwork-owned handler, so
+    ``setup_logging(verbose=0)`` followed by ``setup_logging(verbose=2)``
+    correctly switches output from WARNING to DEBUG. This combination
+    (idempotent handler identity, live level updates) is part of the 1.0
+    public contract; see ``docs/API_POLICY.md`` for the SemVer
+    implications.
+
     Args:
         verbose: How many -v flags were passed (0, 1, or 2+).
         quiet: Whether --quiet was passed. Overrides verbose.

--- a/src/clickwork/_logging.py
+++ b/src/clickwork/_logging.py
@@ -116,21 +116,33 @@ def setup_logging(
     continue to work -- only the side effects differ.
 
     On repeated invocation (issue #60 item 1): ``setup_logging()`` is
-    idempotent with respect to handler attachment and live with respect
-    to level. Calling it a second (or Nth) time in the same process --
+    idempotent with respect to handler count and live with respect to
+    level. Calling it a second (or Nth) time in the same process --
     which happens routinely in test suites that exercise a CLI via
     ``CliRunner``, and in long-running hosts that import a clickwork CLI
     module more than once -- will NEVER stack a duplicate
-    clickwork-owned handler. Instead, the function finds any existing
-    handler it previously attached via the ``_clickwork_owned`` marker
-    attribute and reuses it in place. The second call IS still
-    meaningful, not a no-op: it updates the verbosity level on both the
-    logger and the clickwork-owned handler, so
+    clickwork-owned handler. The exact behaviour depends on which of
+    the two branches is active:
+
+    - **No host handler configured (standalone CLI mode).** The function
+      finds any clickwork-owned ``StreamHandler`` it previously attached
+      (via the ``_clickwork_owned`` marker attribute) and reuses it in
+      place -- re-binding its stream to the current ``sys.stderr`` (for
+      pytest-capture-style stream swaps) and updating its level/format.
+    - **Host root handler configured.** The function actively
+      ``removeHandler()``-s any clickwork-owned ``StreamHandler`` left
+      over from an earlier standalone-mode call, so records propagate
+      up to the host's root handler only. This is the path that gets
+      hit when code does
+      ``setup_logging(); logging.basicConfig(); setup_logging()`` --
+      without the eviction that sequence would emit each record twice.
+
+    In both branches the level on the logger is always updated, so
     ``setup_logging(verbose=0)`` followed by ``setup_logging(verbose=2)``
-    correctly switches output from WARNING to DEBUG. This combination
-    (idempotent handler identity, live level updates) is part of the 1.0
-    public contract; see ``docs/API_POLICY.md`` for the SemVer
-    implications.
+    correctly switches output from WARNING to DEBUG regardless of which
+    mode is live. This combination (at-most-one clickwork-owned
+    handler, live level updates) is part of the 1.0 public contract;
+    see ``docs/API_POLICY.md`` for the SemVer implications.
 
     Args:
         verbose: How many -v flags were passed (0, 1, or 2+).

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -344,3 +344,142 @@ class TestHostPreservingBehavior:
         )
         # Final level should reflect the LAST call (-v -> INFO).
         assert owned[0].level == logging.INFO
+
+
+class TestSetupLoggingReinvocationContract:
+    """Pin the public re-invocation contract for ``setup_logging()`` (issue #60 item 1).
+
+    The scenarios this class targets come up in the wild more often than
+    they look:
+
+    - **Test suites** that exercise a CLI by calling its entry-point
+      function in-process multiple times (pytest + Click's ``CliRunner``
+      is the canonical example). Each invocation re-runs
+      ``setup_logging()``.
+    - **Long-running hosts** that import a clickwork CLI module for its
+      public API (e.g. a REPL, a notebook, or a supervisor process) and
+      may import/reload it more than once in the lifetime of the
+      interpreter.
+
+    The contract ``TestSetupLoggingReinvocationContract`` pins:
+
+    1. **Handler identity is idempotent.** Calling ``setup_logging()``
+       again never stacks a second clickwork-owned handler on top of the
+       first. The count stays at exactly one, whether the second call is
+       made with identical arguments or with different verbosity.
+    2. **Level is live-updated.** A second call with a different
+       ``verbose`` / ``quiet`` argument UPDATES the level on both the
+       logger and its clickwork-owned handler -- it is NOT a no-op. This
+       is the behavior CLI users expect (``my-tool -v subcommand``
+       followed by ``my-tool -vv subcommand`` from the same Python
+       process should reflect the second verbosity).
+
+    Changing either half of this contract is a SemVer major bump per
+    ``docs/API_POLICY.md``.
+    """
+
+    def test_same_args_twice_keeps_single_handler(self, reset_logging):
+        """Calling ``setup_logging`` twice with the same args keeps exactly one handler.
+
+        This is the canonical test-harness scenario: a ``CliRunner``
+        invokes the CLI entry point, which calls ``setup_logging()``,
+        and then the same test file invokes the entry point a second
+        time in the same process. The second call must not stack a
+        duplicate handler -- if it did, every subsequent log record
+        would emit twice, which is exactly the double-output bug #43
+        fixed for the host-preserving case.
+        """
+        # Bare root simulates "no host logging configured", which is the
+        # branch that actually attaches a StreamHandler. (The
+        # host-configured branch is covered in
+        # ``TestHostPreservingBehavior`` above.)
+        root = logging.getLogger()
+        root.handlers = []
+
+        from clickwork._logging import setup_logging
+
+        # First call: attach the clickwork-owned StreamHandler.
+        setup_logging(verbose=0, quiet=False, name="test_no_dup")
+        # Second call with IDENTICAL arguments. The expected outcome is
+        # that the existing handler is found via its ``_clickwork_owned``
+        # marker and reused in place; no second handler is appended.
+        setup_logging(verbose=0, quiet=False, name="test_no_dup")
+
+        logger = logging.getLogger("test_no_dup")
+        owned = [h for h in logger.handlers if getattr(h, "_clickwork_owned", False)]
+        assert len(owned) == 1, (
+            f"setup_logging(verbose=0) called twice must not stack "
+            f"handlers; got {len(owned)} clickwork-owned handlers: "
+            f"{logger.handlers}"
+        )
+
+    def test_second_call_updates_level_not_noop(self, reset_logging):
+        """Second call with different verbosity UPDATES level; it is NOT a no-op.
+
+        Pins the "level is live-updated" half of the re-invocation
+        contract. Both the logger itself and the clickwork-owned handler
+        must reflect the NEW level after the second call. If a future
+        refactor ever makes the second call a no-op (e.g., guarding
+        "already configured" at the top of the function), this test
+        catches the regression.
+        """
+        # Bare root so the StreamHandler path runs -- this is where the
+        # "update the handler level too" code lives.
+        root = logging.getLogger()
+        root.handlers = []
+
+        from clickwork._logging import setup_logging
+
+        # First call: WARNING-level baseline.
+        logger = setup_logging(verbose=0, quiet=False, name="test_no_dup")
+        assert logger.level == logging.WARNING
+
+        # Second call with -vv should switch the level to DEBUG. The
+        # clickwork-owned handler's ``setLevel`` is called on every
+        # invocation, so both logger.level and handler.level should move.
+        logger = setup_logging(verbose=2, quiet=False, name="test_no_dup")
+        assert logger.level == logging.DEBUG, (
+            f"second setup_logging call must update logger level to " f"DEBUG; got {logger.level}"
+        )
+
+        # And verify the handler's own level moved too -- if only the
+        # logger level updated, records above the handler's stale
+        # threshold would still be filtered out at the handler stage.
+        owned = [h for h in logger.handlers if getattr(h, "_clickwork_owned", False)]
+        assert len(owned) == 1
+        assert (
+            owned[0].level == logging.DEBUG
+        ), f"handler level must update on re-invocation; got {owned[0].level}"
+
+    def test_reinvocation_with_host_configured_keeps_no_stream_handler(self, reset_logging):
+        """Re-invocation under a host-configured root must never (re)attach a StreamHandler.
+
+        Host-configured path: ``setup_logging()`` attaches only a
+        NullHandler baseline, and propagation delivers records to the
+        host's root handler. Calling ``setup_logging()`` a second time
+        in this state must NOT flip-flop -- it must stay at zero
+        clickwork-owned StreamHandlers.
+        """
+        # Install a fake "host" root handler so ``_host_root_is_configured()``
+        # returns True.
+        root = logging.getLogger()
+        root.handlers = []
+        root.addHandler(logging.StreamHandler(io.StringIO()))
+
+        from clickwork._logging import setup_logging
+
+        setup_logging(verbose=0, quiet=False, name="test_no_dup")
+        setup_logging(verbose=1, quiet=False, name="test_no_dup")
+
+        logger = logging.getLogger("test_no_dup")
+        owned_streams = [
+            h
+            for h in logger.handlers
+            if getattr(h, "_clickwork_owned", False)
+            and isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.NullHandler)
+        ]
+        assert owned_streams == [], (
+            "host-configured re-invocation must not attach a "
+            f"clickwork-owned StreamHandler; got: {owned_streams}"
+        )

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -53,6 +53,7 @@ def reset_logging():
         "test_propagate",
         "test_no_dup",
         "test_standalone",
+        "test_transition",
     ]
     snapshots = []
     for name in logger_names:
@@ -482,4 +483,64 @@ class TestSetupLoggingReinvocationContract:
         assert owned_streams == [], (
             "host-configured re-invocation must not attach a "
             f"clickwork-owned StreamHandler; got: {owned_streams}"
+        )
+
+    def test_reinvocation_evicts_stream_handler_when_host_configures_after(self, reset_logging):
+        """Bare-root ``setup_logging()`` then host ``basicConfig``; second
+        ``setup_logging()`` must evict the clickwork stream handler.
+
+        This is the transition path Copilot flagged on PR #89 that the
+        earlier test_reinvocation_with_host_configured_keeps_no_stream_handler
+        does not exercise: the ``_clickwork_owned`` handler was already
+        attached when the first call ran under a bare root, and the
+        second call needs to ``removeHandler`` it because the host has
+        since taken responsibility for root-level output.
+
+        Without the eviction, records propagate to the host's root AND
+        get printed by the now-stale clickwork stream handler, so the
+        operator sees each line twice. That was the original duplicate-
+        output bug from #43; this test pins it stays fixed across
+        re-invocation.
+        """
+        # Reset root handlers -- see the sibling test for why pytest's
+        # default handlers need to come off first.
+        root = logging.getLogger()
+        root.handlers = []
+
+        from clickwork._logging import setup_logging
+
+        # 1. Bare root: first call attaches a clickwork-owned StreamHandler.
+        setup_logging(verbose=0, quiet=False, name="test_transition")
+        logger = logging.getLogger("test_transition")
+        owned_before_host = [
+            h
+            for h in logger.handlers
+            if getattr(h, "_clickwork_owned", False)
+            and isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.NullHandler)
+        ]
+        assert len(owned_before_host) == 1, (
+            "bare-root setup_logging must attach exactly one clickwork-owned "
+            f"StreamHandler on first call; got {owned_before_host}"
+        )
+
+        # 2. Host takes over root (simulating a later ``basicConfig()``
+        # or a framework wiring up logging after clickwork imported).
+        host_buffer = io.StringIO()
+        root.addHandler(logging.StreamHandler(host_buffer))
+
+        # 3. Second call must notice the host is now configured and
+        # evict the clickwork-owned StreamHandler left over from step 1.
+        setup_logging(verbose=0, quiet=False, name="test_transition")
+        owned_after_host = [
+            h
+            for h in logger.handlers
+            if getattr(h, "_clickwork_owned", False)
+            and isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.NullHandler)
+        ]
+        assert owned_after_host == [], (
+            "re-invocation under a host that configured root AFTER the "
+            "first setup_logging must evict the stale clickwork-owned "
+            f"StreamHandler; got {owned_after_host}"
         )


### PR DESCRIPTION
## Summary

Closes item 1 of #60 -- pins the re-invocation contract for ``setup_logging()`` with a test class and explicit documentation. The last small polish item before 1.0 can cut.

Issue #43 already built the mechanism (handlers tagged with a ``_clickwork_owned`` marker so re-invocations find and reuse them instead of stacking), but the contract wasn't pinned by test or documentation. A future refactor could regress it silently.

### What this adds

- **``TestSetupLoggingReinvocationContract``** in ``tests/unit/test_logging.py`` -- three cases:
  1. Same-args re-invocation keeps exactly one clickwork-owned handler.
  2. Different-args re-invocation live-updates the level on both the logger and its handler (NOT a no-op -- the second call is meaningful).
  3. Re-invocation under a host-configured root never (re)attaches a clickwork-owned StreamHandler.
- **Docstring update** on ``setup_logging()`` in ``src/clickwork/_logging.py`` with a dedicated paragraph explaining the contract and its rationale (test suites via ``CliRunner``, long-running hosts).
- **``docs/API_POLICY.md``** bullet under "Protocol-level surfaces" marking the contract as covered by SemVer -- changing either half (stacking a duplicate, or making the second call a no-op) is a major bump.

### Behavior (for the reviewer)

Current behavior already matches the documented contract -- this is a test-and-doc pin, not a functional fix:

- Handler identity: **idempotent** (reuses the existing ``_clickwork_owned`` handler in place).
- Level: **live-updated** on every call, on both the logger and its handler.

## Test plan

- [x] ``mise exec -- uv run pytest tests/unit -q`` -- 334 passed
- [x] ``mise exec -- uvx --from ruff==0.6.9 ruff format --check .`` -- clean
- [x] ``mise exec -- uvx --from ruff==0.6.9 ruff check .`` -- clean
- [x] ``mise exec -- uv run mypy --strict src/clickwork`` -- no issues

Links: #60 (item 1), references #43.

Generated with [Claude Code](https://claude.com/claude-code)