### PR TITLE
fix: exclude root project from uv export so RTD build works

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,13 @@ build:
     post_create_environment:
       - python -m pip install uv
     pre_install:
-      - uv export --frozen --no-dev --extra docs --format requirements-txt --output-file /tmp/rtd-docs-requirements.txt
+      # --no-emit-project excludes the clickwork package itself from
+      # the requirements file. Without this, uv emits `-e .` as line
+      # 3 of the output, pip auto-enables --require-hashes (because
+      # other lines in the file have hashes), and then refuses the
+      # editable install because you can't hash a directory. Install
+      # clickwork separately in the next step.
+      - uv export --frozen --no-dev --extra docs --no-emit-project --format requirements-txt --output-file /tmp/rtd-docs-requirements.txt
       - python -m pip install --requirement /tmp/rtd-docs-requirements.txt
       # Install clickwork itself (editable) so mkdocstrings can import
       # the package to pull docstrings. --no-deps because the


### PR DESCRIPTION
## Problem

First RTD build after the migration (PR #105) failed:

\`\`\`
ERROR: The editable requirement file:///home/docs/checkouts/readthedocs.org/user_builds/clickwork/checkouts/latest (from -r /tmp/rtd-docs-requirements.txt (line 3)) cannot be installed when requiring hashes, because there is no single file to hash.
\`\`\`

## Root cause

\`uv export --frozen --no-dev --extra docs\` emits \`-e .\` as line 3 of the requirements file to re-install the root project. Every other line carries a \`--hash\` specifier, which auto-activates pip's \`--require-hashes\` mode. \`--require-hashes\` forbids editable installs (a directory can't be hashed to a single digest), so the whole install aborted before any dep landed.

## Fix

Add \`--no-emit-project\` to the \`uv export\` invocation so the root project line is skipped entirely. The editable install of clickwork still happens in the follow-up \`pip install --no-deps --editable .\` step — that was already in the config, it just wasn't being reached because the prior step errored out.

## Verification

Locally:

\`\`\`
\$ uv export --frozen --no-dev --extra docs --no-emit-project --format requirements-txt | head -3
# This file was autogenerated by uv via the following command:
#    uv export --frozen --no-dev --extra docs --no-emit-project --format requirements-txt
babel==2.18.0 \
\`\`\`

No more \`-e .\` line — pip will accept this under \`--require-hashes\`.

## Test plan

- [x] \`uv export --no-emit-project\` verified locally to skip the \`-e .\` line.
- [ ] RTD rebuilds successfully after merge. Site reachable at \`https://clickwork.readthedocs.io/\`.

Unblocks RTD migration per #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)