### PR TITLE
docs: bug-template placeholder + LLM_REFERENCE link + CHANGELOG path precision

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: clickwork version
       description: Output of `python -c "import clickwork; print(clickwork.__version__)"`
-      placeholder: "0.1.0"
+      placeholder: "1.0.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,11 +138,11 @@ complete 0.2.x → 1.0 upgrade guide including before/after diffs.
 - **`docs/LLM_REFERENCE.md` "Common Footguns"** section collecting
   every gotcha that external reviewers and auto-review tools have
   caught on clickwork PRs (rewritten throughout the 1.0 cycle).
-- **GUIDE.md "Testing commands with clickwork.testing"** section
-  consolidated the testing story.
-- **README.md** rebuilt around the documented public surface with
-  direct links to `GUIDE`, `API_POLICY`, `PLUGINS`, `SECURITY`, and
-  `MIGRATING`.
+- **`docs/GUIDE.md` "Testing commands with clickwork.testing"**
+  section consolidated the testing story.
+- **`README.md`** rebuilt around the documented public surface with
+  direct links to `docs/GUIDE.md`, `docs/API_POLICY.md`,
+  `docs/PLUGINS.md`, `docs/SECURITY.md`, and `docs/MIGRATING.md`.
 
 ## [0.2.0] - 2026-04-18
 
@@ -188,15 +188,15 @@ subsection.
   preserving SIGINT forwarding. (#10)
 - `create_cli()` now accepts `enable_parent_package_imports=True` to
   opt into importing commands as relative to a parent package. (#15)
-- LLM_REFERENCE.md — new "Common Footguns" section (11 entries:
+- `docs/LLM_REFERENCE.md` — new "Common Footguns" section (11 entries:
   patching prereqs, `ClickException` routing, CliRunner streams,
   URL-encoding, secrets-in-argv, `.env` parsing, platform dispatch,
   HTTP calls, `import sys`, `bash -c` risk, module-scope
   `Secret.get()`). (#17)
-- GUIDE.md — new "Testing commands with `clickwork.testing`"
+- `docs/GUIDE.md` — new "Testing commands with `clickwork.testing`"
   subsection covering the new helpers and `result.output` /
   `.stdout` / `.stderr` semantics on Click 8.2+.
-- CHANGELOG.md (this file).
+- `CHANGELOG.md` (this file).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,9 +135,9 @@ complete 0.2.x → 1.0 upgrade guide including before/after diffs.
 
 ### Docs
 
-- **LLM_REFERENCE.md "Common Footguns"** section collecting every
-  gotcha that external reviewers and auto-review tools have caught
-  on clickwork PRs (rewritten throughout the 1.0 cycle).
+- **`docs/LLM_REFERENCE.md` "Common Footguns"** section collecting
+  every gotcha that external reviewers and auto-review tools have
+  caught on clickwork PRs (rewritten throughout the 1.0 cycle).
 - **GUIDE.md "Testing commands with clickwork.testing"** section
   consolidated the testing story.
 - **README.md** rebuilt around the documented public surface with
@@ -153,8 +153,9 @@ numbers**, except where explicitly noted as `(PR #NN)`. Major new
 modules: `clickwork.http`, `clickwork.platform`, `clickwork.testing`.
 New helpers on `CliContext`: `run_with_secrets`, stdin forwarding. New
 public API for docs-level CLIs: `add_global_option`. New dotenv helper:
-`clickwork.config.load_env_file`. Plus docs: LLM_REFERENCE "Common
-Footguns" section and GUIDE "Testing commands" subsection.
+`clickwork.config.load_env_file`. Plus docs: `docs/LLM_REFERENCE.md`
+"Common Footguns" section and `docs/GUIDE.md` "Testing commands"
+subsection.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ working example with subcommand groups.
   to report vulnerabilities.
 - **[Migrating 0.2.x to 1.0](docs/MIGRATING.md)** -- Breaking changes,
   new opt-in surfaces, and concrete before/after diffs for upgraders.
+- **[API Policy](docs/API_POLICY.md)** -- The 1.0 public surface:
+  which symbols are covered by SemVer, deprecation runway, supported
+  Python and Click ranges.
+- **[LLM Reference](docs/LLM_REFERENCE.md)** -- Compact, LLM-oriented
+  cheat sheet of the public surface with a "Common Footguns" section
+  (patching prereqs, `ClickException` routing, CliRunner streams,
+  secrets-in-argv, `bash -c` risks, etc.). Useful whether you're an
+  AI agent generating clickwork code or a human skimming for
+  gotchas.
 
 ## Features
 


### PR DESCRIPTION
## Summary

Three small pre-tag polish items caught on the final README pass:

1. **`.github/ISSUE_TEMPLATE/bug_report.yml`**: version placeholder bumped `0.1.0` → `1.0.0`. 0.1.0 predates PyPI entirely and would confuse a first bug reporter.
2. **`CHANGELOG.md`**: qualify the bare `LLM_REFERENCE.md` / `LLM_REFERENCE` mentions in both the 1.0.0 and 0.2.0 sections as `docs/LLM_REFERENCE.md` so the path is precise. These aren't markdown links so it's cosmetic, but consistency with every other `docs/*.md` reference in the file.
3. **`README.md`**: add Documentation entries for `API_POLICY.md` and `LLM_REFERENCE.md`. API_POLICY is the 1.0 compat contract that downstream maintainers want to find from the landing page; LLM_REFERENCE is the compact cheat sheet that's useful both to LLM agents generating clickwork code and to humans skimming for gotchas.

## Test plan

- [x] grep confirms no remaining bare `LLM_REFERENCE` references outside historical snapshots
- [ ] CI green (docs-only + issue template YAML, no code impact)

This is the last docs PR before the v1.0.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)