### PR TITLE
docs: migrate docs hosting from GitHub Pages to Read the Docs

### DIFF
--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -27,7 +27,19 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress 'docs/**/*.md' README.md
+          # Match the exclusion pattern used in mkdocs.yml (exclude_docs)
+          # and .markdownlint.yaml (ignores): the internal planning /
+          # spec artifacts live under docs/ for proximity to the work
+          # they describe but aren't published on the site and
+          # shouldn't be part of the public link-check's concern.
+          # They reference internal URLs (pre-migration examples, etc)
+          # that would otherwise produce noisy false-positives.
+          args: >-
+            --verbose
+            --no-progress
+            --exclude-path 'docs/superpowers/**'
+            --exclude-path 'docs/plans/**'
+            'docs/**/*.md' README.md
           fail: false
 
       - name: Look for an existing open link-check issue

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -27,17 +27,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          # Exclude the deployed docs URL until the account-level
-          # custom-domain redirect is resolved (currently redirects
-          # qubitrenegade.github.io/clickwork -> qubitrenegade.com/
-          # clickwork which 404s). Remove this --exclude once the
-          # redirect is fixed so the linkcheck actually verifies the
-          # published site's own URL.
-          args: >-
-            --verbose
-            --no-progress
-            --exclude 'https://qubitrenegade\.github\.io/clickwork/'
-            'docs/**/*.md' README.md
+          args: --verbose --no-progress 'docs/**/*.md' README.md
           fail: false
 
       - name: Look for an existing open link-check issue

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,12 @@ on:
       - '.vale/**'
       - 'pyproject.toml'
       - 'uv.lock'
+      # src/** so PRs that only touch the codebase still surface
+      # mkdocstrings / api.md rendering regressions before they hit
+      # RTD on main. Without this, a code-only PR could break the
+      # auto-generated API reference and only get caught in RTD's
+      # post-merge build.
+      - 'src/**'
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,34 +1,24 @@
 name: Docs
 
+# PR-only validation. Read the Docs handles the actual deploy off `main`
+# via its own webhook, so there's no push-trigger / deploy-job here any
+# more — the `.readthedocs.yaml` at the repo root is what drives
+# production builds. This workflow's job is to catch build/lint
+# regressions BEFORE they hit main, so RTD's next main-branch build
+# succeeds.
+
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - '.github/workflows/docs.yml'
-      - '.markdownlint.yaml'
-      - '.vale.ini'
-      - '.vale/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - 'src/**'
   pull_request:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - '.readthedocs.yaml'
       - '.github/workflows/docs.yml'
       - '.markdownlint.yaml'
       - '.vale.ini'
       - '.vale/**'
       - 'pyproject.toml'
       - 'uv.lock'
-
-# src/** is intentionally ONLY in the push trigger (main-branch merges).
-# reference/api.md is auto-generated from src/ via mkdocstrings, so a
-# code-only merge to main must re-deploy to keep the API reference
-# fresh. Leaving src/** out of the PR trigger preserves the "code-only
-# PRs don't burn docs CI" intent.
 
 permissions:
   contents: read
@@ -94,28 +84,3 @@ jobs:
           version: 3.9.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy:
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Set up Python
-        run: |
-          uv python install 3.13
-          uv python pin 3.13
-
-      - name: Install docs deps
-        run: uv sync --frozen --extra docs
-
-      - name: mkdocs gh-deploy
-        run: uv run mkdocs gh-deploy --force

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,22 +7,31 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
+  jobs:
+    # Install uv so we can export the frozen lockfile's resolved
+    # versions into a pip-compatible requirements file. Without this,
+    # RTD's `pip install .[docs]` would re-resolve transitive deps
+    # from scratch, which means RTD builds can drift from CI over
+    # time as upstream mkdocs-material / mkdocstrings / etc. ship
+    # releases. Using the same pinned versions as CI keeps the two
+    # environments aligned.
+    post_create_environment:
+      - python -m pip install uv
+    pre_install:
+      - uv export --frozen --no-dev --extra docs --format requirements-txt --output-file /tmp/rtd-docs-requirements.txt
+      - python -m pip install --requirement /tmp/rtd-docs-requirements.txt
+      # Install clickwork itself (editable) so mkdocstrings can import
+      # the package to pull docstrings. --no-deps because the
+      # requirements file above already locked every transitive.
+      - python -m pip install --no-deps --editable .
 
 # mkdocs (not Sphinx) drives the build. Config lives at the repo root.
 mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: true   # match the --strict behaviour used in CI
 
-# Install clickwork itself (editable) so mkdocstrings can import the
-# package to pull docstrings, plus the `docs` optional-dependencies
-# extra from pyproject.toml (mkdocs-material, mkdocstrings[python],
-# mkdocs-redirects).
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+# Dependencies installed via the jobs above from uv.lock, so skip the
+# python.install block that would otherwise do its own pip install.
 
 # Don't build PDFs or ePubs — mkdocs-material doesn't produce them,
 # and we publish only HTML.

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# Read the Docs build config for clickwork.
+# https://docs.readthedocs.com/platform/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# mkdocs (not Sphinx) drives the build. Config lives at the repo root.
+mkdocs:
+  configuration: mkdocs.yml
+  fail_on_warning: true   # match the --strict behaviour used in CI
+
+# Install clickwork itself (editable) so mkdocstrings can import the
+# package to pull docstrings, plus the `docs` optional-dependencies
+# extra from pyproject.toml (mkdocs-material, mkdocstrings[python],
+# mkdocs-redirects).
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+# Don't build PDFs or ePubs — mkdocs-material doesn't produce them,
+# and we publish only HTML.
+formats: []

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # clickwork
 
-[![PyPI](https://img.shields.io/pypi/v/clickwork.svg)](https://pypi.org/project/clickwork/) [![Python Versions](https://img.shields.io/pypi/pyversions/clickwork.svg)](https://pypi.org/project/clickwork/) [![Docs](https://img.shields.io/badge/docs-qubitrenegade.github.io%2Fclickwork-blue)](https://qubitrenegade.github.io/clickwork/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/qubitrenegade/clickwork/blob/main/LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/clickwork.svg)](https://pypi.org/project/clickwork/) [![Python Versions](https://img.shields.io/pypi/pyversions/clickwork.svg)](https://pypi.org/project/clickwork/) [![Docs](https://img.shields.io/badge/docs-clickwork.readthedocs.io-blue)](https://clickwork.readthedocs.io/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/qubitrenegade/clickwork/blob/main/LICENSE)
 
-**Docs:** <https://qubitrenegade.github.io/clickwork/> — full tutorials, how-to recipes, API reference, and LLM-oriented reference.
+**Docs:** <https://clickwork.readthedocs.io/> — full tutorials, how-to recipes, API reference, and LLM-oriented reference.
 
 Reusable CLI framework for project automation. Build project-specific CLIs
 with plugin discovery, layered config, subprocess helpers, and common
 utilities -- so your commands focus on business logic, not boilerplate.
 
 > **Status:** 1.0 stable. The public API is documented in the
-> [API Policy](https://qubitrenegade.github.io/clickwork/explanation/api-policy/)
+> [API Policy](https://clickwork.readthedocs.io/explanation/api-policy/)
 > and covered by SemVer: breaking changes require a major bump and
 > removals carry a one-minor deprecation runway. All features are
 > driven by real
@@ -17,7 +17,7 @@ utilities -- so your commands focus on business logic, not boilerplate.
 > needs -- no speculative abstractions.
 
 Upgrading from 0.2.x? See the
-[Migrating guide](https://qubitrenegade.github.io/clickwork/reference/migrating/)
+[Migrating guide](https://clickwork.readthedocs.io/reference/migrating/)
 for the complete before/after diff.
 
 ## Installation
@@ -96,54 +96,54 @@ working example with subcommand groups.
 ## Documentation
 
 The full site lives at
-**<https://qubitrenegade.github.io/clickwork/>**. Highlights:
+**<https://clickwork.readthedocs.io/>**. Highlights:
 
 ### Start here
 
-- **[Quickstart](https://qubitrenegade.github.io/clickwork/tutorials/quickstart/)**
+- **[Quickstart](https://clickwork.readthedocs.io/tutorials/quickstart/)**
   -- install to first working command in about 5 minutes.
-- **[Practical Walkthrough](https://qubitrenegade.github.io/clickwork/tutorials/walkthrough/)**
+- **[Practical Walkthrough](https://clickwork.readthedocs.io/tutorials/walkthrough/)**
   -- build a realistic CLI with a local command, an installed plugin,
   and a publishable wheel.
 
 ### Cookbook
 
-- **[How-To recipes](https://qubitrenegade.github.io/clickwork/how-to/)**
+- **[How-To recipes](https://clickwork.readthedocs.io/how-to/)**
   -- tame an out-of-control script directory, add a command, write a
   plugin, migrate from argparse.
 
 ### Reference
 
-- **[User Guide](https://qubitrenegade.github.io/clickwork/reference/guide/)**
+- **[User Guide](https://clickwork.readthedocs.io/reference/guide/)**
   -- Step-by-step tutorial: building a CLI, adding config, using
   subprocess helpers, distributing as a package, testing your
   commands.
-- **[Plugins](https://qubitrenegade.github.io/clickwork/reference/plugins/)**
+- **[Plugins](https://clickwork.readthedocs.io/reference/plugins/)**
   -- 15-minute walkthrough for shipping a pip-installable plugin via
   the `clickwork.commands` entry-point group.
-- **[Security](https://qubitrenegade.github.io/clickwork/reference/security/)**
+- **[Security](https://clickwork.readthedocs.io/reference/security/)**
   -- What clickwork defends against, what it leaves to the CLI
   author, threat model assumptions, and how to report
   vulnerabilities.
-- **[Migrating 0.2.x to 1.0](https://qubitrenegade.github.io/clickwork/reference/migrating/)**
+- **[Migrating 0.2.x to 1.0](https://clickwork.readthedocs.io/reference/migrating/)**
   -- Breaking changes, new opt-in surfaces, and concrete before/after
   diffs for upgraders.
-- **[API Reference](https://qubitrenegade.github.io/clickwork/reference/api/)**
+- **[API Reference](https://clickwork.readthedocs.io/reference/api/)**
   -- Auto-generated from docstrings.
-- **[LLM Reference](https://qubitrenegade.github.io/clickwork/reference/llm-reference/)**
+- **[LLM Reference](https://clickwork.readthedocs.io/reference/llm-reference/)**
   -- Compact, LLM-oriented cheat sheet of the public surface with a
   "Common Footguns" section. Useful whether you're an AI agent
   generating clickwork code or a human skimming for gotchas.
 
 ### Explanation
 
-- **[Architecture](https://qubitrenegade.github.io/clickwork/explanation/architecture/)**
+- **[Architecture](https://clickwork.readthedocs.io/explanation/architecture/)**
   -- Design decisions, module responsibilities, security model, and
   the reasoning behind non-obvious choices.
-- **[API Policy](https://qubitrenegade.github.io/clickwork/explanation/api-policy/)**
+- **[API Policy](https://clickwork.readthedocs.io/explanation/api-policy/)**
   -- The 1.0 public surface: which symbols are covered by SemVer,
   deprecation runway, supported Python and Click ranges.
-- **[Plugin Model](https://qubitrenegade.github.io/clickwork/explanation/plugin-model/)**
+- **[Plugin Model](https://clickwork.readthedocs.io/explanation/plugin-model/)**
   -- Why entry points, why local files win on collision, and how
   discovery actually works.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,27 +8,27 @@ correctly.
 
 ## Tutorials
 
-- [Quickstart](https://qubitrenegade.github.io/clickwork/tutorials/quickstart/): Install to first working command, five-minute read.
-- [Practical Walkthrough](https://qubitrenegade.github.io/clickwork/tutorials/walkthrough/): Multi-page guided build of a realistic CLI with a local command and an installed plugin.
+- [Quickstart](https://clickwork.readthedocs.io/tutorials/quickstart/): Install to first working command, five-minute read.
+- [Practical Walkthrough](https://clickwork.readthedocs.io/tutorials/walkthrough/): Multi-page guided build of a realistic CLI with a local command and an installed plugin.
 
 ## How-To
 
-- [Tame a script directory](https://qubitrenegade.github.io/clickwork/how-to/tame-a-script-directory/): Convert a pile of utility scripts into one clickwork CLI.
-- [Add a command](https://qubitrenegade.github.io/clickwork/how-to/add-a-command/): Short version for existing clickwork projects.
-- [Write a plugin](https://qubitrenegade.github.io/clickwork/how-to/write-a-plugin/): Entry-point-based plugin authoring.
-- [Migrate from argparse](https://qubitrenegade.github.io/clickwork/how-to/migrate-from-argparse/): Pattern-by-pattern conversion.
+- [Tame a script directory](https://clickwork.readthedocs.io/how-to/tame-a-script-directory/): Convert a pile of utility scripts into one clickwork CLI.
+- [Add a command](https://clickwork.readthedocs.io/how-to/add-a-command/): Short version for existing clickwork projects.
+- [Write a plugin](https://clickwork.readthedocs.io/how-to/write-a-plugin/): Entry-point-based plugin authoring.
+- [Migrate from argparse](https://clickwork.readthedocs.io/how-to/migrate-from-argparse/): Pattern-by-pattern conversion.
 
 ## Reference
 
-- [User Guide](https://qubitrenegade.github.io/clickwork/reference/guide/): Full reference for `create_cli()`, config, process, logging.
-- [Plugins](https://qubitrenegade.github.io/clickwork/reference/plugins/): Entry-point format and discovery rules.
-- [Security](https://qubitrenegade.github.io/clickwork/reference/security/): Threat model and what clickwork does/doesn't defend against.
-- [Migrating 0.x -> 1.0](https://qubitrenegade.github.io/clickwork/reference/migrating/): Breaking changes across the 0.2 -> 1.0 cycle.
-- [API Reference](https://qubitrenegade.github.io/clickwork/reference/api/): Auto-generated from docstrings.
-- [LLM Reference](https://qubitrenegade.github.io/clickwork/reference/llm-reference/): Compact reference designed for use with coding assistants.
+- [User Guide](https://clickwork.readthedocs.io/reference/guide/): Full reference for `create_cli()`, config, process, logging.
+- [Plugins](https://clickwork.readthedocs.io/reference/plugins/): Entry-point format and discovery rules.
+- [Security](https://clickwork.readthedocs.io/reference/security/): Threat model and what clickwork does/doesn't defend against.
+- [Migrating 0.x -> 1.0](https://clickwork.readthedocs.io/reference/migrating/): Breaking changes across the 0.2 -> 1.0 cycle.
+- [API Reference](https://clickwork.readthedocs.io/reference/api/): Auto-generated from docstrings.
+- [LLM Reference](https://clickwork.readthedocs.io/reference/llm-reference/): Compact reference designed for use with coding assistants.
 
 ## Explanation
 
-- [Architecture](https://qubitrenegade.github.io/clickwork/explanation/architecture/): High-level design.
-- [API Policy](https://qubitrenegade.github.io/clickwork/explanation/api-policy/): Public API surface and semver promise.
-- [Plugin Model](https://qubitrenegade.github.io/clickwork/explanation/plugin-model/): Why entry points, why local-wins.
+- [Architecture](https://clickwork.readthedocs.io/explanation/architecture/): High-level design.
+- [API Policy](https://clickwork.readthedocs.io/explanation/api-policy/): Public API surface and semver promise.
+- [Plugin Model](https://clickwork.readthedocs.io/explanation/plugin-model/): Why entry points, why local-wins.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: clickwork
-site_url: https://qubitrenegade.github.io/clickwork/
+site_url: https://clickwork.readthedocs.io/
 site_description: Reusable CLI framework for project automation.
 repo_url: https://github.com/qubitrenegade/clickwork
 repo_name: qubitrenegade/clickwork

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Homepage = "https://github.com/qubitrenegade/clickwork"
 Repository = "https://github.com/qubitrenegade/clickwork"
 Issues = "https://github.com/qubitrenegade/clickwork/issues"
 Changelog = "https://github.com/qubitrenegade/clickwork/blob/main/CHANGELOG.md"
-Documentation = "https://github.com/qubitrenegade/clickwork/blob/main/docs/GUIDE.md"
+Documentation = "https://clickwork.readthedocs.io/"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

Migrates docs hosting away from GitHub Pages (blocked by an account-level redirect on qubitrenegade.github.io) to Read the Docs.

### Why RTD

- **Domain authority.** readthedocs.io is a top-tier destination for Python docs; every major Python library lives there (Django, FastAPI, pytest, click, etc.). Inherited ranking signal beats a cold-start domain by a wide margin in the first year.
- **Ecosystem convention.** PyPI's \"Documentation\" link idiomatically points at RTD. Python users muscle-memory-type \`<pkg>.readthedocs.io\`.
- **Free, zero DNS work.** No new domain purchase, no CNAME configuration, no wrestling with account-level Pages custom-domain inheritance.
- **PR previews + versioned docs out of the box.** Versioning is deferred scope for this cycle but available when we want it.

### Changes

- **New** \`.readthedocs.yaml\`: ubuntu-24.04, Python 3.13, \`fail_on_warning: true\` for parity with the \`mkdocs build --strict\` we run in CI. Installs via \`pip install -e .[docs]\` so mkdocstrings can import clickwork for the auto-generated API reference page.
- \`.github/workflows/docs.yml\`: drop the \`deploy\` job and the \`push:\` trigger. Keep \`build\` + markdownlint + Vale as PR-only validation — this stops regressions before they hit main (and before RTD tries to build them). RTD's webhook handles production deploys off \`main\` via \`.readthedocs.yaml\` now.
- \`.github/workflows/docs-linkcheck.yml\`: drop the stale \`--exclude 'https://qubitrenegade.github.io/clickwork/'\` (it was a temporary shield while the old URL was redirecting to a 404; no content references the old URL now).
- \`mkdocs.yml\`: \`site_url\` → \`https://clickwork.readthedocs.io/\`.
- \`docs/llms.txt\`: 15 URL substitutions → readthedocs.io.
- \`README.md\`: badge + 17 in-line doc links → readthedocs.io.
- \`pyproject.toml\`: \`[project.urls].Documentation\` → readthedocs.io (was pointing at pre-site \`docs/GUIDE.md\`; now points at the canonical docs site).

### Not touched in this PR

- **\`gh-pages\` branch left in place.** Once \`clickwork.readthedocs.io\` is confirmed live, a follow-up PR can \`gh api DELETE .../pages\` and drop the branch. Keeping it around for now means anyone with a cached github.io URL still sees the last-deployed content instead of a hard 404.
- **\`mkdocs-redirects\` + GH-native stubs at old doc paths:** preserved. RTD supports the redirects plugin; old bookmarked URLs (\`GUIDE.md\`, \`API_POLICY.md\`, etc.) continue to work on the new host.

### Test plan

- [x] \`uv run mkdocs build --strict\` passes locally.
- [x] All three YAML configs (\`.readthedocs.yaml\`, \`docs.yml\`, \`docs-linkcheck.yml\`) parse cleanly.
- [ ] PR-validation CI (build + markdownlint + Vale) passes.
- [ ] After RTD project is imported (done by maintainer) and this PR merges, RTD's webhook triggers a build against \`main\` and \`https://clickwork.readthedocs.io/\` serves the site.

### Follow-ups

- Close #103 (docs-site DNS redirect tracking issue) — obsolete after this change.
- A later PR can delete the \`gh-pages\` branch and disable GH Pages once RTD is confirmed working in production.

Refs #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)