### PR TITLE
feat: tutorials + how-to + plugin-model + llms.txt (#94, part 2/3)

### DIFF
--- a/docs/explanation/plugin-model.md
+++ b/docs/explanation/plugin-model.md
@@ -32,14 +32,25 @@ When `create_cli()` runs, clickwork:
 **Caveat on visibility of these log messages.** Discovery runs
 during `create_cli()` — often at module import time, before the
 host application has configured logging. clickwork attaches a
-`NullHandler` on its own logger at import time, so discovery-time
-records don't produce "no handlers" complaints, but they may also
-not reach any handler the host installs later. For WARNING+
-records, Python's "last resort" stderr fallback usually kicks in;
-INFO records typically do not. If you need collisions / import
-errors surfaced reliably regardless of logging config, pass
-`strict=True` to `create_cli()` — discovery failures become a
-`ClickworkDiscoveryError` raised at CLI construction time.
+`NullHandler` on its own logger at import time, which suppresses
+the "no handlers" complaint AND also disables Python's
+`logging.lastResort` stderr fallback (because `callHandlers` walks
+the logger chain and counts the NullHandler as a handler). The
+practical effect: discovery-time records of any severity go to
+the NullHandler (a no-op) and propagate to root, where they reach
+whatever the host has installed — if anything has been installed
+yet. In default / not-yet-configured setups, they're effectively
+invisible.
+
+Reliable options, in order of preference:
+
+1. Pass `strict=True` to `create_cli()` — discovery failures
+   (duplicate names, broken imports, missing `cli` attr) become a
+   `ClickworkDiscoveryError` raised at CLI construction time,
+   completely independent of logging config.
+2. Configure logging before `create_cli()` — call `setup_logging()`
+   or attach a root handler at module import time, so records
+   emitted during discovery have somewhere to go.
 
 ## Why entry points
 

--- a/docs/explanation/plugin-model.md
+++ b/docs/explanation/plugin-model.md
@@ -25,8 +25,21 @@ When `create_cli()` runs, clickwork:
    the filename stem only if `.name` is unset).
 3. Overlays directory commands on top of entry-point commands, so
    local files win any name collision. clickwork emits an INFO log
-   when a local file shadows an installed command, so stale local
-   files don't silently hide plugin updates.
+   when a local file shadows an installed command — visibility
+   depends on the host's logging setup though (see the caveat
+   below).
+
+**Caveat on visibility of these log messages.** Discovery runs
+during `create_cli()` — often at module import time, before the
+host application has configured logging. clickwork attaches a
+`NullHandler` on its own logger at import time, so discovery-time
+records don't produce "no handlers" complaints, but they may also
+not reach any handler the host installs later. For WARNING+
+records, Python's "last resort" stderr fallback usually kicks in;
+INFO records typically do not. If you need collisions / import
+errors surfaced reliably regardless of logging config, pass
+`strict=True` to `create_cli()` — discovery failures become a
+`ClickworkDiscoveryError` raised at CLI construction time.
 
 ## Why entry points
 

--- a/docs/explanation/plugin-model.md
+++ b/docs/explanation/plugin-model.md
@@ -74,11 +74,19 @@ The practical consequences:
 - When authoring a plugin, choose command names that are unlikely to
   collide with other plugins or with local command-directory files
   in target CLIs.
-- If two plugins (or a plugin and a local file) register the same
-  command name, clickwork keeps the first-loaded one deterministically
-  (directory scan is sorted alphabetically, entry-point iteration
-  order is `importlib.metadata`'s) and emits a warning on the
-  others. Strict mode promotes the duplicate to a hard error.
+- **Within-mechanism duplicates** — two plugins both registering the
+  same entry-point name, or two directory files producing the same
+  Click command name — are a *bug*. clickwork keeps the first-loaded
+  one (directory scan sorted alphabetically; entry points in
+  `importlib.metadata` iteration order), emits a warning, and strict
+  mode promotes the duplicate to a hard error via
+  `ClickworkDiscoveryError`.
+- **Cross-mechanism "collisions"** — a local `commands/foo.py` with
+  the same name as an installed-plugin entry point — are the
+  *intentional* shadowing feature: the local command wins, clickwork
+  logs at INFO (not WARNING) so you can tell the shadowing happened,
+  and strict mode explicitly does NOT treat this as a failure. See
+  the "Why local wins on collision" section below.
 - If you're planning to ship an ecosystem of distinct CLIs in the
   same venv, be deliberate about namespacing command names at
   design time (`projectctl-deploy`, `dataops-deploy`, not just

--- a/docs/explanation/plugin-model.md
+++ b/docs/explanation/plugin-model.md
@@ -1,0 +1,82 @@
+# The plugin model
+
+Why clickwork's plugin system is entry-point based, how discovery
+works conceptually, and how the local-wins rule plays out.
+
+## The shape
+
+Plugins are regular Python packages. They contribute commands by
+declaring an entry point in the `clickwork.commands.<cli-name>` group
+of their `pyproject.toml`.
+
+```toml
+[project.entry-points."clickwork.commands.projectctl"]
+deploy = "projectctl_deploy:cli"
+```
+
+When `create_cli(name="projectctl")` runs, clickwork:
+
+1. Iterates `importlib.metadata.entry_points(group=
+   "clickwork.commands.projectctl")` and loads each entry point's
+   `cli` object.
+2. Reads the local `commands_dir` (when it exists and auto mode is
+   active) and registers every file that exposes a `cli` attribute.
+3. Overlays directory commands on top of entry-point commands, so
+   local files win any name collision. clickwork emits an INFO log
+   when a local file shadows an installed command, so stale local
+   files don't silently hide plugin updates.
+
+## Why entry points
+
+Three alternatives got rejected in the 0.x cycle:
+
+1. **A central registry config file** (e.g. `plugins.toml` listing
+   which packages contribute). Rejected because it's an extra thing
+   to keep in sync on every plugin install, and it turns plugin
+   discovery into "did someone update the config" instead of "did
+   someone install the package."
+2. **Directory scanning** (look at `site-packages/*/plugin.json`).
+   Rejected because it's coupled to filesystem layout — breaks on
+   editable installs, zipped installs, and namespace packages.
+3. **Manual registration** (`@cli.register_plugin(X)` at runtime).
+   Rejected because it requires the main CLI to know about every
+   plugin, defeating the purpose.
+
+Entry points are the Python ecosystem's native plugin mechanism.
+`pip install` registers them; `pip uninstall` unregisters them; the
+tooling already knows how to introspect them
+(`pip show -f <package>` lists entry points).
+
+## Why the `.<cli-name>` suffix
+
+A sibling CLI named `dataops` in the same venv shouldn't see
+`projectctl`'s deploy plugin. Scoping by CLI name keeps plugins
+targeted:
+
+- `clickwork.commands.projectctl` → plugins for the `projectctl` CLI
+- `clickwork.commands.dataops` → plugins for the `dataops` CLI
+
+Without this, every plugin would appear in every CLI, and names
+would collide in minutes.
+
+## Why local wins on collision
+
+Scenario: a plugin you installed six months ago exposes a command
+named `deploy`. You later write a local `commands/deploy.py` because
+your project's deploy story diverged. clickwork picks the local file.
+
+Rationale:
+
+- **Local code is what the project maintainer is actively editing.**
+  A plugin winning would silently shadow work-in-progress.
+- **Plugins are easy to replace; hand-written code is not.** If a
+  plugin's `deploy` no longer fits, `pip uninstall` + `rm` is one
+  command; rewriting a local command to match a plugin's shape is
+  weeks.
+- **The override is visible.** `projectctl deploy --help` shows the
+  local file's docstring, not the plugin's. You can tell by reading
+  the help which one ran.
+
+See [plugins reference](../reference/plugins.md) for the exact
+discovery algorithm, including strict mode behaviour and diagnostic
+hooks.

--- a/docs/explanation/plugin-model.md
+++ b/docs/explanation/plugin-model.md
@@ -6,21 +6,23 @@ works conceptually, and how the local-wins rule plays out.
 ## The shape
 
 Plugins are regular Python packages. They contribute commands by
-declaring an entry point in the `clickwork.commands.<cli-name>` group
-of their `pyproject.toml`.
+declaring an entry point in the `clickwork.commands` group of their
+`pyproject.toml`.
 
 ```toml
-[project.entry-points."clickwork.commands.projectctl"]
+[project.entry-points."clickwork.commands"]
 deploy = "projectctl_deploy:cli"
 ```
 
-When `create_cli(name="projectctl")` runs, clickwork:
+When `create_cli()` runs, clickwork:
 
-1. Iterates `importlib.metadata.entry_points(group=
-   "clickwork.commands.projectctl")` and loads each entry point's
-   `cli` object.
+1. Iterates `importlib.metadata.entry_points(group="clickwork.commands")`
+   and wraps each in a `LazyEntryPointCommand` keyed by the entry-point
+   name (the LHS — `deploy` above).
 2. Reads the local `commands_dir` (when it exists and auto mode is
-   active) and registers every file that exposes a `cli` attribute.
+   active) and registers every file that exposes a `cli` attribute,
+   keyed by the Click command's `.name` attribute (with fallback to
+   the filename stem only if `.name` is unset).
 3. Overlays directory commands on top of entry-point commands, so
    local files win any name collision. clickwork emits an INFO log
    when a local file shadows an installed command, so stale local
@@ -44,20 +46,48 @@ Three alternatives got rejected in the 0.x cycle:
 
 Entry points are the Python ecosystem's native plugin mechanism.
 `pip install` registers them; `pip uninstall` unregisters them; the
-tooling already knows how to introspect them
-(`pip show -f <package>` lists entry points).
+tooling already knows how to introspect them.
 
-## Why the `.<cli-name>` suffix
+To see the entry points a distribution declares, read the
+distribution's `*.dist-info/entry_points.txt` directly, or use the
+programmatic API:
 
-A sibling CLI named `dataops` in the same venv shouldn't see
-`projectctl`'s deploy plugin. Scoping by CLI name keeps plugins
-targeted:
+```python
+import importlib.metadata
+for ep in importlib.metadata.entry_points(group="clickwork.commands"):
+    print(ep.name, "->", ep.value, "from", ep.dist.name)
+```
 
-- `clickwork.commands.projectctl` → plugins for the `projectctl` CLI
-- `clickwork.commands.dataops` → plugins for the `dataops` CLI
+(`pip show -f <package>` lists installed files but does not parse
+entry-point metadata, so it's not the right tool for this question.)
 
-Without this, every plugin would appear in every CLI, and names
-would collide in minutes.
+## No per-CLI scoping today
+
+The entry-point group is `clickwork.commands` — a single global group
+for every clickwork-built CLI. Every CLI running in the same Python
+environment sees every plugin published under this group. There is
+no `.<cli-name>` suffix or other per-CLI scoping in the current
+implementation.
+
+The practical consequences:
+
+- When authoring a plugin, choose command names that are unlikely to
+  collide with other plugins or with local command-directory files
+  in target CLIs.
+- If two plugins (or a plugin and a local file) register the same
+  command name, clickwork keeps the first-loaded one deterministically
+  (directory scan is sorted alphabetically, entry-point iteration
+  order is `importlib.metadata`'s) and emits a warning on the
+  others. Strict mode promotes the duplicate to a hard error.
+- If you're planning to ship an ecosystem of distinct CLIs in the
+  same venv, be deliberate about namespacing command names at
+  design time (`projectctl-deploy`, `dataops-deploy`, not just
+  `deploy`, `deploy`).
+
+Per-CLI scoping is a credible future feature (it'd scope a group
+name like `clickwork.commands.projectctl`), but it's not shipped.
+Don't publish plugins under a scoped group name today — clickwork
+won't read them.
 
 ## Why local wins on collision
 

--- a/docs/how-to/add-a-command.md
+++ b/docs/how-to/add-a-command.md
@@ -12,7 +12,7 @@ attribute that's a Click command:
 import click
 
 
-@click.command()
+@click.command(name="status")
 @click.option("--json", "as_json", is_flag=True,
               help="Emit machine-readable JSON.")
 def cli(as_json: bool) -> None:
@@ -29,8 +29,13 @@ def cli(as_json: bool) -> None:
 uv run python -m <project> --help
 ```
 
-The command shows up, named after the file (underscores become
-hyphens: `status.py` → `status`; `tail_logs.py` → `tail-logs`).
+The command shows up under the name set in `@click.command(name=...)`.
+Without that explicit `name=`, Click derives the command's `.name`
+from the decorated function — which for `def cli(...)` is `cli`.
+clickwork keys registered commands off the Click command's `.name`
+(falling back to the filename stem only when `.name` is unset),
+so always set `name=` explicitly to avoid collisions between files.
+For multi-word commands, use `-` in the name (`@click.command(name="tail-logs")`).
 
 ## Ship it
 

--- a/docs/how-to/add-a-command.md
+++ b/docs/how-to/add-a-command.md
@@ -1,0 +1,65 @@
+# Add a new command
+
+For an existing clickwork project. Three minutes.
+
+## Add the file
+
+In `src/<project>/commands/`, create a new module with a `cli`
+attribute that's a Click command:
+
+```python
+# src/<project>/commands/status.py
+import click
+
+
+@click.command()
+@click.option("--json", "as_json", is_flag=True,
+              help="Emit machine-readable JSON.")
+def cli(as_json: bool) -> None:
+    """Show project status."""
+    if as_json:
+        click.echo('{"status": "ok"}')
+    else:
+        click.echo("ok")
+```
+
+## Verify discovery
+
+```bash
+uv run python -m <project> --help
+```
+
+The command shows up, named after the file (underscores become
+hyphens: `status.py` → `status`; `tail_logs.py` → `tail-logs`).
+
+## Ship it
+
+Add a test (`tests/test_status.py`), commit, push, PR.
+
+```python
+# tests/test_status.py
+from click.testing import CliRunner
+
+from <project>.commands.status import cli
+
+
+def test_status_plain() -> None:
+    result = CliRunner().invoke(cli, [])
+    assert result.exit_code == 0
+    assert result.output.strip() == "ok"
+
+
+def test_status_json() -> None:
+    result = CliRunner().invoke(cli, ["--json"])
+    assert result.exit_code == 0
+    assert '"status": "ok"' in result.output
+```
+
+## Gotchas
+
+- The attribute MUST be named `cli` (not `command`, not `main`).
+- `@click.command()` returns a Click `Command`, not a function you
+  can call directly. Always test via `CliRunner`.
+- If the file imports a missing dependency, discovery fails for that
+  file alone — the other commands still register. Pass `strict=True`
+  to `create_cli()` if you want discovery failures to be fatal.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,21 @@
+# How-To recipes
+
+Task-oriented, self-contained pages. Each one assumes you already know
+what you want to do.
+
+## Start here if you have an existing codebase
+
+- **[Tame an out-of-control script directory](tame-a-script-directory.md)**
+  — you have a pile of bash + Python utility scripts, you want one CLI.
+- **[Migrate from argparse (or plain Click)](migrate-from-argparse.md)**
+  — pattern-by-pattern conversion guide.
+
+## Start here if you already use clickwork
+
+- **[Add a new command](add-a-command.md)** — the short version.
+- **[Write a plugin](write-a-plugin.md)** — when a command should ship
+  on its own release cadence.
+
+If you're not sure which recipe applies, the
+[Practical Walkthrough](../tutorials/walkthrough/index.md) covers the
+happy path end-to-end.

--- a/docs/how-to/migrate-from-argparse.md
+++ b/docs/how-to/migrate-from-argparse.md
@@ -49,12 +49,18 @@ if args.cmd == "greet":
 import click
 
 
-@click.command()
+@click.command(name="greet")
 @click.option("--name", default="world", show_default=True)
 def cli(name: str) -> None:
     """Say hello."""
     click.echo(f"Hello, {name}!")
 ```
+
+`name="greet"` is important: clickwork keys commands off the Click
+command's `.name` attribute, and `@click.command()` without `name=`
+derives it from the function — which here is `cli`. Without
+`name="greet"`, every file doing the `def cli(...)` pattern would
+collide on the name `cli`.
 
 ## Convert a positional
 

--- a/docs/how-to/migrate-from-argparse.md
+++ b/docs/how-to/migrate-from-argparse.md
@@ -1,0 +1,157 @@
+# Migrate from argparse (or plain Click)
+
+Pattern-by-pattern conversion. Start with the structural shape, then
+move individual commands.
+
+## Map the existing CLI
+
+If you have a single-file argparse CLI:
+
+```python
+# old_cli.py
+import argparse
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd")
+
+    greet = sub.add_parser("greet")
+    greet.add_argument("--name", default="world")
+
+    count = sub.add_parser("count")
+    count.add_argument("n", type=int)
+
+    args = ap.parse_args()
+    if args.cmd == "greet":
+        print(f"Hello, {args.name}!")
+    elif args.cmd == "count":
+        for i in range(args.n):
+            print(i)
+```
+
+Each subparser becomes one file under `commands/`.
+
+## Convert a subparser to a clickwork command
+
+**Before** (argparse subparser):
+
+```python
+greet = sub.add_parser("greet")
+greet.add_argument("--name", default="world")
+# ...
+if args.cmd == "greet":
+    print(f"Hello, {args.name}!")
+```
+
+**After** (`commands/greet.py`):
+
+```python
+import click
+
+
+@click.command()
+@click.option("--name", default="world", show_default=True)
+def cli(name: str) -> None:
+    """Say hello."""
+    click.echo(f"Hello, {name}!")
+```
+
+## Convert a positional
+
+**argparse:**
+
+```python
+count.add_argument("n", type=int)
+```
+
+**Click:**
+
+```python
+@click.argument("n", type=int)
+```
+
+## Convert `store_true` / `store_false`
+
+**argparse:**
+
+```python
+ap.add_argument("--verbose", action="store_true")
+ap.add_argument("--no-progress", dest="progress", action="store_false")
+```
+
+**Click:**
+
+```python
+@click.option("--verbose", is_flag=True)
+@click.option("--progress/--no-progress", default=True)
+```
+
+## Convert `choices`
+
+**argparse:**
+
+```python
+ap.add_argument("--env", choices=["dev", "staging", "prod"])
+```
+
+**Click:**
+
+```python
+@click.option("--env", type=click.Choice(["dev", "staging", "prod"]))
+```
+
+## If you're already using Click
+
+If you already have a multi-command Click CLI with manual
+`@cli.group()` / `cli.add_command()` wiring, clickwork's job is to
+replace that plumbing with auto-discovery:
+
+**Before:**
+
+```python
+# cli.py
+import click
+
+from .commands import greet, count
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(greet.cli)
+cli.add_command(count.cli)
+```
+
+**After:**
+
+```python
+from pathlib import Path
+
+from clickwork import create_cli
+
+cli = create_cli(
+    name="<project>",
+    commands_dir=Path(__file__).parent / "commands",
+)
+```
+
+No `add_command` calls. Dropping a new file in `commands/` is the only
+action needed to add a command. `commands_dir` is a `pathlib.Path`;
+`Path(__file__).parent / "commands"` resolves relative to the cli
+module so the command works from any cwd.
+
+## What doesn't translate
+
+- **argparse's `--help` formatting** is different from Click's. You
+  can customise Click's via `@click.command(context_settings=...)`
+  but it won't be identical.
+- **argparse's `parents=` composition** has no direct equivalent. Use
+  Click decorators as shared modules (`from _shared_options import
+  verbose_opt`; then `@verbose_opt` above each command).
+
+## Tests
+
+Click's `CliRunner` replaces `argparse.parse_args()` for tests. No
+need to construct `sys.argv`.

--- a/docs/how-to/tame-a-script-directory.md
+++ b/docs/how-to/tame-a-script-directory.md
@@ -129,9 +129,14 @@ directory.
 
 ## Tips
 
-- Naming: `commands/foo_bar.py` → `projectctl foo-bar`. Use
-  `@click.command(name="...")` only if you need to override the
-  default filename-based name.
+- Naming: set it explicitly with `@click.command(name="foo-bar")`
+  on every command. clickwork keys commands off the Click command's
+  `.name` (with filename fallback only when `.name` is unset), and
+  `@click.command()` without an explicit name derives the name from
+  the decorated function — so the common `def cli(...)` pattern
+  registers as the command `cli` unless you override it. Pick kebab-
+  case names (`foo-bar`, not `foo_bar`) to match standard CLI
+  conventions.
 - Shared helpers go in `src/<project>/_lib.py` (or similar); commands
   import from there. Don't put helper modules in `commands/` — they
   get treated as commands and clickwork will complain.

--- a/docs/how-to/tame-a-script-directory.md
+++ b/docs/how-to/tame-a-script-directory.md
@@ -1,0 +1,133 @@
+# Tame an out-of-control script directory
+
+You have `scripts/` with `cleanup.sh`, `deploy.py`, `oldstuff.py`,
+`thing_v3_final.py`, some of them still work, some don't, and nobody
+remembers what `do_the_thing.sh` does.
+
+The goal: one `projectctl` CLI where each script becomes a discoverable
+subcommand, with `--help` that actually tells you what each one does.
+
+## Step 1 — inventory
+
+List what you have and roughly what each script does:
+
+```bash
+ls scripts/ > /tmp/inventory.txt
+# Manually annotate the file with one-line descriptions.
+```
+
+Drop the scripts you don't need anymore. This is the most valuable
+step and nobody does it.
+
+## Step 2 — scaffold clickwork
+
+```bash
+uv init --package .
+uv add clickwork
+mkdir -p src/<project>/commands
+```
+
+Create `src/<project>/cli.py`:
+
+```python
+from pathlib import Path
+
+from clickwork import create_cli
+
+cli = create_cli(
+    name="<project>",
+    commands_dir=Path(__file__).parent / "commands",
+)
+```
+
+`commands_dir` is typed as `pathlib.Path`. Resolving via
+`Path(__file__).parent` makes the path work from any cwd.
+
+And `src/<project>/__main__.py`:
+
+```python
+from <project>.cli import cli
+
+if __name__ == "__main__":
+    cli()
+```
+
+## Step 3 — convert one script
+
+Pick the simplest script. For a Python one:
+
+**Before** (`scripts/cleanup.py`):
+
+```python
+import sys, os
+
+path = sys.argv[1]
+for f in os.listdir(path):
+    if f.endswith(".tmp"):
+        os.remove(os.path.join(path, f))
+```
+
+**After** (`src/<project>/commands/cleanup.py`):
+
+```python
+from pathlib import Path
+
+import click
+
+
+@click.command()
+@click.argument("path", type=click.Path(path_type=Path, exists=True,
+                                         file_okay=False))
+@click.option("--pattern", default="*.tmp", show_default=True)
+def cli(path: Path, pattern: str) -> None:
+    """Remove matching files from PATH."""
+    for f in path.glob(pattern):
+        f.unlink()
+        click.echo(f"removed {f}")
+```
+
+Benefits: proper `--help`, validated path, the pattern is now
+discoverable, the command prints what it did.
+
+## Step 4 — convert a shell script
+
+Shell scripts become Python commands that shell out. Use clickwork's
+process helpers for correct signal forwarding:
+
+```python
+import click
+
+from clickwork.process import run
+
+
+@click.command(name="do-the-thing")
+def cli() -> None:
+    """What this actually does (write ONE sentence)."""
+    run(["bash", "scripts/do_the_thing.sh"])
+```
+
+`clickwork.process.run()` streams output in real time and raises
+`CliProcessError` on non-zero exit — no `check=` kwarg needed
+(non-zero always raises). If you want the output captured into a
+string instead of streamed, use `clickwork.process.capture()`
+instead of `run()`.
+
+You can keep the original `.sh` file and wrap it, OR rewrite the
+logic in Python. Wrap first, rewrite later if it stays.
+
+## Step 5 — repeat and delete
+
+One command per commit. After each, run `projectctl --help` and verify
+the new command shows up. When `scripts/` is empty, delete the
+directory.
+
+## Tips
+
+- Naming: `commands/foo_bar.py` → `projectctl foo-bar`. Use
+  `@click.command(name="...")` only if you need to override the
+  default filename-based name.
+- Shared helpers go in `src/<project>/_lib.py` (or similar); commands
+  import from there. Don't put helper modules in `commands/` — they
+  get treated as commands and clickwork will complain.
+- Tests: `tests/test_cleanup.py` with `click.testing.CliRunner`
+  gives you command-level coverage without shelling out.

--- a/docs/how-to/tame-a-script-directory.md
+++ b/docs/how-to/tame-a-script-directory.md
@@ -75,7 +75,7 @@ from pathlib import Path
 import click
 
 
-@click.command()
+@click.command(name="cleanup")
 @click.argument("path", type=click.Path(path_type=Path, exists=True,
                                          file_okay=False))
 @click.option("--pattern", default="*.tmp", show_default=True)
@@ -85,6 +85,12 @@ def cli(path: Path, pattern: str) -> None:
         f.unlink()
         click.echo(f"removed {f}")
 ```
+
+**Why `name="cleanup"`:** clickwork keys registered commands off the
+Click command's `.name` attribute. `@click.command()` without `name=`
+derives the name from the decorated function, which here is `cli` —
+so without the explicit `name="cleanup"`, every command file doing
+this pattern would collide on the name `cli`.
 
 Benefits: proper `--help`, validated path, the pattern is now
 discoverable, the command prints what it did.

--- a/docs/how-to/write-a-plugin.md
+++ b/docs/how-to/write-a-plugin.md
@@ -14,17 +14,19 @@ cd my-cli-deploy
 ## Entry point in pyproject.toml
 
 ```toml
-[project.entry-points."clickwork.commands.<target-cli-name>"]
+[project.entry-points."clickwork.commands"]
 deploy = "my_cli_deploy:cli"
 ```
 
 Breakdown:
 
-- `clickwork.commands.<target-cli-name>` — the entry-point group.
-  The `.<target-cli-name>` suffix scopes the plugin to a specific
-  CLI. If your plugin ships commands for `projectctl`, it's
-  `clickwork.commands.projectctl`.
+- `clickwork.commands` — the entry-point group. Every clickwork CLI
+  running in the same Python environment discovers entry points
+  under this single group; there is no per-CLI scoping in the
+  current implementation.
 - `deploy` — the command name as it appears on the command line.
+  Pick names carefully so they don't collide with commands from
+  other plugins or with local `commands/` files in target CLIs.
 - `my_cli_deploy:cli` — the import path of the Click object.
 
 ## Write the command

--- a/docs/how-to/write-a-plugin.md
+++ b/docs/how-to/write-a-plugin.md
@@ -1,0 +1,89 @@
+# Write a plugin
+
+When a command should ship on its own release cadence, publish it as a
+separate package. See also: the [plugin reference](../reference/plugins.md)
+for the full spec.
+
+## Scaffold
+
+```bash
+uv init --package my-cli-deploy  # replace "my-cli" with your target CLI name
+cd my-cli-deploy
+```
+
+## Entry point in pyproject.toml
+
+```toml
+[project.entry-points."clickwork.commands.<target-cli-name>"]
+deploy = "my_cli_deploy:cli"
+```
+
+Breakdown:
+
+- `clickwork.commands.<target-cli-name>` — the entry-point group.
+  The `.<target-cli-name>` suffix scopes the plugin to a specific
+  CLI. If your plugin ships commands for `projectctl`, it's
+  `clickwork.commands.projectctl`.
+- `deploy` — the command name as it appears on the command line.
+- `my_cli_deploy:cli` — the import path of the Click object.
+
+## Write the command
+
+```python
+# src/my_cli_deploy/__init__.py
+import click
+
+
+@click.command()
+@click.option("--env", default="staging", show_default=True)
+def cli(env: str) -> None:
+    """Deploy."""
+    click.echo(f"Deploying to {env}...")
+```
+
+## Install into the target CLI's venv
+
+From the target CLI's directory:
+
+```bash
+uv add --dev ../my-cli-deploy  # editable install during development
+```
+
+## Verify
+
+```bash
+uv run python -m <target-cli> deploy --env production
+```
+
+## Ship
+
+- `uv build` produces the wheel.
+- Upload to PyPI (or a private index).
+- `pip install my-cli-deploy` alongside the target CLI and your
+  command shows up.
+
+## Collision: local wins
+
+If the target CLI has a `commands/deploy.py` file, that wins over the
+plugin's `deploy`. This is by design — hand-maintained local commands
+are never silently overwritten by a plugin install. clickwork emits
+an `INFO` log when the shadowing happens so stale local files don't
+silently hide plugin updates.
+
+## Testing plugins independently
+
+```python
+# tests/test_deploy.py in the plugin repo
+from click.testing import CliRunner
+
+from my_cli_deploy import cli
+
+
+def test_deploy_defaults_to_staging() -> None:
+    result = CliRunner().invoke(cli, [])
+    assert result.exit_code == 0
+    assert "staging" in result.output
+```
+
+No clickwork dependency in the test — plugins are just Click commands
+that clickwork happens to discover.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,16 +22,17 @@ Requires Python 3.11+.
 
 === "New here"
 
-    A guided Quickstart and a multi-page practical Walkthrough are
-    landing in the next docs PR. Until then, start with the
-    [User Guide](reference/guide.md) for a single-page tour.
+    Start with the **[Quickstart](tutorials/quickstart.md)** — install
+    to first working command in about 5 minutes. Then the
+    **[Practical Walkthrough](tutorials/walkthrough/index.md)** takes
+    you through building a realistic small CLI with a local command
+    and an installed plugin.
 
 === "I know what I want to do"
 
-    Task-oriented How-To recipes are landing in the next docs PR. For
-    now, the [User Guide](reference/guide.md) has examples inline and
-    the [Plugin reference](reference/plugins.md) covers plugin
-    authoring.
+    The **[How-To](how-to/index.md)** section has recipes for common
+    tasks — taming an out-of-control script dir, adding a command,
+    writing a plugin, migrating from argparse.
 
 === "I need to look something up"
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,34 @@
+# clickwork
+
+Reusable CLI framework for project automation. clickwork gives you a
+one-file `cli.py` that auto-discovers commands from a local
+directory AND from installed plugins, with type-safe config,
+structured logging, and subprocess helpers that handle signals
+correctly.
+
+## Tutorials
+
+- [Quickstart](https://qubitrenegade.github.io/clickwork/tutorials/quickstart/): Install to first working command, five-minute read.
+- [Practical Walkthrough](https://qubitrenegade.github.io/clickwork/tutorials/walkthrough/): Multi-page guided build of a realistic CLI with a local command and an installed plugin.
+
+## How-To
+
+- [Tame a script directory](https://qubitrenegade.github.io/clickwork/how-to/tame-a-script-directory/): Convert a pile of utility scripts into one clickwork CLI.
+- [Add a command](https://qubitrenegade.github.io/clickwork/how-to/add-a-command/): Short version for existing clickwork projects.
+- [Write a plugin](https://qubitrenegade.github.io/clickwork/how-to/write-a-plugin/): Entry-point-based plugin authoring.
+- [Migrate from argparse](https://qubitrenegade.github.io/clickwork/how-to/migrate-from-argparse/): Pattern-by-pattern conversion.
+
+## Reference
+
+- [User Guide](https://qubitrenegade.github.io/clickwork/reference/guide/): Full reference for `create_cli()`, config, process, logging.
+- [Plugins](https://qubitrenegade.github.io/clickwork/reference/plugins/): Entry-point format and discovery rules.
+- [Security](https://qubitrenegade.github.io/clickwork/reference/security/): Threat model and what clickwork does/doesn't defend against.
+- [Migrating 0.x -> 1.0](https://qubitrenegade.github.io/clickwork/reference/migrating/): Breaking changes across the 0.2 -> 1.0 cycle.
+- [API Reference](https://qubitrenegade.github.io/clickwork/reference/api/): Auto-generated from docstrings.
+- [LLM Reference](https://qubitrenegade.github.io/clickwork/reference/llm-reference/): Compact reference designed for use with coding assistants.
+
+## Explanation
+
+- [Architecture](https://qubitrenegade.github.io/clickwork/explanation/architecture/): High-level design.
+- [API Policy](https://qubitrenegade.github.io/clickwork/explanation/api-policy/): Public API surface and semver promise.
+- [Plugin Model](https://qubitrenegade.github.io/clickwork/explanation/plugin-model/): Why entry points, why local-wins.

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -32,9 +32,10 @@ Work from a parent directory containing a `greet/` subdirectory:
 
 ```bash
 mkdir -p greet/commands
-# Stay in the PARENT directory — don't cd into greet/. The entry-
-# point command below runs the CLI from the parent so Python can
-# import the `greet` package without extra PYTHONPATH juggling.
+# Stay in the PARENT directory — don't cd into greet/. We'll keep
+# cwd fixed so the file paths below (greet/cli.py, greet/commands/
+# hello.py) and the run command in step 3 (python greet/cli.py ...)
+# all agree about where things live.
 ```
 
 Create the entry point `greet/cli.py`:

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -1,0 +1,104 @@
+# Quickstart
+
+Five minutes from `pip install` to your first clickwork command.
+
+## What you'll build
+
+A minimal CLI named `greet` with one command, `greet hello`, that
+takes a `--name` flag.
+
+## Prerequisites
+
+- Python 3.11 or newer
+- A fresh directory to work in
+
+## Step 1 — install
+
+```bash
+pip install clickwork
+```
+
+Verify:
+
+```bash
+python -c "import clickwork; print(clickwork.__version__)"
+```
+
+You should see `1.0.0` (or whatever the latest is).
+
+## Step 2 — create the project layout
+
+```bash
+mkdir -p greet/commands
+cd greet
+```
+
+Then create the entry point `greet/cli.py`:
+
+```python
+from pathlib import Path
+
+from clickwork import create_cli
+
+cli = create_cli(
+    name="greet",
+    commands_dir=Path(__file__).parent / "commands",
+)
+
+if __name__ == "__main__":
+    cli()
+```
+
+`commands_dir` is typed as `pathlib.Path`, not `str` — clickwork's
+discovery calls `.is_dir()` and `.glob()` on it directly. Using
+`Path(__file__).parent / "commands"` makes the path resolve relative
+to the `cli.py` file, so `python -m greet.cli` works from any working
+directory.
+
+And your first command `greet/commands/hello.py`:
+
+```python
+import click
+
+
+@click.command()
+@click.option("--name", default="world", help="Who to greet.")
+def cli(name: str) -> None:
+    """Say hello."""
+    click.echo(f"Hello, {name}!")
+```
+
+## Step 3 — run it
+
+From the `greet/` directory:
+
+```bash
+python -m greet.cli hello --name "clickwork"
+```
+
+Expected:
+
+```
+Hello, clickwork!
+```
+
+You've just written a clickwork CLI.
+
+## What just happened
+
+- `create_cli()` returned a Click `Group` configured to load commands
+  from `greet/commands/`.
+- Each file in that directory that exposes a `cli` attribute becomes
+  a subcommand, named after the file (so `hello.py` becomes
+  `greet hello`).
+- The `--name` option is plain Click — clickwork doesn't get in
+  Click's way.
+
+## Where to next
+
+- **[Practical Walkthrough](walkthrough/index.md)** — build a realistic
+  multi-command CLI with a plugin.
+- **[User Guide](../reference/guide.md)** — the full reference.
+- **[How-To: Tame a script directory](../how-to/tame-a-script-directory.md)**
+  — if you arrived with an existing pile of scripts rather than a
+  blank slate.

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -28,12 +28,16 @@ You should see `1.0.0` (or whatever the latest is).
 
 ## Step 2 — create the project layout
 
+Work from a parent directory containing a `greet/` subdirectory:
+
 ```bash
 mkdir -p greet/commands
-cd greet
+# Stay in the PARENT directory — don't cd into greet/. The entry-
+# point command below runs the CLI from the parent so Python can
+# import the `greet` package without extra PYTHONPATH juggling.
 ```
 
-Then create the entry point `greet/cli.py`:
+Create the entry point `greet/cli.py`:
 
 ```python
 from pathlib import Path
@@ -52,8 +56,7 @@ if __name__ == "__main__":
 `commands_dir` is typed as `pathlib.Path`, not `str` — clickwork's
 discovery calls `.is_dir()` and `.glob()` on it directly. Using
 `Path(__file__).parent / "commands"` makes the path resolve relative
-to the `cli.py` file, so `python -m greet.cli` works from any working
-directory.
+to the `cli.py` file, so the CLI works from any working directory.
 
 And your first command `greet/commands/hello.py`:
 
@@ -78,10 +81,11 @@ same). Setting `name=` explicitly is the safest pattern.
 
 ## Step 3 — run it
 
-From the `greet/` directory:
+From the parent directory of `greet/` (the dir you've been working
+in — don't `cd greet/`):
 
 ```bash
-python -m greet.cli hello --name "clickwork"
+python greet/cli.py hello --name "clickwork"
 ```
 
 Expected:

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -61,12 +61,20 @@ And your first command `greet/commands/hello.py`:
 import click
 
 
-@click.command()
+@click.command(name="hello")
 @click.option("--name", default="world", help="Who to greet.")
 def cli(name: str) -> None:
     """Say hello."""
     click.echo(f"Hello, {name}!")
 ```
+
+**Why `name="hello"`:** clickwork keys each registered command off the
+Click command's `.name` attribute (falling back to the filename only
+if `.name` is unset). When you write `@click.command()` on a function
+called `cli`, Click derives the name as `"cli"` — which means without
+the explicit `name="hello"`, this file would register as a command
+named `cli` (and would collide with any other file that did the
+same). Setting `name=` explicitly is the safest pattern.
 
 ## Step 3 — run it
 
@@ -89,8 +97,11 @@ You've just written a clickwork CLI.
 - `create_cli()` returned a Click `Group` configured to load commands
   from `greet/commands/`.
 - Each file in that directory that exposes a `cli` attribute becomes
-  a subcommand, named after the file (so `hello.py` becomes
-  `greet hello`).
+  a subcommand, using the Click command's own `.name` (falling back
+  to the filename stem only when `.name` is unset). That's why the
+  example uses `@click.command(name="hello")` — without the explicit
+  name, Click would derive it from the decorated function's name
+  (`cli`), and every such file would collide on the name `cli`.
 - The `--name` option is plain Click — clickwork doesn't get in
   Click's way.
 

--- a/docs/tutorials/walkthrough/01-your-first-command.md
+++ b/docs/tutorials/walkthrough/01-your-first-command.md
@@ -1,0 +1,116 @@
+# 1. Your first command
+
+By the end of this page you'll have a working `projectctl tail-logs`
+command and understand how clickwork finds commands on disk.
+
+## Scaffold the project
+
+```bash
+mkdir -p projectctl/commands
+cd projectctl
+uv init --package .
+```
+
+`uv init --package .` gives you a modern `pyproject.toml` and a
+`src/projectctl/` layout. Move the `commands/` dir inside the package:
+
+```bash
+mkdir -p src/projectctl/commands
+rmdir projectctl/commands
+```
+
+## Wire up the CLI
+
+Create `src/projectctl/__main__.py`:
+
+```python
+from projectctl.cli import cli
+
+if __name__ == "__main__":
+    cli()
+```
+
+And `src/projectctl/cli.py`:
+
+```python
+from pathlib import Path
+
+from clickwork import create_cli
+
+cli = create_cli(
+    name="projectctl",
+    commands_dir=Path(__file__).parent / "commands",
+)
+```
+
+`commands_dir` is typed as `pathlib.Path` (discovery calls `.is_dir()`
+and `.glob()` on it). `Path(__file__).parent / "commands"` resolves
+relative to this `cli.py` so the command works regardless of what
+directory you run `python -m projectctl` from.
+
+## Write the first command
+
+Create `src/projectctl/commands/tail_logs.py`:
+
+```python
+from pathlib import Path
+
+import click
+
+
+@click.command(name="tail-logs")
+@click.argument("path", type=click.Path(path_type=Path, exists=True))
+@click.option("-n", "--lines", default=20, show_default=True,
+              help="How many lines from the tail.")
+def cli(path: Path, lines: int) -> None:
+    """Tail a log file."""
+    content = path.read_text().splitlines()
+    for line in content[-lines:]:
+        click.echo(line)
+```
+
+**Note:** the attribute MUST be named `cli` — that's what clickwork's
+discovery looks for. The Click `name=` kwarg controls how the
+subcommand appears on the command line.
+
+## Install the project into the venv
+
+```bash
+uv sync
+```
+
+This creates `.venv/` and installs `projectctl` in editable mode plus
+clickwork.
+
+Add clickwork as a dep if `uv init` didn't:
+
+```bash
+uv add clickwork
+```
+
+## Run it
+
+Create a sample log:
+
+```bash
+printf 'line 1\nline 2\nline 3\nline 4\nline 5\n' > sample.log
+```
+
+Then:
+
+```bash
+uv run python -m projectctl tail-logs sample.log --lines 2
+```
+
+Expected:
+
+```
+line 4
+line 5
+```
+
+## Next
+
+In [Adding a plugin](02-adding-a-plugin.md) you'll add a second
+command, but via a separate installable package rather than another
+file in `commands/`.

--- a/docs/tutorials/walkthrough/01-your-first-command.md
+++ b/docs/tutorials/walkthrough/01-your-first-command.md
@@ -6,17 +6,17 @@ command and understand how clickwork finds commands on disk.
 ## Scaffold the project
 
 ```bash
-mkdir -p projectctl/commands
+mkdir projectctl
 cd projectctl
 uv init --package .
 ```
 
 `uv init --package .` gives you a modern `pyproject.toml` and a
-`src/projectctl/` layout. Move the `commands/` dir inside the package:
+`src/projectctl/` layout. Create the `commands/` directory **inside
+the package** (that's where `commands_dir` will point):
 
 ```bash
 mkdir -p src/projectctl/commands
-rmdir projectctl/commands
 ```
 
 ## Wire up the CLI

--- a/docs/tutorials/walkthrough/02-adding-a-plugin.md
+++ b/docs/tutorials/walkthrough/02-adding-a-plugin.md
@@ -42,13 +42,16 @@ Two things are happening here:
   registered under this group. There is no per-CLI scoping today; if
   you publish a command under this group in a venv that also has a
   sibling CLI, both CLIs see it. Design per-command names carefully
-  to avoid collisions. When you need collisions surfaced reliably,
-  pass `strict=True` to `create_cli()` — clickwork raises
-  `ClickworkDiscoveryError` on duplicates. (Relying on
-  `logger.warning` alone is fragile: clickwork attaches a
-  `NullHandler` at import time and discovery runs during CLI
-  construction, before most hosts have configured logging, so the
-  messages often go unseen.)
+  to avoid collisions. For *same-mechanism* duplicates (two plugins
+  both registering the same command name, or two local files
+  producing the same Click command name), pass `strict=True` to
+  `create_cli()` — clickwork raises `ClickworkDiscoveryError` at CLI
+  construction time. Note `strict=True` does NOT raise when a local
+  `commands/` file shadows an installed plugin: that's an
+  intentional auto-mode feature, not a collision. (And don't rely on
+  `logger.warning` alone: clickwork attaches a `NullHandler` at
+  import and discovery runs during CLI construction, before most
+  hosts have configured logging, so the messages often go unseen.)
 - `deploy = "projectctl_deploy:cli"` says "expose a `deploy` command
   whose Click object lives at `projectctl_deploy.cli`". The command
   name on the command line comes from the entry-point key (`deploy`),

--- a/docs/tutorials/walkthrough/02-adding-a-plugin.md
+++ b/docs/tutorials/walkthrough/02-adding-a-plugin.md
@@ -1,0 +1,116 @@
+# 2. Adding a plugin
+
+Plugins ship separately from the main CLI and contribute commands via
+entry points. By the end of this page you'll have `projectctl-deploy`
+installed and showing up as `projectctl deploy`.
+
+## Why a plugin and not just another `commands/` file
+
+Use a plugin when:
+
+- The command ships on a different release cadence than the main CLI.
+- A separate team owns it.
+- You want it installable standalone (`pip install projectctl-deploy`
+  without installing the whole project).
+
+Use a local `commands/` file when the command is part of this
+project's lifecycle and versioning.
+
+## Scaffold the plugin
+
+From the parent directory (not inside `projectctl/`):
+
+```bash
+uv init --package projectctl-deploy
+cd projectctl-deploy
+```
+
+## Add the clickwork entry point
+
+Edit `projectctl-deploy/pyproject.toml` and add the
+`clickwork.commands` entry-point group:
+
+```toml
+[project.entry-points."clickwork.commands.projectctl"]
+deploy = "projectctl_deploy:cli"
+```
+
+Two things are happening here:
+
+- `clickwork.commands.projectctl` is the entry-point group — the
+  `.projectctl` suffix tells clickwork this plugin contributes
+  commands to the CLI named `projectctl`. Other CLIs (e.g. a sibling
+  `dataops` CLI) have their own suffix and won't see these.
+- `deploy = "projectctl_deploy:cli"` says "expose a `deploy` command
+  whose Click object lives at `projectctl_deploy.cli`".
+
+## Write the command
+
+Create `projectctl-deploy/src/projectctl_deploy/__init__.py`:
+
+```python
+import click
+
+
+@click.command()
+@click.option("--env", default="staging", show_default=True,
+              help="Target environment.")
+@click.option("--dry-run", is_flag=True, default=False,
+              help="Print what would happen without doing it.")
+def cli(env: str, dry_run: bool) -> None:
+    """Deploy the project to <env>."""
+    prefix = "[dry-run] " if dry_run else ""
+    click.echo(f"{prefix}Deploying to {env}...")
+```
+
+## Install the plugin into the main CLI's venv
+
+Back in the `projectctl/` directory:
+
+```bash
+cd ../projectctl
+uv add --dev ../projectctl-deploy  # or drop --dev for a runtime dep
+```
+
+`uv add` with a local path installs in editable mode — edits to the
+plugin reflect immediately.
+
+## Verify discovery
+
+```bash
+uv run python -m projectctl --help
+```
+
+You should see:
+
+```
+Commands:
+  deploy     Deploy the project to <env>.
+  tail-logs  Tail a log file.
+```
+
+And run it:
+
+```bash
+uv run python -m projectctl deploy --env production --dry-run
+```
+
+Expected:
+
+```
+[dry-run] Deploying to production...
+```
+
+## Conflict handling: local wins
+
+If a plugin ships a `tail-logs` command and you have
+`commands/tail_logs.py` locally, the local file wins. Install-time
+collisions never overwrite hand-maintained local commands. clickwork
+emits an `INFO` log when a local file shadows an installed command
+so stale local files don't silently hide plugin updates.
+
+## Next
+
+In [Packaging](03-packaging.md) we'll build both projects as wheels
+and install them in a fresh venv to confirm the setup is
+reproducible.

--- a/docs/tutorials/walkthrough/02-adding-a-plugin.md
+++ b/docs/tutorials/walkthrough/02-adding-a-plugin.md
@@ -31,18 +31,23 @@ Edit `projectctl-deploy/pyproject.toml` and add the
 `clickwork.commands` entry-point group:
 
 ```toml
-[project.entry-points."clickwork.commands.projectctl"]
+[project.entry-points."clickwork.commands"]
 deploy = "projectctl_deploy:cli"
 ```
 
 Two things are happening here:
 
-- `clickwork.commands.projectctl` is the entry-point group — the
-  `.projectctl` suffix tells clickwork this plugin contributes
-  commands to the CLI named `projectctl`. Other CLIs (e.g. a sibling
-  `dataops` CLI) have their own suffix and won't see these.
+- `clickwork.commands` is the entry-point group — every clickwork CLI
+  running in this Python environment will discover entry points
+  registered under this group. There is no per-CLI scoping today; if
+  you publish a command under this group in a venv that also has a
+  sibling CLI, both CLIs see it. Design per-command names carefully
+  to avoid collisions, and watch `logger.warning` output for
+  duplicate-name signals from clickwork's discovery.
 - `deploy = "projectctl_deploy:cli"` says "expose a `deploy` command
-  whose Click object lives at `projectctl_deploy.cli`".
+  whose Click object lives at `projectctl_deploy.cli`". The command
+  name on the command line comes from the entry-point key (`deploy`),
+  not from the Click command's internal `.name`.
 
 ## Write the command
 

--- a/docs/tutorials/walkthrough/02-adding-a-plugin.md
+++ b/docs/tutorials/walkthrough/02-adding-a-plugin.md
@@ -42,8 +42,13 @@ Two things are happening here:
   registered under this group. There is no per-CLI scoping today; if
   you publish a command under this group in a venv that also has a
   sibling CLI, both CLIs see it. Design per-command names carefully
-  to avoid collisions, and watch `logger.warning` output for
-  duplicate-name signals from clickwork's discovery.
+  to avoid collisions. When you need collisions surfaced reliably,
+  pass `strict=True` to `create_cli()` — clickwork raises
+  `ClickworkDiscoveryError` on duplicates. (Relying on
+  `logger.warning` alone is fragile: clickwork attaches a
+  `NullHandler` at import time and discovery runs during CLI
+  construction, before most hosts have configured logging, so the
+  messages often go unseen.)
 - `deploy = "projectctl_deploy:cli"` says "expose a `deploy` command
   whose Click object lives at `projectctl_deploy.cli`". The command
   name on the command line comes from the entry-point key (`deploy`),

--- a/docs/tutorials/walkthrough/03-packaging.md
+++ b/docs/tutorials/walkthrough/03-packaging.md
@@ -1,0 +1,78 @@
+# 3. Packaging
+
+Build `projectctl` and `projectctl-deploy` as wheels, install them
+into a fresh venv, and confirm they work the same way. This is the
+"can I hand this to a teammate?" gate.
+
+## Fill in the metadata
+
+In `projectctl/pyproject.toml`:
+
+```toml
+[project]
+name = "projectctl"
+version = "0.1.0"
+description = "Operate the toy project."
+authors = [{name = "Your Name", email = "you@example.com"}]
+requires-python = ">=3.11"
+dependencies = ["clickwork>=1.0"]
+
+[project.scripts]
+projectctl = "projectctl.__main__:cli"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+```
+
+The `[project.scripts]` entry means `pip install projectctl` puts a
+`projectctl` executable on `$PATH` — no more `python -m projectctl`.
+
+Do the same for `projectctl-deploy/pyproject.toml` (it doesn't need a
+`project.scripts` entry because it's loaded via the plugin entry
+point).
+
+## Build
+
+In each directory:
+
+```bash
+uv build
+```
+
+You'll get `dist/projectctl-0.1.0-py3-none-any.whl` and
+`dist/projectctl-0.1.0.tar.gz` (and similar for the plugin).
+
+## Smoke-test in a fresh venv
+
+```bash
+cd /tmp
+python -m venv smoke
+source smoke/bin/activate
+pip install /path/to/projectctl/dist/projectctl-0.1.0-py3-none-any.whl
+pip install /path/to/projectctl-deploy/dist/projectctl_deploy-0.1.0-py3-none-any.whl
+projectctl --help
+projectctl deploy --env production --dry-run
+deactivate && rm -rf smoke
+```
+
+Both commands appear. Plugin discovery works off the installed wheel's
+entry points, no extra config needed.
+
+## Share with a teammate
+
+- Push both projects to git.
+- Cut a release on each (`uv build` → upload wheel to PyPI or an
+  internal index).
+- Teammate: `pip install projectctl projectctl-deploy`.
+
+That's the full loop: local command → plugin → wheel → installed.
+
+## Next
+
+- **[User Guide](../../reference/guide.md)** — the full reference for
+  `create_cli()` options, config handling, subprocess helpers.
+- **[Plugin reference](../../reference/plugins.md)** — the entry-point
+  format, naming conventions, and discovery rules in full.
+- **[How-To recipes](../../how-to/index.md)** — if you have a specific
+  task in mind.

--- a/docs/tutorials/walkthrough/index.md
+++ b/docs/tutorials/walkthrough/index.md
@@ -1,0 +1,32 @@
+# Practical Walkthrough
+
+A 30-to-60-minute guided build of a realistic clickwork CLI. You'll
+end up with a project that has a local command, an installed plugin
+that contributes a command, and a publishable wheel.
+
+## What you'll build
+
+A CLI named `projectctl` that helps you operate a toy project:
+
+- `projectctl tail-logs` — a local command that tails a log file
+- `projectctl deploy` — a command contributed by an installed plugin
+  `projectctl-deploy`
+
+## Pages
+
+1. **[Your first command](01-your-first-command.md)** — project layout,
+   local command, `create_cli()` + `commands_dir`, running it.
+2. **[Adding a plugin](02-adding-a-plugin.md)** — a separate plugin
+   package that contributes commands via entry points, installed
+   alongside the main CLI.
+3. **[Packaging](03-packaging.md)** — `pyproject.toml` metadata,
+   `uv build`, installing the wheel in a fresh venv, sharing with a
+   teammate.
+
+## Prerequisites
+
+- Completed the [Quickstart](../quickstart.md) OR comfortable with
+  Python packaging basics.
+- `uv` installed (`curl -LsSf https://astral.sh/uv/install.sh | sh`).
+
+Ready? Start with [Your first command](01-your-first-command.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,9 +82,23 @@ plugins:
 
 nav:
   - Home: index.md
+  - Tutorials:
+      - Quickstart: tutorials/quickstart.md
+      - Walkthrough:
+          - tutorials/walkthrough/index.md
+          - Your first command: tutorials/walkthrough/01-your-first-command.md
+          - Adding a plugin: tutorials/walkthrough/02-adding-a-plugin.md
+          - Packaging: tutorials/walkthrough/03-packaging.md
+  - How-To:
+      - how-to/index.md
+      - Tame a script directory: how-to/tame-a-script-directory.md
+      - Add a command: how-to/add-a-command.md
+      - Write a plugin: how-to/write-a-plugin.md
+      - Migrate from argparse: how-to/migrate-from-argparse.md
   - Explanation:
       - Architecture: explanation/architecture.md
       - API Policy: explanation/api-policy.md
+      - Plugin Model: explanation/plugin-model.md
   - Reference:
       - User Guide: reference/guide.md
       - Plugins: reference/plugins.md


### PR DESCRIPTION
## Summary

Part 2 of 3 for the documentation site (#94, per [docs/superpowers/plans/2026-04-19-docs-site-implementation.md](https://github.com/qubitrenegade/clickwork/blob/main/docs/superpowers/plans/2026-04-19-docs-site-implementation.md)).

This PR authors the new teaching content the spec called for.

- **Tutorials:** Quickstart (5-min install-to-first-command) + 3-page Practical Walkthrough (local command → plugin → packaging).
- **How-To:** index + 4 recipes — tame-a-script-directory, add-a-command, write-a-plugin, migrate-from-argparse.
- **Explanation:** Plugin Model page covering why entry points and why local-wins on collision. Documents the actual implemented discovery behavior (single `clickwork.commands` entry-point group, no per-CLI scoping today; entry points loaded first, directory overlay second, cross-mechanism shadowing logged at INFO not WARNING). Flags per-CLI scoping as a credible-but-unshipped future idea.
- **`docs/llms.txt`**: llmstxt.org-format index, served at site root.
- Landing page's three triage blocks now link at the real tutorials / how-to / reference destinations (replacing PR 1's placeholder prose).
- `mkdocs.yml` nav extended to include Tutorials and How-To sections and the new Plugin Model page.

All code samples were authored against the verified clickwork API:
- `commands_dir=Path(__file__).parent / "commands"` (typed `Path | None`, not `str`).
- Command discovery keys off `cli_attr.name` (Click's Command `.name`), which `@click.command()` derives from the decorated function name. Every example uses an explicit `@click.command(name="<target>")` so files with `def cli(...)` patterns don't all collide on the command name `cli`.
- `from clickwork.process import run` (not `clickwork.subprocess` — that module doesn't exist).
- `run([...])` with no `check=`/`capture_output=` kwargs (non-zero always raises; streams by default; `clickwork.process.capture()` is the helper for stream-to-string).
- Plugin entry-point group is `clickwork.commands` (global — no `.<cli-name>` suffix; the earlier draft documented a scoping pattern that doesn't exist in the code).

## Test plan

- [x] `uv run mkdocs build --strict` passes locally (0 warnings, all new links resolve).
- [x] `markdownlint-cli2` passes across 20 content files (0 errors).
- [ ] CI build + deploy succeed on merge to main.
- [ ] Deployed site's nav shows all five Diátaxis sections in order Home → Tutorials → How-To → Explanation → Reference.

Refs #94. Part 2 of 3; #94 stays open until PR 3 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)