### PR TITLE
docs: plan for Sigstore signing + workflow-driven tag signing (part of #61)

### DIFF
--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -1,0 +1,164 @@
+# Plan — Sigstore signing + workflow-driven tag signing (issue #61)
+
+**Date:** 2026-04-19
+**Milestone:** 1.0.x
+**Parent issue:** [#61](https://github.com/qubitrenegade/clickwork/issues/61)
+**Relevant docs:**
+[docs/SECURITY.md](../../SECURITY.md) (current unsigned-release caveats + placeholder verify section),
+[.github/workflows/publish.yml](../../../.github/workflows/publish.yml) (current build → create-release → PyPI publish flow)
+
+## Goal
+
+Add Sigstore keyless signing for clickwork's release artifacts (wheel + sdist), publish the resulting `.sigstore` bundles alongside the artifacts on the GitHub Release, move git-tag signing from the maintainer's local GPG key into the release workflow, and document verification commands in `docs/SECURITY.md` so downstream consumers can prove provenance of every 1.0.x release onward.
+
+## Non-goals
+
+- SLSA provenance attestation (separate issue, post-1.0.x).
+- Reproducible-build work (out of scope for #61).
+- Retroactively signing 0.2.0 or 1.0.0. The first signed release is 1.0.1.
+
+## Current state
+
+Release flow on `main` (from `.github/workflows/publish.yml`):
+
+1. Push tag `v*` → workflow fires.
+2. `build` job: `uv build` → `dist/*.whl` + `dist/*.tar.gz` → upload artifact.
+3. `create-release` job: download artifact → `softprops/action-gh-release@v2` creates the Release, attaches the dist files, uses `.github/release.yml` for auto-generated notes.
+4. `publish` job: download artifact → `pypa/gh-action-pypi-publish` uploads to PyPI via Trusted Publishing (OIDC).
+
+Tag signing today: maintainer runs `git tag -s vX.Y.Z` locally, which requires `GPG_TTY=$(tty)` export and a GPG key in the maintainer's keyring. See the "Cutting a release" runbook in `CONTRIBUTING.md`. The tag is cryptographically signed but the workflow itself is not involved — future maintainers would need their own GPG key + the same runbook.
+
+`docs/SECURITY.md` has a placeholder "Verifying release artifacts" section with a pip hash-check example and a note that Sigstore signing is planned for 1.0.1 with `cosign verify-blob` / `sigstore-python` as the recommended verify path.
+
+## Scope of this plan
+
+Three pieces, each with one or more open design questions the maintainer needs to answer before implementation:
+
+1. **Sigstore signing of wheel + sdist** (build-job or create-release-job?)
+2. **Workflow-driven tag signing** (cosign keyless vs workflow GPG key?)
+3. **Verification docs** (inline expansion of SECURITY.md vs new dedicated file?)
+
+## Design questions
+
+### Q1. Which Sigstore action?
+
+- **A) `sigstore/gh-action-sigstore-python`** — official Sigstore action, wraps the `sigstore` Python CLI, produces `.sigstore` bundle files. Maintained by Sigstore Foundation. Works with any artifact type.
+- **B) `pypa/gh-action-pypi-publish` with `attestations: true`** — pip-installable packages only; publishes attestations to PyPI's attestation endpoint rather than sideloading bundles. Simpler surface, coupled to PyPI.
+- **C) `slsa-framework/slsa-github-generator`** — different tool focused on SLSA provenance rather than Sigstore-bundle sign-everything. Out of scope per non-goals above but worth naming for rejection.
+
+**Recommendation:** A. Gives us standalone `.sigstore` bundles that verify without a PyPI round-trip and works the same for wheel, sdist, or any future artifact (e.g., Docker images if we ever ship one). B is narrower and couples us to PyPI's attestation story.
+
+**Open question for maintainer:** confirm A, or if B's simplicity wins.
+
+### Q2. Where in the workflow does Sigstore run?
+
+- **A) Inside the `build` job** — run `sigstore sign dist/*` right after `uv build`, upload the `.sigstore` bundles as part of the `dist` artifact alongside the wheel and sdist. `create-release` then attaches bundles to the Release as files.
+- **B) Inside a new dedicated `sign` job** — between `build` and `create-release`. `build` produces dist, `sign` downloads+signs+uploads a new artifact including bundles, `create-release` and `publish` both download the new artifact.
+- **C) Inside `create-release`** — sign just before uploading to the Release.
+
+**Recommendation:** A. One artifact, one OIDC exchange, fewer job boundaries. B adds a deployment stage for no security win (the OIDC token is scoped the same way). C couples signing to release creation which makes it harder to sign a sdist for PyPI that we don't surface on the Release (edge case but still).
+
+**Open question for maintainer:** confirm A, or prefer B's job-level separation.
+
+### Q3. How are `.sigstore` bundles published?
+
+- **A) Release assets only** — bundles live on GitHub Release alongside wheel/sdist. Verification command: download bundle + artifact, `sigstore verify identity ...`.
+- **B) PyPI attestations + Release assets** — same as A, PLUS publish to PyPI's attestation endpoint via `pypa/gh-action-pypi-publish` `attestations: true`. Verification command (PyPI side): `pip` / `uv` auto-verifies during install.
+- **C) Release assets + Sigstore transparency log only** — rely on Rekor transparency log + artifact hash for verification, skip bundle files on the Release.
+
+**Recommendation:** B. PyPI attestations make verification automatic for the most common install path (`pip install clickwork`), and the Release-side bundles cover anyone installing from a tarball or a git tag. A alone means `pip install` users get no automatic verification. C alone makes manual verification harder and depends entirely on Rekor uptime.
+
+**Open question for maintainer:** confirm B (bundle + PyPI attestation both).
+
+### Q4. Tag signing mechanism?
+
+- **A) cosign keyless OIDC via `sigstore/cosign-installer` + `cosign sign-blob` on the tag ref** — workflow uses its own OIDC token against Sigstore's Fulcio CA to create an ephemeral signing identity tied to the workflow+repo. No long-lived key to manage. Signature is a separate `.sig` file (or a transparency-log entry on Rekor), NOT a git `-S` signature on the tag itself.
+- **B) Workflow-managed GPG key stored as an encrypted secret in the `pypi` environment** — workflow imports the key, runs `git tag -s` inside the workflow. Produces a real GPG-signed git tag that `git verify-tag` checks natively. Long-lived key needs rotation policy, but the tag signature form is the one GitHub's "Verified" badge understands.
+- **C) Status quo** — maintainer signs locally with their own GPG key; the workflow stays agnostic. Lose workflow-driven signing as a 1.0.x goal; defer indefinitely.
+
+**Recommendation:** B. GitHub's "Verified" badge on the tag page is what most downstream consumers actually look at. Cosign keyless is a good complement (sign the release artifacts with it per Q1) but isn't recognised as a git tag signature. Managing one long-lived GPG key in the `pypi` environment secret is a known-acceptable operational cost.
+
+**Open concern with B:** the private key material ends up in secrets, which is a step back from the "no long-lived keys" principle that Sigstore is built around. Rotating the key should be part of the runbook.
+
+**Alt: hybrid A+B** — use cosign keyless to produce a Rekor entry referencing the tag SHA (proves the workflow signed something) AND the maintainer continues to `git tag -s` locally. Preserves the "Verified" badge on GitHub, adds a workflow-level artifact. Belt-and-suspenders.
+
+**Open question for maintainer:** B, A, or hybrid A+B? This is the biggest design call in the plan.
+
+### Q5. Verification docs placement?
+
+- **A) Expand the existing "Verifying release artifacts" section in `docs/SECURITY.md`** — one file, cross-references stay simple. File gets longer.
+- **B) New `docs/VERIFYING.md`** — dedicated page that SECURITY.md links to. Keeps SECURITY.md focused on threat model.
+- **C) Both — brief 3-4-line summary in SECURITY.md, detailed commands in `docs/VERIFYING.md`** — progressive disclosure.
+
+**Recommendation:** C. SECURITY.md readers want the high-level "yes there's a verify path and here's one command," while someone actively verifying wants a dedicated reference. Matches the skill's own progressive-disclosure convention (SKILL.md + references).
+
+**Open question for maintainer:** A, B, or C?
+
+### Q6. Backward compat / retroactive signing?
+
+- **A) No retroactive signing. First signed release is 1.0.1.**
+- **B) Retroactively sign 1.0.0 from the tag** — rerun the signing step against the existing `v1.0.0` tag, upload bundles as a second Release asset batch. Viable because `cosign sign-blob` + Sigstore bundles work against any artifact SHA, regardless of when it was built.
+- **C) Retroactively sign 0.2.0 too** — same mechanism, older release.
+
+**Recommendation:** A. Keeping a clean "from this version onward, signed" cutline is easier to document and reduces the change surface. B+C open us up to "does the sdist on PyPI for 1.0.0 need to be re-published or just gain a Release-side bundle?" ambiguity.
+
+**Open question for maintainer:** confirm A, or push back for B.
+
+## Proposed implementation waves
+
+Assuming maintainer picks **Q1=A, Q2=A, Q3=B, Q4=B (or hybrid A+B), Q5=C, Q6=A**, the implementation breaks into:
+
+### Wave 1 (PR #a): Sigstore bundle signing on release artifacts
+
+- Add `sigstore/gh-action-sigstore-python@v3` step in the `build` job after `uv build`. Signs `dist/*.whl` and `dist/*.tar.gz`. Produces `.sigstore` bundles next to the artifacts.
+- Extend the `upload-artifact` step to include `*.sigstore` bundles.
+- Extend `softprops/action-gh-release@v2` `files:` glob to include `dist/*.sigstore`.
+- In the `publish` job, add `attestations: true` to `pypa/gh-action-pypi-publish`. This handles Q3=B's PyPI attestation side.
+- New permissions on the build job: `id-token: write` (for OIDC → Fulcio). Already present on the publish job for Trusted Publishing.
+
+**Target diff size:** ~30 lines of `publish.yml` + workflow smoke-test verification.
+
+### Wave 2 (PR #b): Workflow-driven tag signing
+
+If Q4=B: generate a GPG key, store public half on GitHub user account (for the Verified badge), store private half as secret in the `pypi` environment. Add a pre-build step that imports the key and re-tags the current ref with `git tag -s`. Subtle issue: the workflow sees the tag that fired it, not a mutable HEAD — retagging during the same workflow run is awkward. Alternative: a separate `tag-signing` workflow that runs on `workflow_dispatch`, signs a future tag in advance.
+
+If Q4=A: add `cosign-installer` action, `cosign sign-blob` against the tag SHA, upload result as a Rekor entry. Simpler, no secrets to manage, but no Verified badge.
+
+If Q4=hybrid: just do A for the workflow (cosign blob signing) and keep the CONTRIBUTING runbook for the maintainer's local-GPG tag signing. Simplest landing for 1.0.1 while leaving the B path open for later.
+
+**Target diff size:** depends on Q4 — hybrid is ~15 lines, full B is ~60 lines + secrets-setup documentation.
+
+### Wave 3 (PR #c): Verification docs
+
+Assuming Q5=C:
+
+- `docs/VERIFYING.md`: concrete commands for (1) verifying the PyPI install via `pip install --require-hashes` or the attestation endpoint, (2) verifying a downloaded wheel/sdist against its `.sigstore` bundle via `sigstore verify identity`, (3) verifying the tag via `git verify-tag` (if Q4=B) or Rekor (if Q4=A or hybrid).
+- Update `docs/SECURITY.md` "Verifying release artifacts" section to a short summary + link to `VERIFYING.md`.
+- Cross-link from `CONTRIBUTING.md`'s "Cutting a release" runbook.
+
+**Target diff size:** ~100 lines new docs, ~10 lines updates.
+
+### Wave 4 (PR #d): Cut 1.0.1 to exercise the flow
+
+Release-cut PR (version bump + CHANGELOG 1.0.1 entry). Maintainer tags+pushes, the new `publish.yml` fires end-to-end, Sigstore bundles land on the Release, attestations show on PyPI, verification commands in `VERIFYING.md` work against the real 1.0.1 artifacts. Any bugs that surface get fixed in a follow-up PR before the pattern is documented as "this is how we ship."
+
+**Target diff size:** minimal — version + changelog + follow-up fixes as needed.
+
+## Merge-order constraints
+
+- Wave 1 must land before Wave 4 (can't cut 1.0.1 unsigned with the unsigned publish flow).
+- Wave 2 can land in parallel with Wave 1 if hybrid-A.
+- Wave 3 can land in parallel with Waves 1+2 (docs). Arguably easier to write the verify docs AFTER we've seen the actual bundle shapes, so schedule Wave 3 last-or-parallel but not first.
+
+## Success criteria
+
+- `publish.yml` on main ends with: PyPI upload attested, Release has `.sigstore` bundles as assets, tag verified (by whichever of A/B/hybrid we pick in Q4).
+- `docs/VERIFYING.md` documents three concrete verification paths: PyPI attestation, bundle-side, tag-side.
+- A fresh consumer running `pip install --require-hashes clickwork==1.0.1` gets automatic PyPI-attestation verification.
+- A fresh consumer running `sigstore verify identity dist/clickwork-1.0.1-py3-none-any.whl --bundle dist/clickwork-1.0.1-py3-none-any.whl.sigstore --cert-identity <workflow-identity> --cert-oidc-issuer https://token.actions.githubusercontent.com` gets a pass.
+
+## Out of scope for this plan
+
+- SLSA provenance attestation (separate follow-up after 1.0.x stabilises).
+- Signing orbit-admin's clickwork dependency. Downstream concern for orbit-admin's own release workflow.
+- Mirroring signed bundles to conda-forge (conda-forge has its own signing story via #62).

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -171,7 +171,7 @@ Release-cut PR (version bump + CHANGELOG 1.0.1 entry). Maintainer tags+pushes, t
 ## Merge-order constraints
 
 - Wave 1 must land before Wave 4 (can't cut 1.0.1 unsigned with the unsigned publish flow).
-- Wave 2 can land in parallel with Wave 1 under the locked Q4 choice (**B / Path 1**) — both are pure additions to `.github/workflows/` with no file overlap.
+- Wave 2 can land in parallel with Wave 1 under the locked Q4 choice (**B / Path 1**) — Wave 1 modifies the existing `.github/workflows/publish.yml`, while Wave 2 adds a new `.github/workflows/sign-release-tag.yml` and updates `CONTRIBUTING.md`, so expected overlap is low (no shared lines) even though these are not both pure additions.
 - Wave 3 can land in parallel with Waves 1+2 (docs). Arguably easier to write the verify docs AFTER we've seen the actual bundle shapes, so schedule Wave 3 last-or-parallel but not first.
 
 ## Success criteria

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -130,7 +130,8 @@ Q4 is decided (**B, Path 1** — workflow-only GPG key). Implementation:
 1. Generate a new GPG key specifically for workflow signing. Identity: something like `clickwork-release-bot <release@clickwork.example>` or similar — clearly NOT the maintainer's personal identity. Passwordless.
 2. Upload the public half to the maintainer's GitHub account (`Settings → SSH and GPG keys → New GPG key`) so signatures on tags show the Verified badge against the maintainer's account.
 3. Store the private half as an encrypted secret in the `pypi` environment (we already gate PyPI publish on that environment for approval). Suggest secret names: `RELEASE_GPG_PRIVATE_KEY` (armored private block), `RELEASE_GPG_KEY_ID` (long-form fingerprint for `git config user.signingkey`).
-4. Document the rotation cadence in `CONTRIBUTING.md` — suggested: rotate yearly or on any suspected exposure, with revocation publishing a new `.asc` to both GitHub and the secret.
+4. Generate a fine-scoped PAT (fine-grained PAT limited to this repo with `contents: write`, or a classic token with `repo` scope) for pushing the signed tag back to origin. Store as `RELEASE_TAG_PUSH_TOKEN` in the same `pypi` environment. See "Gotcha" below for why `GITHUB_TOKEN` alone isn't enough. (Rotate alongside the GPG key.)
+5. Document the rotation cadence in `CONTRIBUTING.md` — suggested: rotate yearly or on any suspected exposure. GPG key revocation publishes a new `.asc` to both GitHub and the secret; PAT rotation is a secret update plus revoking the old PAT in account settings.
 
 **Workflow changes:**
 
@@ -141,7 +142,15 @@ Because the workflow is triggered by a tag push, it cannot re-tag the commit it 
 
 **Decision: B.1.** New workflow, clean boundary with `publish.yml`, no recursive-trigger risk.
 
-**Target diff size:** ~80 lines new workflow (`sign-release-tag.yml`) + ~30 lines secrets-setup documentation in `CONTRIBUTING.md` + ~20 lines rotation runbook.
+**Gotcha: `GITHUB_TOKEN` pushes don't trigger other workflows.** By default, a tag pushed from inside a workflow authenticated with the standard `GITHUB_TOKEN` does NOT fire `on: push` listeners in sibling workflows — GitHub's explicit anti-recursion guard ([docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). So naive B.1 (sign-release-tag.yml pushes the tag, publish.yml listens for the tag push) silently fails to release. Three mitigations, ranked:
+
+- **M1 (recommended): PAT-authenticated push.** Generate a fine-scoped Personal Access Token (fine-grained PAT or classic token with `contents: write`), store it as `RELEASE_TAG_PUSH_TOKEN` in the `pypi` environment, and configure `sign-release-tag.yml`'s push step to use it via `git push https://x-access-token:${TOKEN}@github.com/...`. The PAT-authored push triggers `publish.yml` normally. Rotation cadence pairs with the GPG key rotation (yearly).
+- **M2: `workflow_run` chaining.** Add `on: workflow_run: workflows: ["Sign Release Tag"]` to `publish.yml` (or a wrapper that invokes it via `workflow_dispatch` inputs). No PAT needed, but `publish.yml` now has two triggers (`push: tags` + `workflow_run`) and the two paths diverge enough to complicate the runbook.
+- **M3: GitHub App token.** Use a dedicated GitHub App installed on the repo, mint a token from it in the sign workflow, push with that token. Same trigger-firing behaviour as M1 but heavier setup (app creation, installation, private key as secret). Overkill for a single-repo maintainer.
+
+**Chosen mitigation: M1.** One more secret (`RELEASE_TAG_PUSH_TOKEN`), no change to `publish.yml`, minimum runbook surface. Rotation pairs with GPG key rotation. Rejected M2 because splitting `publish.yml`'s trigger surface invites subtle divergence between "maintainer pushes tag directly" and "workflow pushed tag" paths; rejected M3 because the GitHub App story is too much operational weight for a one-maintainer repo.
+
+**Target diff size:** ~80 lines new workflow (`sign-release-tag.yml`) + ~30 lines secrets-setup documentation in `CONTRIBUTING.md` (now covers `RELEASE_GPG_PRIVATE_KEY`, `RELEASE_GPG_KEY_ID`, and `RELEASE_TAG_PUSH_TOKEN`) + ~20 lines rotation runbook.
 
 ### Wave 3 (PR #c): Verification docs
 

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -129,7 +129,7 @@ Q4 is decided (**B, Path 1** — workflow-only GPG key). Implementation:
 
 1. Generate a new GPG key specifically for workflow signing. Identity: something like `clickwork-release-bot <release@clickwork.example>` or similar — clearly NOT the maintainer's personal identity. Passwordless.
 2. Upload the public half to the maintainer's GitHub account (`Settings → SSH and GPG keys → New GPG key`) so signatures on tags show the Verified badge against the maintainer's account.
-3. Store the private half as an encrypted secret in the `pypi` environment (we already gate PyPI publish on that environment for approval). Suggest secret names: `RELEASE_GPG_PRIVATE_KEY` (armored private block), `RELEASE_GPG_KEY_ID` (long-form fingerprint for `git config user.signingkey`).
+3. Store the private half as an encrypted secret in the `pypi` environment (we already gate PyPI publish on that environment for approval). Suggest secret names: `RELEASE_GPG_PRIVATE_KEY` (armored private block), `RELEASE_GPG_FINGERPRINT` (full 40-character fingerprint — NOT a short or long key ID — for `git config user.signingkey`).
 4. Generate a fine-scoped PAT (fine-grained PAT limited to this repo with `contents: write`, or a classic token with `repo` scope) for pushing the signed tag back to origin. Store as `RELEASE_TAG_PUSH_TOKEN` in the same `pypi` environment. See "Gotcha" below for why `GITHUB_TOKEN` alone isn't enough. (Rotate alongside the GPG key.)
 5. Document the rotation cadence in `CONTRIBUTING.md` — suggested: rotate yearly or on any suspected exposure. GPG key revocation publishes a new `.asc` to both GitHub and the secret; PAT rotation is a secret update plus revoking the old PAT in account settings.
 
@@ -150,7 +150,7 @@ Because the workflow is triggered by a tag push, it cannot re-tag the commit it 
 
 **Chosen mitigation: M1.** One more secret (`RELEASE_TAG_PUSH_TOKEN`), no change to `publish.yml`, minimum runbook surface. Rotation pairs with GPG key rotation. Rejected M2 because splitting `publish.yml`'s trigger surface invites subtle divergence between "maintainer pushes tag directly" and "workflow pushed tag" paths; rejected M3 because the GitHub App story is too much operational weight for a one-maintainer repo.
 
-**Target diff size:** ~80 lines new workflow (`sign-release-tag.yml`) + ~30 lines secrets-setup documentation in `CONTRIBUTING.md` (now covers `RELEASE_GPG_PRIVATE_KEY`, `RELEASE_GPG_KEY_ID`, and `RELEASE_TAG_PUSH_TOKEN`) + ~20 lines rotation runbook.
+**Target diff size:** ~80 lines new workflow (`sign-release-tag.yml`) + ~30 lines secrets-setup documentation in `CONTRIBUTING.md` (now covers `RELEASE_GPG_PRIVATE_KEY`, `RELEASE_GPG_FINGERPRINT`, and `RELEASE_TAG_PUSH_TOKEN`) + ~20 lines rotation runbook.
 
 ### Wave 3 (PR #c): Verification docs
 

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -23,7 +23,7 @@ Release flow on `main` (from `.github/workflows/publish.yml`):
 
 1. Push tag `v*` → workflow fires.
 2. `build` job: `uv build` → `dist/*.whl` + `dist/*.tar.gz` → upload artifact.
-3. `create-release` job: download artifact → `softprops/action-gh-release@v2` creates the Release, attaches the dist files, uses `.github/release.yml` for auto-generated notes.
+3. `create-release` job: download artifact → `softprops/action-gh-release` (pinned to a specific commit SHA that resolves to the v2 line, per supply-chain discipline) creates the Release, attaches the dist files, uses `.github/release.yml` for auto-generated notes.
 4. `publish` job: download artifact → `pypa/gh-action-pypi-publish` uploads to PyPI via Trusted Publishing (OIDC).
 
 Tag signing today: maintainer runs `git tag -s vX.Y.Z` locally, which requires `GPG_TTY=$(tty)` export and a GPG key in the maintainer's keyring. See the "Cutting a release" runbook in `CONTRIBUTING.md`. The tag is cryptographically signed but the workflow itself is not involved — future maintainers would need their own GPG key + the same runbook.
@@ -63,10 +63,10 @@ Three pieces, each with one or more open design questions the maintainer needs t
 ### Q3. How are `.sigstore` bundles published?
 
 - **A) Release assets only** — bundles live on GitHub Release alongside wheel/sdist. Verification command: download bundle + artifact, `sigstore verify identity ...`.
-- **B) PyPI attestations + Release assets** — same as A, PLUS publish to PyPI's attestation endpoint via `pypa/gh-action-pypi-publish` `attestations: true`. Verification command (PyPI side): `pip` / `uv` auto-verifies during install.
+- **B) PyPI attestations + Release assets** — same as A, PLUS publish to PyPI's attestation endpoint via `pypa/gh-action-pypi-publish` `attestations: true`. Verification command (PyPI side) is manual today via `pypi-attestations verify` or `sigstore-python`; pip/uv auto-verify of PyPI attestations is not GA yet (tracked upstream; once it ships, B upgrades to "automatic on install" for free).
 - **C) Release assets + Sigstore transparency log only** — rely on Rekor transparency log + artifact hash for verification, skip bundle files on the Release.
 
-**Recommendation:** B. PyPI attestations make verification automatic for the most common install path (`pip install clickwork`), and the Release-side bundles cover anyone installing from a tarball or a git tag. A alone means `pip install` users get no automatic verification. C alone makes manual verification harder and depends entirely on Rekor uptime.
+**Recommendation:** B. PyPI attestations give every `pip install clickwork` consumer a future-proof path to automatic verification (the moment pip lands auto-verify, B starts working with zero action from us), while the Release-side bundles cover anyone installing from a tarball or a git tag today. A alone leaves PyPI consumers with no attestation story at all. C alone makes manual verification harder and depends entirely on Rekor uptime.
 
 **Open question for maintainer:** confirm B (bundle + PyPI attestation both).
 
@@ -110,9 +110,9 @@ Assuming maintainer picks **Q1=A, Q2=A, Q3=B, Q4=B (or hybrid A+B), Q5=C, Q6=A**
 
 ### Wave 1 (PR #a): Sigstore bundle signing on release artifacts
 
-- Add `sigstore/gh-action-sigstore-python@v3` step in the `build` job after `uv build`. Signs `dist/*.whl` and `dist/*.tar.gz`. Produces `.sigstore` bundles next to the artifacts.
-- Extend the `upload-artifact` step to include `*.sigstore` bundles.
-- Extend `softprops/action-gh-release@v2` `files:` glob to include `dist/*.sigstore`.
+- Add `sigstore/gh-action-sigstore-python@v3` step in the `build` job after `uv build`. Signs `dist/*.whl` and `dist/*.tar.gz`. Produces `.sigstore` bundles in `dist/` alongside the artifacts.
+- The current `upload-artifact` step already uploads the entire `dist/` directory, so `.sigstore` files emitted into `dist/` come along automatically — no change to that step needed.
+- Extend `softprops/action-gh-release` `files:` glob to include `dist/*.sigstore` so the bundles appear as Release assets.
 - In the `publish` job, add `attestations: true` to `pypa/gh-action-pypi-publish`. This handles Q3=B's PyPI attestation side.
 - New permissions on the build job: `id-token: write` (for OIDC → Fulcio). Already present on the publish job for Trusted Publishing.
 

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -41,7 +41,7 @@ Release flow on `main` (from `.github/workflows/publish.yml`):
 3. `create-release` job: download artifact → `softprops/action-gh-release` (pinned to a specific commit SHA that resolves to the v2 line, per supply-chain discipline) creates the Release, attaches the dist files, uses `.github/release.yml` for auto-generated notes.
 4. `publish` job: download artifact → `pypa/gh-action-pypi-publish` uploads to PyPI via Trusted Publishing (OIDC).
 
-Tag signing today: maintainer runs `git tag -s vX.Y.Z` locally, which requires `GPG_TTY=$(tty)` export and a GPG key in the maintainer's keyring. See the "Cutting a release" runbook in `CONTRIBUTING.md`. The tag is cryptographically signed but the workflow itself is not involved — future maintainers would need their own GPG key + the same runbook.
+Tag signing today: maintainer runs `git tag -s vX.Y.Z` locally, which requires a GPG key in the maintainer's keyring; in some environments `GPG_TTY=$(tty)` may also need to be exported so GPG pinentry can access a TTY. See the "Cutting a release" runbook in `CONTRIBUTING.md`. The tag is cryptographically signed but the workflow itself is not involved — future maintainers would need their own GPG key + the same runbook.
 
 `docs/SECURITY.md` has a placeholder "Verifying release artifacts" section with a pip hash-check example and a note that Sigstore signing is planned for 1.0.1 with `cosign verify-blob` / `sigstore-python` as the recommended verify path.
 

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -47,13 +47,15 @@ Tag signing today: maintainer runs `git tag -s vX.Y.Z` locally, which requires `
 
 ## Scope of this plan
 
-Three pieces, each with one or more open design questions the maintainer needs to answer before implementation:
+Three implementation pieces, aligned with the locked decisions above:
 
-1. **Sigstore signing of wheel + sdist** (build-job or create-release-job?)
-2. **Workflow-driven tag signing** (cosign keyless vs workflow GPG key?)
-3. **Verification docs** (inline expansion of SECURITY.md vs new dedicated file?)
+1. **Sigstore signing of wheel + sdist** — Q1=A, Q2=A, Q3=B: run `sigstore/gh-action-sigstore-python` inside the existing `build` job, publish bundles as both Release assets and PyPI attestations.
+2. **Workflow-driven tag signing** — Q4=B (Path 1): dedicated workflow-only GPG key in the `pypi` environment, public half on the maintainer's GitHub account.
+3. **Verification docs** — Q5=C: short summary in `docs/SECURITY.md` + detailed `docs/VERIFYING.md`.
 
-## Design questions
+## Design questions (resolved — kept for historical context)
+
+The A/B/C alternatives below were the options considered; each has a **Decision:** line pointing at the locked choice from the table above. Left in the doc so future readers can see what was weighed and why.
 
 ### Q1. Which Sigstore action?
 
@@ -61,9 +63,7 @@ Three pieces, each with one or more open design questions the maintainer needs t
 - **B) `pypa/gh-action-pypi-publish` with `attestations: true`** — pip-installable packages only; publishes attestations to PyPI's attestation endpoint rather than sideloading bundles. Simpler surface, coupled to PyPI.
 - **C) `slsa-framework/slsa-github-generator`** — different tool focused on SLSA provenance rather than Sigstore-bundle sign-everything. Out of scope per non-goals above but worth naming for rejection.
 
-**Recommendation:** A. Gives us standalone `.sigstore` bundles that verify without a PyPI round-trip and works the same for wheel, sdist, or any future artifact (e.g., Docker images if we ever ship one). B is narrower and couples us to PyPI's attestation story.
-
-**Open question for maintainer:** confirm A, or if B's simplicity wins.
+**Decision: A.** Gives us standalone `.sigstore` bundles that verify without a PyPI round-trip and works the same for wheel, sdist, or any future artifact (e.g., Docker images if we ever ship one). B is narrower and couples us to PyPI's attestation story. (B's PyPI-attestation benefit is still captured — see Q3.)
 
 ### Q2. Where in the workflow does Sigstore run?
 
@@ -71,9 +71,7 @@ Three pieces, each with one or more open design questions the maintainer needs t
 - **B) Inside a new dedicated `sign` job** — between `build` and `create-release`. `build` produces dist, `sign` downloads+signs+uploads a new artifact including bundles, `create-release` and `publish` both download the new artifact.
 - **C) Inside `create-release`** — sign just before uploading to the Release.
 
-**Recommendation:** A. One artifact, one OIDC exchange, fewer job boundaries. B adds a deployment stage for no security win (the OIDC token is scoped the same way). C couples signing to release creation which makes it harder to sign a sdist for PyPI that we don't surface on the Release (edge case but still).
-
-**Open question for maintainer:** confirm A, or prefer B's job-level separation.
+**Decision: A.** One artifact, one OIDC exchange, fewer job boundaries. B adds a deployment stage for no security win (the OIDC token is scoped the same way). C couples signing to release creation which makes it harder to sign a sdist for PyPI that we don't surface on the Release (edge case but still).
 
 ### Q3. How are `.sigstore` bundles published?
 
@@ -81,9 +79,7 @@ Three pieces, each with one or more open design questions the maintainer needs t
 - **B) PyPI attestations + Release assets** — same as A, PLUS publish to PyPI's attestation endpoint via `pypa/gh-action-pypi-publish` `attestations: true`. Verification command (PyPI side) is manual today via `pypi-attestations verify` or `sigstore-python`; pip/uv auto-verify of PyPI attestations is not GA yet (tracked upstream; once it ships, B upgrades to "automatic on install" for free).
 - **C) Release assets + Sigstore transparency log only** — rely on Rekor transparency log + artifact hash for verification, skip bundle files on the Release.
 
-**Recommendation:** B. PyPI attestations give every `pip install clickwork` consumer a future-proof path to automatic verification (the moment pip lands auto-verify, B starts working with zero action from us), while the Release-side bundles cover anyone installing from a tarball or a git tag today. A alone leaves PyPI consumers with no attestation story at all. C alone makes manual verification harder and depends entirely on Rekor uptime.
-
-**Open question for maintainer:** confirm B (bundle + PyPI attestation both).
+**Decision: B.** PyPI attestations give every `pip install clickwork` consumer a future-proof path to automatic verification (the moment pip lands auto-verify, B starts working with zero action from us), while the Release-side bundles cover anyone installing from a tarball or a git tag today. A alone leaves PyPI consumers with no attestation story at all. C alone makes manual verification harder and depends entirely on Rekor uptime.
 
 ### Q4. Tag signing mechanism?
 
@@ -91,13 +87,9 @@ Three pieces, each with one or more open design questions the maintainer needs t
 - **B) Workflow-managed GPG key stored as an encrypted secret in the `pypi` environment** — workflow imports the key, runs `git tag -s` inside the workflow. Produces a real GPG-signed git tag that `git verify-tag` checks natively. Long-lived key needs rotation policy, but the tag signature form is the one GitHub's "Verified" badge understands.
 - **C) Status quo** — maintainer signs locally with their own GPG key; the workflow stays agnostic. Lose workflow-driven signing as a 1.0.x goal; defer indefinitely.
 
-**Recommendation:** B. GitHub's "Verified" badge on the tag page is what most downstream consumers actually look at. Cosign keyless is a good complement (sign the release artifacts with it per Q1) but isn't recognised as a git tag signature. Managing one long-lived GPG key in the `pypi` environment secret is a known-acceptable operational cost.
+**Decision: B (Path 1).** GitHub's "Verified" badge on the tag page is what most downstream consumers actually look at. Cosign keyless is a good complement (sign the release artifacts with it per Q1) but isn't recognised as a git tag signature. Managing one dedicated **workflow-only** GPG key — generated specifically for release signing, uploaded to the maintainer's GitHub account for the Verified badge, stored passwordless in the `pypi` environment secret — is a known-acceptable operational cost. The key is NOT the maintainer's personal identity key; it's revocable if it ever leaks without touching the maintainer's personal key.
 
-**Open concern with B:** the private key material ends up in secrets, which is a step back from the "no long-lived keys" principle that Sigstore is built around. Rotating the key should be part of the runbook.
-
-**Alt: hybrid A+B** — use cosign keyless to produce a Rekor entry referencing the tag SHA (proves the workflow signed something) AND the maintainer continues to `git tag -s` locally. Preserves the "Verified" badge on GitHub, adds a workflow-level artifact. Belt-and-suspenders.
-
-**Open question for maintainer:** B, A, or hybrid A+B? This is the biggest design call in the plan.
+**Acknowledged tradeoff:** dedicated release-signing key material ends up in secrets, which is a step back from the "no long-lived keys" principle that Sigstore is built around. Rotation cadence (yearly or on suspected exposure) is part of the runbook in Wave 2 below.
 
 ### Q5. Verification docs placement?
 
@@ -105,9 +97,7 @@ Three pieces, each with one or more open design questions the maintainer needs t
 - **B) New `docs/VERIFYING.md`** — dedicated page that SECURITY.md links to. Keeps SECURITY.md focused on threat model.
 - **C) Both — brief 3-4-line summary in SECURITY.md, detailed commands in `docs/VERIFYING.md`** — progressive disclosure.
 
-**Recommendation:** C. SECURITY.md readers want the high-level "yes there's a verify path and here's one command," while someone actively verifying wants a dedicated reference. Matches the skill's own progressive-disclosure convention (SKILL.md + references).
-
-**Open question for maintainer:** A, B, or C?
+**Decision: C.** SECURITY.md readers want the high-level "yes there's a verify path and here's one command," while someone actively verifying wants a dedicated reference. Matches the skill's own progressive-disclosure convention (SKILL.md + references).
 
 ### Q6. Backward compat / retroactive signing?
 
@@ -115,13 +105,11 @@ Three pieces, each with one or more open design questions the maintainer needs t
 - **B) Retroactively sign 1.0.0 from the tag** — rerun the signing step against the existing `v1.0.0` tag, upload bundles as a second Release asset batch. Viable because `cosign sign-blob` + Sigstore bundles work against any artifact SHA, regardless of when it was built.
 - **C) Retroactively sign 0.2.0 too** — same mechanism, older release.
 
-**Recommendation:** A. Keeping a clean "from this version onward, signed" cutline is easier to document and reduces the change surface. B+C open us up to "does the sdist on PyPI for 1.0.0 need to be re-published or just gain a Release-side bundle?" ambiguity.
-
-**Open question for maintainer:** confirm A, or push back for B.
+**Decision: A.** Keeping a clean "from this version onward, signed" cutline is easier to document and reduces the change surface. B+C open us up to "does the sdist on PyPI for 1.0.0 need to be re-published or just gain a Release-side bundle?" ambiguity.
 
 ## Proposed implementation waves
 
-Assuming maintainer picks **Q1=A, Q2=A, Q3=B, Q4=B (or hybrid A+B), Q5=C, Q6=A**, the implementation breaks into:
+Based on the locked decisions above — **Q1=A, Q2=A, Q3=B, Q4=B (Path 1), Q5=C, Q6=A** — the implementation breaks into:
 
 ### Wave 1 (PR #a): Sigstore bundle signing on release artifacts
 
@@ -151,7 +139,7 @@ Because the workflow is triggered by a tag push, it cannot re-tag the commit it 
 - **B.1 Pre-release workflow**: separate `.github/workflows/sign-release-tag.yml` fired via `workflow_dispatch` (or on release-PR merge) that signs a planned vX.Y.Z tag BEFORE the maintainer pushes it. Maintainer merges the release PR → workflow dispatch → workflow creates the signed tag → `publish.yml` fires on the tag push as usual. This keeps the existing `publish.yml` untouched.
 - **B.2 Force-resign in publish.yml**: riskier — delete and recreate the tag during the run. Generally discouraged because it re-triggers `publish.yml` in a loop unless carefully guarded.
 
-**Recommendation:** B.1. New workflow, clean boundary with `publish.yml`, no recursive-trigger risk.
+**Decision: B.1.** New workflow, clean boundary with `publish.yml`, no recursive-trigger risk.
 
 **Target diff size:** ~80 lines new workflow (`sign-release-tag.yml`) + ~30 lines secrets-setup documentation in `CONTRIBUTING.md` + ~20 lines rotation runbook.
 
@@ -174,12 +162,12 @@ Release-cut PR (version bump + CHANGELOG 1.0.1 entry). Maintainer tags+pushes, t
 ## Merge-order constraints
 
 - Wave 1 must land before Wave 4 (can't cut 1.0.1 unsigned with the unsigned publish flow).
-- Wave 2 can land in parallel with Wave 1 if hybrid-A.
+- Wave 2 can land in parallel with Wave 1 under the locked Q4 choice (**B / Path 1**) — both are pure additions to `.github/workflows/` with no file overlap.
 - Wave 3 can land in parallel with Waves 1+2 (docs). Arguably easier to write the verify docs AFTER we've seen the actual bundle shapes, so schedule Wave 3 last-or-parallel but not first.
 
 ## Success criteria
 
-- `publish.yml` on main ends with: PyPI upload attested, Release has `.sigstore` bundles as assets, tag verified (by whichever of A/B/hybrid we pick in Q4).
+- `publish.yml` on main ends with: PyPI upload attested, Release has `.sigstore` bundles as assets, tag verifiable via `git verify-tag vX.Y.Z` against the dedicated workflow-only GPG key (Q4=B, Path 1).
 - `docs/VERIFYING.md` documents three concrete verification paths: PyPI attestation, bundle-side, tag-side.
 - `pypi-attestations verify` (or equivalent client) against a PyPI-hosted clickwork 1.0.1 wheel returns success, using the workflow identity on Fulcio. `pip install` itself does not yet auto-verify PyPI attestations (pending upstream work); the success criterion here is "attestations are published and manually verifiable," not "pip blocks unverified installs."
 - A fresh consumer running `sigstore verify identity dist/clickwork-1.0.1-py3-none-any.whl --bundle dist/clickwork-1.0.1-py3-none-any.whl.sigstore --cert-identity <workflow-identity> --cert-oidc-issuer https://token.actions.githubusercontent.com` against the Release-attached bundle gets a pass.

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -24,7 +24,7 @@ Implementation waves below assume these decisions are final.
 
 ## Goal
 
-Add Sigstore keyless signing for clickwork's release artifacts (wheel + sdist), publish the resulting `.sigstore` bundles alongside the artifacts on the GitHub Release, move git-tag signing from the maintainer's local GPG key into the release workflow, and document verification commands in `docs/SECURITY.md` so downstream consumers can prove provenance of every 1.0.x release onward.
+Add Sigstore keyless signing for clickwork's release artifacts (wheel + sdist), publish the resulting `.sigstore` bundles alongside the artifacts on the GitHub Release, move git-tag signing from the maintainer's local GPG key into the release workflow, and document verification guidance with a short summary in `docs/SECURITY.md` and detailed commands in `docs/VERIFYING.md` so downstream consumers can prove provenance of every 1.0.x release onward.
 
 ## Non-goals
 
@@ -135,7 +135,7 @@ Q4 is decided (**B, Path 1** — workflow-only GPG key). Implementation:
 
 **Workflow changes:**
 
-Because the workflow is triggered by a tag push, it cannot re-tag the commit it already ran on. Two options:
+Because the workflow is triggered by a tag push, re-tagging the commit it already ran on from within that same run is awkward and risky. Two options:
 
 - **B.1 Pre-release workflow**: separate `.github/workflows/sign-release-tag.yml` fired via `workflow_dispatch` (or on release-PR merge) that signs a planned vX.Y.Z tag BEFORE the maintainer pushes it. Maintainer merges the release PR → workflow dispatch → workflow creates the signed tag → `publish.yml` fires on the tag push as usual. This keeps the existing `publish.yml` untouched.
 - **B.2 Force-resign in publish.yml**: riskier — delete and recreate the tag during the run. Generally discouraged because it re-triggers `publish.yml` in a loop unless carefully guarded.

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -132,7 +132,7 @@ If Q4=hybrid: just do A for the workflow (cosign blob signing) and keep the CONT
 
 Assuming Q5=C:
 
-- `docs/VERIFYING.md`: concrete commands for (1) verifying the PyPI install via `pip install --require-hashes` or the attestation endpoint, (2) verifying a downloaded wheel/sdist against its `.sigstore` bundle via `sigstore verify identity`, (3) verifying the tag via `git verify-tag` (if Q4=B) or Rekor (if Q4=A or hybrid).
+- `docs/VERIFYING.md`: concrete commands for (1) verifying PyPI attestations for a downloaded wheel/sdist — as of early 2026 this is a manual step via the `pypi-attestations` CLI or `sigstore-python`; pip's own auto-verification of PyPI attestations is not yet GA, so we document the manual flow until it is, (2) verifying a downloaded wheel/sdist against its Release-attached `.sigstore` bundle via `sigstore verify identity --cert-identity <workflow-identity> --cert-oidc-issuer https://token.actions.githubusercontent.com`, (3) verifying the tag via `git verify-tag` (if Q4=B) or the Rekor transparency-log entry (if Q4=A or hybrid).
 - Update `docs/SECURITY.md` "Verifying release artifacts" section to a short summary + link to `VERIFYING.md`.
 - Cross-link from `CONTRIBUTING.md`'s "Cutting a release" runbook.
 
@@ -154,8 +154,8 @@ Release-cut PR (version bump + CHANGELOG 1.0.1 entry). Maintainer tags+pushes, t
 
 - `publish.yml` on main ends with: PyPI upload attested, Release has `.sigstore` bundles as assets, tag verified (by whichever of A/B/hybrid we pick in Q4).
 - `docs/VERIFYING.md` documents three concrete verification paths: PyPI attestation, bundle-side, tag-side.
-- A fresh consumer running `pip install --require-hashes clickwork==1.0.1` gets automatic PyPI-attestation verification.
-- A fresh consumer running `sigstore verify identity dist/clickwork-1.0.1-py3-none-any.whl --bundle dist/clickwork-1.0.1-py3-none-any.whl.sigstore --cert-identity <workflow-identity> --cert-oidc-issuer https://token.actions.githubusercontent.com` gets a pass.
+- `pypi-attestations verify` (or equivalent client) against a PyPI-hosted clickwork 1.0.1 wheel returns success, using the workflow identity on Fulcio. `pip install` itself does not yet auto-verify PyPI attestations (pending upstream work); the success criterion here is "attestations are published and manually verifiable," not "pip blocks unverified installs."
+- A fresh consumer running `sigstore verify identity dist/clickwork-1.0.1-py3-none-any.whl --bundle dist/clickwork-1.0.1-py3-none-any.whl.sigstore --cert-identity <workflow-identity> --cert-oidc-issuer https://token.actions.githubusercontent.com` against the Release-attached bundle gets a pass.
 
 ## Out of scope for this plan
 

--- a/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md
@@ -7,6 +7,21 @@
 [docs/SECURITY.md](../../SECURITY.md) (current unsigned-release caveats + placeholder verify section),
 [.github/workflows/publish.yml](../../../.github/workflows/publish.yml) (current build → create-release → PyPI publish flow)
 
+## Decisions (locked 2026-04-19)
+
+After review on PR #97 the maintainer confirmed:
+
+| # | Question | Decision |
+|---|---|---|
+| Q1 | Which Sigstore action? | **A** — `sigstore/gh-action-sigstore-python` |
+| Q2 | Where in the workflow? | **A** — inside `build`, immediately after `uv build` |
+| Q3 | How are bundles published? | **B** — Release assets + PyPI attestations |
+| Q4 | Tag signing? | **B** (Path 1) — dedicated **workflow-only** GPG key uploaded to the maintainer's GitHub account (for the Verified badge) and stored passwordless as a secret in the `pypi` environment. NOT the maintainer's personal key. Revocable if it ever leaks without touching the maintainer's identity key. |
+| Q5 | Verification docs placement? | **C** — short summary in `docs/SECURITY.md` + detailed `docs/VERIFYING.md` |
+| Q6 | Retroactive signing? | **A** — first signed release is 1.0.1, no retroactive signing of 1.0.0 or 0.2.x |
+
+Implementation waves below assume these decisions are final.
+
 ## Goal
 
 Add Sigstore keyless signing for clickwork's release artifacts (wheel + sdist), publish the resulting `.sigstore` bundles alongside the artifacts on the GitHub Release, move git-tag signing from the maintainer's local GPG key into the release workflow, and document verification commands in `docs/SECURITY.md` so downstream consumers can prove provenance of every 1.0.x release onward.
@@ -120,19 +135,31 @@ Assuming maintainer picks **Q1=A, Q2=A, Q3=B, Q4=B (or hybrid A+B), Q5=C, Q6=A**
 
 ### Wave 2 (PR #b): Workflow-driven tag signing
 
-If Q4=B: generate a GPG key, store public half on GitHub user account (for the Verified badge), store private half as secret in the `pypi` environment. Add a pre-build step that imports the key and re-tags the current ref with `git tag -s`. Subtle issue: the workflow sees the tag that fired it, not a mutable HEAD — retagging during the same workflow run is awkward. Alternative: a separate `tag-signing` workflow that runs on `workflow_dispatch`, signs a future tag in advance.
+Q4 is decided (**B, Path 1** — workflow-only GPG key). Implementation:
 
-If Q4=A: add `cosign-installer` action, `cosign sign-blob` against the tag SHA, upload result as a Rekor entry. Simpler, no secrets to manage, but no Verified badge.
+**Prerequisite (one-time, before wave runs):**
 
-If Q4=hybrid: just do A for the workflow (cosign blob signing) and keep the CONTRIBUTING runbook for the maintainer's local-GPG tag signing. Simplest landing for 1.0.1 while leaving the B path open for later.
+1. Generate a new GPG key specifically for workflow signing. Identity: something like `clickwork-release-bot <release@clickwork.example>` or similar — clearly NOT the maintainer's personal identity. Passwordless.
+2. Upload the public half to the maintainer's GitHub account (`Settings → SSH and GPG keys → New GPG key`) so signatures on tags show the Verified badge against the maintainer's account.
+3. Store the private half as an encrypted secret in the `pypi` environment (we already gate PyPI publish on that environment for approval). Suggest secret names: `RELEASE_GPG_PRIVATE_KEY` (armored private block), `RELEASE_GPG_KEY_ID` (long-form fingerprint for `git config user.signingkey`).
+4. Document the rotation cadence in `CONTRIBUTING.md` — suggested: rotate yearly or on any suspected exposure, with revocation publishing a new `.asc` to both GitHub and the secret.
 
-**Target diff size:** depends on Q4 — hybrid is ~15 lines, full B is ~60 lines + secrets-setup documentation.
+**Workflow changes:**
+
+Because the workflow is triggered by a tag push, it cannot re-tag the commit it already ran on. Two options:
+
+- **B.1 Pre-release workflow**: separate `.github/workflows/sign-release-tag.yml` fired via `workflow_dispatch` (or on release-PR merge) that signs a planned vX.Y.Z tag BEFORE the maintainer pushes it. Maintainer merges the release PR → workflow dispatch → workflow creates the signed tag → `publish.yml` fires on the tag push as usual. This keeps the existing `publish.yml` untouched.
+- **B.2 Force-resign in publish.yml**: riskier — delete and recreate the tag during the run. Generally discouraged because it re-triggers `publish.yml` in a loop unless carefully guarded.
+
+**Recommendation:** B.1. New workflow, clean boundary with `publish.yml`, no recursive-trigger risk.
+
+**Target diff size:** ~80 lines new workflow (`sign-release-tag.yml`) + ~30 lines secrets-setup documentation in `CONTRIBUTING.md` + ~20 lines rotation runbook.
 
 ### Wave 3 (PR #c): Verification docs
 
 Assuming Q5=C:
 
-- `docs/VERIFYING.md`: concrete commands for (1) verifying PyPI attestations for a downloaded wheel/sdist — as of early 2026 this is a manual step via the `pypi-attestations` CLI or `sigstore-python`; pip's own auto-verification of PyPI attestations is not yet GA, so we document the manual flow until it is, (2) verifying a downloaded wheel/sdist against its Release-attached `.sigstore` bundle via `sigstore verify identity --cert-identity <workflow-identity> --cert-oidc-issuer https://token.actions.githubusercontent.com`, (3) verifying the tag via `git verify-tag` (if Q4=B) or the Rekor transparency-log entry (if Q4=A or hybrid).
+- `docs/VERIFYING.md`: concrete commands for (1) verifying PyPI attestations for a downloaded wheel/sdist — as of early 2026 this is a manual step via the `pypi-attestations` CLI or `sigstore-python`; pip's own auto-verification of PyPI attestations is not yet GA, so we document the manual flow until it is, (2) verifying a downloaded wheel/sdist against its Release-attached `.sigstore` bundle via `sigstore verify identity --cert-identity <workflow-identity> --cert-oidc-issuer https://token.actions.githubusercontent.com`, (3) verifying the tag via `git verify-tag vX.Y.Z` (works because Q4=B produces a real GPG-signed tag from the dedicated release-signing key, with the public half on the maintainer's GitHub account).
 - Update `docs/SECURITY.md` "Verifying release artifacts" section to a short summary + link to `VERIFYING.md`.
 - Cross-link from `CONTRIBUTING.md`'s "Cutting a release" runbook.
 


### PR DESCRIPTION
## Summary

Wave-plan PR for issue #61 (Sigstore signing + workflow-driven tag signing, 1.0.x milestone). This is the design doc the maintainer reviews and approves **before** any workflow code changes land.

**Status: decisions locked (2026-04-19)** — see the `## Decisions` table at the top of the spec. Six design questions (Q1–Q6) were surfaced with A/B/C options and answered inline by the maintainer during review. All `## Design questions` blocks are retained as historical context with a `Decision:` pointer per question.

Spec lives at `docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md`.

## Locked decisions

| # | Question | Decision |
|---|---|---|
| Q1 | Which Sigstore action? | **A** — `sigstore/gh-action-sigstore-python` |
| Q2 | Where does signing run? | **A** — inside `build`, immediately after `uv build` |
| Q3 | How are bundles published? | **B** — Release assets + PyPI attestations |
| Q4 | Tag signing? | **B (Path 1)** — dedicated workflow-only GPG key uploaded to the maintainer's GitHub account (Verified badge), stored passwordless in the `pypi` environment. NOT the maintainer's personal key. |
| Q5 | Verification docs? | **C** — short summary in `docs/SECURITY.md` + detailed `docs/VERIFYING.md` |
| Q6 | Retroactive signing? | **A** — first signed release is 1.0.1, no retroactive |

## Proposed implementation waves

- **Wave 1**: Sigstore bundle signing on release artifacts (~30 lines of `publish.yml`)
- **Wave 2**: Workflow-driven tag signing via `sign-release-tag.yml` using a PAT-authenticated push (the `RELEASE_TAG_PUSH_TOKEN` + `RELEASE_GPG_PRIVATE_KEY` + `RELEASE_GPG_FINGERPRINT` secrets). Three mitigations for the GITHUB_TOKEN-push-trigger gotcha are documented inline; M1 (PAT push) is chosen.
- **Wave 3**: Verification docs (~100 lines new + ~10 lines updates)
- **Wave 4**: Cut 1.0.1 to exercise the flow end-to-end

Merge-order constraint: Wave 1 must land before Wave 4. Waves 2+3 can overlap. See full spec.

## How to review

Decisions are locked, so at this point review is sanity-checking the implementation waves + success criteria rather than voting on A/B/C. Flag anything that:

1. Contradicts the locked decisions (prose sweep).
2. Would block implementation (e.g., missing secrets, ambiguous workflow trigger, wrong runbook).
3. Points at a non-goal that should actually be in scope.

Once reviewers sign off, this PR merges. Implementation PRs open after, referencing the answered plan.

## Related

- Closes discussion on #61 (plan layer only; implementation PRs close #61)
- Parent tracker: #45
- Follows the wave-planning pattern from [github-pr-review-loop](https://github.com/qubitrenegade/github-pr-review-loop) skill — plan-first, then implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)