### PR TITLE
docs: sweep stale pre-1.0 framing and install pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,24 @@ Reusable CLI framework for project automation. Build project-specific CLIs
 with plugin discovery, layered config, subprocess helpers, and common
 utilities -- so your commands focus on business logic, not boilerplate.
 
-> **Status:** Pre-1.0 (`0.x`). API is unstable. All features are driven by
-> real [orbit-admin](https://github.com/qubitrenegade/qbrd-orbit-widener)
+> **Status:** 1.0 stable. The public API is documented in
+> [docs/API_POLICY.md](docs/API_POLICY.md) and covered by SemVer:
+> breaking changes require a major bump and removals carry a one-minor
+> deprecation runway. All features are driven by real
+> [orbit-admin](https://github.com/qubitrenegade/qbrd-orbit-widener)
 > needs -- no speculative abstractions.
 
-See [docs/API_POLICY.md](docs/API_POLICY.md) for the post-1.0 public API and compatibility policy.
+Upgrading from 0.2.x? See
+[docs/MIGRATING.md](docs/MIGRATING.md) for the complete
+before/after diff.
 
 ## Installation
 
 ```bash
 # From PyPI (preferred)
-uv pip install "clickwork==0.2.0"
+uv pip install "clickwork>=1.0,<2"
 # or, pinning to a git tag if you need a ref PyPI doesn't expose
-uv pip install "git+https://github.com/qubitrenegade/clickwork.git@v0.2.0"
+uv pip install "git+https://github.com/qubitrenegade/clickwork.git@v1.0.0"
 ```
 
 For local development alongside a consumer project:

--- a/docs/API_POLICY.md
+++ b/docs/API_POLICY.md
@@ -3,19 +3,18 @@
 ## Scope
 
 This document defines clickwork's public API surface and the
-compatibility guarantees that apply to it once version 1.0.0 ships. It
-covers which symbols callers can depend on, what constitutes a breaking
-change, how long deprecated symbols stick around, and which dependency
-and interpreter versions clickwork commits to supporting. The policy
-below starts applying on 1.0.0; pre-1.0 releases (0.x) carry no
-compatibility promise by semver convention, and the 1.0 release is
-explicitly allowed to break 0.2.x where the break corrects a genuine
-design mistake.
+compatibility guarantees that apply to it. It covers which symbols
+callers can depend on, what constitutes a breaking change, how long
+deprecated symbols stick around, and which dependency and interpreter
+versions clickwork commits to supporting. The policy is in effect
+from 1.0.0 onward; the 1.0 cut was explicitly allowed to break 0.2.x
+where the break corrected a genuine design mistake, and those
+breakages are catalogued in [`MIGRATING.md`](MIGRATING.md).
 
-Related docs that will cross-reference this policy once they land: see
-`MIGRATING.md` (tracked by Wave 4 issue #56) for the 0.x to 1.0 upgrade
-path, and `SECURITY.md` (tracked by Wave 4 issue #55) for the security
-properties clickwork asserts about its public surface.
+Related docs: [`MIGRATING.md`](MIGRATING.md) for the 0.x to 1.0
+upgrade path (covers every breaking change introduced in 1.0),
+and [`SECURITY.md`](SECURITY.md) for the security properties
+clickwork asserts about its public surface.
 
 ## Public API surface
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -27,9 +27,9 @@ clickwork gives you the scaffolding. You write the commands.
 
 ```bash
 # From PyPI (preferred)
-uv pip install "clickwork==0.2.0"
+uv pip install "clickwork>=1.0,<2"
 # or, pinning to a git tag if you need a ref PyPI doesn't expose
-uv pip install "git+https://github.com/qubitrenegade/clickwork.git@v0.2.0"
+uv pip install "git+https://github.com/qubitrenegade/clickwork.git@v1.0.0"
 ```
 
 For local development alongside your project:

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -275,7 +275,7 @@ you want CI to honour.
 Each clickwork minor ships with a migration note in `CHANGELOG.md`,
 and breaking changes carry a `BREAKING:` marker in the PR that
 introduced them. For the 0.x to 1.0 jump specifically, see
-`MIGRATING.md` once 1.0 ships -- it will enumerate every breaking
+[`MIGRATING.md`](MIGRATING.md) -- it enumerates every breaking
 change from the 0.2.x series, every deprecation shim, and every new
 public API your plugin can start relying on.
 


### PR DESCRIPTION
## Summary

Post-release cleanup. Main still had pre-1.0 framing in several docs ("Status: Pre-1.0", "API is unstable", `clickwork==0.2.0` install pins). Now that 1.0.0 has been cut and merged into main, update user-facing docs to match reality.

## Changes

- **README.md**: status block updated to "1.0 stable, API covered by SemVer" with a pointer to MIGRATING.md for 0.2.x users. Install pins: `clickwork>=1.0,<2` and `@v1.0.0`.
- **docs/GUIDE.md**: install block matches the README.
- **docs/API_POLICY.md**: intro paragraph drops the forward-tense "once 1.0 ships" wording; policy is in effect now. MIGRATING + SECURITY cross-references point at the landed files rather than "when they land".
- **docs/PLUGINS.md**: same "once 1.0 ships" fix in the Upgrade path section.

## Out of scope

- `CHANGELOG.md`: already has the 1.0.0 entry.
- `pyproject.toml`: already bumped + classifier = Production/Stable.
- `docs/superpowers/specs/2026-04-18-clickwork-1.0-roadmap.md`: kept as a historical planning document; pre-1.0 framing is accurate in that snapshot.

## Test plan

- [x] `grep` for remaining `0\.2\.0`, `Pre-1\.0`, `API is unstable`, `@v0\.2\.0` in non-historical files: clean
- [ ] CI green on this PR (docs-only, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)