### PR TITLE
ci: tag push -> create release -> publish to PyPI (fix trigger)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,42 @@
 name: Publish to PyPI
 
+# Trigger on pushing a version tag (e.g. v1.0.0, v1.1.0-rc1).
+#
+# This workflow is the single source of truth for cutting a release:
+#   1. Build wheel + sdist from the tagged commit.
+#   2. Create the GitHub Release (matches the orbit-widener pattern;
+#      softprops/action-gh-release handles both create + upload).
+#   3. Publish the built artifacts to PyPI via Trusted Publishing.
+#
+# Pushing the tag alone is enough to ship a release end-to-end.
+# A manual GitHub Release draft is NOT required, and is in fact
+# redundant -- the workflow creates it for you.
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
-permissions:
-  id-token: write
+# Workflow-level deny-all. Each job re-grants only what it needs.
+# Principle of least privilege: a compromised step in one job cannot
+# inherit permissions another job was granted.
+permissions: {}
 
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
 
+    # Checkout reads the repo; nothing else is needed at this stage.
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The default checkout is a shallow fetch of the tag's commit,
+          # which is all `uv build` needs. Sdists don't embed git metadata
+          # so no fetch-depth tweaking is required.
+          fetch-depth: 1
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -30,11 +53,61 @@ jobs:
           name: dist
           path: dist/
 
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+
+    # contents: write is the minimum required to create a release and
+    # attach assets. Do NOT widen.
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      # softprops/action-gh-release creates the GitHub Release AND
+      # uploads the `files:` globs as release assets in one step.
+      # Using the same action (and pinned SHA) as orbit-widener's
+      # release.yml so the behaviour is consistent across both repos.
+      #
+      # generate_release_notes: true uses `.github/release.yml` to
+      # group merged PRs by label (Features / Bug fixes / Documentation
+      # / CI / Other). This replaces the old manual "draft release in
+      # the UI and click generate" flow.
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "clickwork ${{ github.ref_name }}"
+          draft: false
+          # Anything with a hyphen in the tag (e.g. v1.0.0-rc1) is
+          # marked as a pre-release so the "latest release" pointer
+          # on PyPI / GitHub doesn't advance to it accidentally.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: build
+    # Only publish to PyPI after the GitHub Release exists, so a
+    # failed release-creation step doesn't leave PyPI artifacts
+    # orphaned from their GitHub counterpart. Order matters here.
+    needs: create-release
     environment: pypi
+
+    # id-token:write is required by PyPI's Trusted Publisher OIDC flow.
+    # contents are not needed at this stage -- we're pulling the already-
+    # uploaded artifact from the build job.
+    permissions:
+      id-token: write
 
     steps:
       - name: Download distribution artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,14 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
 
-    # Checkout reads the repo; nothing else is needed at this stage.
+    # Checkout reads the repo; upload-artifact writes through the
+    # Actions API. Workflow-level ``permissions: {}`` gives GITHUB_TOKEN
+    # zero rights by default, so we must re-grant here or
+    # actions/upload-artifact@v4 will 403 and later jobs have nothing
+    # to download.
     permissions:
       contents: read
+      actions: write
 
     steps:
       - uses: actions/checkout@v4
@@ -41,8 +46,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Set up Python
-        run: uv python install 3.13
+      - name: Set up Python 3.13
+        # Install + pin so subsequent `uv` commands deterministically
+        # use 3.13 rather than whatever `python` the runner defaults to
+        # (ubuntu-latest ships 3.12 at time of writing). Matches the
+        # install-then-pin pattern in release-smoke.yml.
+        run: |
+          uv python install 3.13
+          uv python pin 3.13
 
       - name: Build package
         run: uv build
@@ -59,9 +70,13 @@ jobs:
     needs: build
 
     # contents: write is the minimum required to create a release and
-    # attach assets. Do NOT widen.
+    # attach assets. actions: read is required because
+    # actions/download-artifact@v4 reads the artifact registry through
+    # the Actions API (workflow-level ``permissions: {}`` starts at
+    # zero). Do NOT widen beyond these two.
     permissions:
       contents: write
+      actions: read
 
     steps:
       - name: Download distribution artifacts
@@ -104,10 +119,14 @@ jobs:
     environment: pypi
 
     # id-token:write is required by PyPI's Trusted Publisher OIDC flow.
-    # contents are not needed at this stage -- we're pulling the already-
-    # uploaded artifact from the build job.
+    # actions:read is required because actions/download-artifact@v4
+    # reads the artifact registry through the Actions API and workflow-
+    # level ``permissions: {}`` gives it nothing by default.
+    # contents: not needed -- we're pulling the already-uploaded
+    # artifact from the build job, not checking out source.
     permissions:
       id-token: write
+      actions: read
 
     steps:
       - name: Download distribution artifacts


### PR DESCRIPTION
## What went wrong

\`publish.yml\` triggered on \`release.published\`, which meant pushing a version tag didn't actually ship anything — you had to follow up with \`gh release create\` to fire the workflow. This deviated from the agreed pattern across qubitrenegade projects (orbit-widener's \`release.yml\` does tag-push -> build -> create release -> upload). My mistake; caught before cutting v1.0.0.

## Fix

Rewrite \`publish.yml\` to mirror orbit-widener's release.yml structure:

- **Trigger**: \`on: push: tags: ['v*']\`
- **Stage 1 (build)**: wheel + sdist via uv build
- **Stage 2 (create-release)**: \`softprops/action-gh-release@v2\` (same pinned SHA as orbit) creates the GitHub Release with auto-generated notes from \`.github/release.yml\` and attaches the dist files
- **Stage 3 (publish)**: PyPI via Trusted Publishing

## Security

Workflow-level \`permissions: {}\` deny-all. Each job re-grants only what it needs:
- build -> \`contents: read\`
- create-release -> \`contents: write\`
- publish -> \`id-token: write\`

## Test plan

- [ ] CI lint + format on this PR (workflow YAML is lint-clean)
- [ ] On merge and v1.0.0 tag push: verify all three stages run, the GitHub Release gets created with wheel/sdist attached, and PyPI receives the upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)