### PR TITLE
docs: add 'Cutting a release' runbook with GPG_TTY fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,8 +154,10 @@ open an issue and ask.
 1. Merge a release PR that bumps `version` in `pyproject.toml`,
    adds the new entry to `CHANGELOG.md`, and (if relevant) updates
    the trove classifier from Beta -> Production/Stable.
-2. Pull main, then sign and push the version tag. Include an
-   annotation so the GitHub Release body reads well:
+2. Pull main, then sign and push the version tag. Write a proper
+   tag annotation -- `git show v1.0.0` and the tag detail page on
+   GitHub surface it; the GitHub Release body itself is separately
+   auto-generated from `.github/release.yml` (see step 3):
 
    ```bash
    git checkout main && git pull
@@ -172,8 +174,8 @@ open an issue and ask.
    export GPG_TTY=$(tty)
    ```
 
-   Adding that to your shell rc makes the problem permanent-fixed
-   for future releases.
+   Adding that to your shell rc makes the fix permanent for
+   future releases.
 
 3. The push fires `.github/workflows/publish.yml`: build wheel +
    sdist, create the GitHub Release with auto-generated notes
@@ -182,7 +184,8 @@ open an issue and ask.
 4. The `pypi` environment is gated on maintainer approval. After
    the tag push, open the Actions tab, find the Publish run, click
    "Review deployments", approve `pypi`. The publish job finishes
-   within ~30s.
+   shortly after (typically under a minute; longer if runner load
+   or the PyPI upload API is slow).
 
 ## Code of conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,41 @@ single-PR cuts that bump version and changelog. If you're unsure
 whether a change you want to make warrants a roadmap-style rollout,
 open an issue and ask.
 
+### Cutting a release
+
+1. Merge a release PR that bumps `version` in `pyproject.toml`,
+   adds the new entry to `CHANGELOG.md`, and (if relevant) updates
+   the trove classifier from Beta -> Production/Stable.
+2. Pull main, then sign and push the version tag. Include an
+   annotation so the GitHub Release body reads well:
+
+   ```bash
+   git checkout main && git pull
+   git tag -s vX.Y.Z -m "clickwork X.Y.Z — <headline>"
+   git push origin vX.Y.Z
+   ```
+
+   **GPG on a headless terminal:** if `git tag -s` fails with
+   `gpg failed to sign the data` / `Inappropriate ioctl for
+   device`, `gpg-agent` can't find a TTY for the pinentry
+   passphrase prompt. Fix before retrying:
+
+   ```bash
+   export GPG_TTY=$(tty)
+   ```
+
+   Adding that to your shell rc makes the problem permanent-fixed
+   for future releases.
+
+3. The push fires `.github/workflows/publish.yml`: build wheel +
+   sdist, create the GitHub Release with auto-generated notes
+   (from `.github/release.yml` label grouping) and the dist files
+   attached, then publish to PyPI via Trusted Publishing.
+4. The `pypi` environment is gated on maintainer approval. After
+   the tag push, open the Actions tab, find the Publish run, click
+   "Review deployments", approve `pypi`. The publish job finishes
+   within ~30s.
+
 ## Code of conduct
 
 This project follows the spirit of the


### PR DESCRIPTION
## Summary

Document the full tag -> PyPI release flow we just validated on v1.0.0, and capture the `GPG_TTY=$(tty)` workaround that unblocked the first tag signing on a headless terminal.

## Why

When `git tag -s` fails with `gpg failed to sign the data` / `Inappropriate ioctl for device`, `gpg-agent` can't find a TTY to prompt for the pinentry passphrase. This bit us during the v1.0.0 cut; future maintainers shouldn't have to re-discover it.

## Changes

Add a `### Cutting a release` subsection to CONTRIBUTING.md's existing "Release process" section:

1. Merge a version-bump PR (pyproject + CHANGELOG + trove classifier).
2. `git tag -s vX.Y.Z -m "..."` + push.
3. **The GPG_TTY footnote** with the exact fix (`export GPG_TTY=$(tty)`).
4. Note that `publish.yml` handles build + GitHub Release + PyPI upload.
5. Reminder that the `pypi` environment is gated on maintainer approval via Actions -> Review deployments.

## Test plan

Docs-only. No code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)