### PR TITLE
docs: implementation plan for Sigstore Wave 1 (part of #61)

### DIFF
--- a/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
@@ -1,0 +1,203 @@
+# Implementation plan — Sigstore Wave 1 (Sigstore bundle signing on release artifacts)
+
+**Date:** 2026-04-19
+**Milestone:** 1.0.x
+**Parent plan:** [2026-04-19-sigstore-signing-plan.md](2026-04-19-sigstore-signing-plan.md) (locked decisions: Q1=A, Q2=A, Q3=B, Q4=B Path 1, Q5=C, Q6=A)
+**Parent issue:** [#61](https://github.com/qubitrenegade/clickwork/issues/61)
+**Scope:** Wave 1 only — Sigstore bundle signing + PyPI attestations on release artifacts. Waves 2-4 are separate plans/PRs.
+**Relevant files:** [.github/workflows/publish.yml](../../../.github/workflows/publish.yml) (current 3-job pipeline), [.github/workflows/release-smoke.yml](../../../.github/workflows/release-smoke.yml) (existing post-release smoke test pattern)
+
+## Goal
+
+Wire Sigstore keyless signing into the existing release pipeline so that `v1.0.1` ships with `.sigstore` bundles on both the GitHub Release assets AND PyPI's attestation endpoint — without changing what a consumer has to do to `pip install clickwork` or re-architecting the 3-job structure.
+
+## Non-goals (Wave 1)
+
+- Tag signing (that's Wave 2 with the `RELEASE_GPG_FINGERPRINT` + `RELEASE_TAG_PUSH_TOKEN` + `RELEASE_GPG_PRIVATE_KEY` secrets flow).
+- Verification documentation (that's Wave 3).
+- Cutting the actual 1.0.1 release (that's Wave 4).
+- Retroactive signing of 1.0.0 or 0.2.x (locked Q6=A).
+
+## Current state
+
+`.github/workflows/publish.yml` is a 3-job pipeline triggered by `push: tags: v*`:
+
+1. `build` (ubuntu-latest, permissions: `contents: read`, `actions: write`) — checkout → install uv → `uv build` → `actions/upload-artifact@v4` uploads entire `dist/` as `dist` artifact.
+2. `create-release` (needs: build, permissions: `contents: write`, `actions: read`) — downloads `dist` artifact → `softprops/action-gh-release` (pinned SHA `153bb8e0...` for v2) creates the Release and attaches `dist/*.whl` + `dist/*.tar.gz`.
+3. `publish` (needs: create-release, environment: pypi, permissions: `id-token: write`, `actions: read`) — downloads `dist` artifact → `pypa/gh-action-pypi-publish@release/v1` uploads to PyPI via Trusted Publishing.
+
+No signing anywhere. PyPI sees unsigned wheels + sdist; GitHub Release has unsigned assets.
+
+## Scope of this plan
+
+Three concrete changes, one commit per logical change:
+
+1. **`build` job:** grant `id-token: write`, add a Sigstore signing step after `uv build` that signs `dist/*` in place.
+2. **`create-release` job:** extend `files:` glob to include `dist/*.sigstore` so bundles appear as Release assets alongside wheel+sdist.
+3. **`publish` job:** add `attestations: true` to `pypa/gh-action-pypi-publish`.
+
+All three land in a single PR (small, cohesive diff ~30 lines net).
+
+## Design questions
+
+### Q1. Pin `sigstore/gh-action-sigstore-python` by SHA or moving ref?
+
+- **A) Pin by commit SHA with a trailing `# vX.Y.Z` comment** — matches the pattern already used for `softprops/action-gh-release` in this same workflow. Supply-chain hardened; Dependabot can bump.
+- **B) Use the moving `@v3` tag** — shorter, matches the pattern used for `astral-sh/setup-uv@v4` and `pypa/gh-action-pypi-publish@release/v1` in this same workflow. Trusts GitHub's tag immutability (which can be force-pushed by the action author in rare cases).
+- **C) Use `@main`** — pinning to upstream HEAD. Definitively rejected: breaks supply-chain guarantees and would fail a reasonable supply-chain audit.
+
+**Recommendation:** A. The existing workflow is already inconsistent (softprops pinned by SHA, others by moving ref). Pinning this addition by SHA nudges the workflow toward the safer pattern without touching the others in this PR. The tradeoff is one extra Dependabot PR per sigstore-action release, which we want anyway.
+
+**Open question for maintainer:** A (SHA pin), or B (match the other unpinned actions for consistency with current style)?
+
+### Q2. How do we smoke-test Wave 1 before cutting 1.0.1?
+
+The workflow only runs on `push: tags: v*`. We need verification it works before committing to 1.0.1.
+
+- **A) Cut a throwaway prerelease tag like `v1.0.1-rc0`** — runs the full pipeline including Trusted Publishing to PyPI. Test appears on PyPI permanently (can yank but not delete). Exercises everything.
+- **B) Add a `workflow_dispatch` trigger that skips the `publish` job** — dry-run: build → sign → create release → STOP. Validates the signing path without poking PyPI. Release gets deleted after. New workflow conditional increases complexity.
+- **C) Test on a fork with its own PyPI Trusted Publisher** — clean-room, no risk to production. High setup cost and fork drift risk.
+- **D) Just ship it on 1.0.1 and roll forward on failure** — cheapest; yanking a failed 1.0.1 and cutting 1.0.2 is tolerable.
+
+**Recommendation:** A with prerelease flag (so it doesn't advance the "latest" pointer). We already have `prerelease: ${{ contains(github.ref_name, '-') }}` in the workflow. A pre-release RC is a real end-to-end test without compromising 1.0.1 itself; if the RC fails we yank and try again without consumer-visible damage. B is tempting but adding a dry-run trigger is a new surface we'd have to maintain.
+
+**Open question for maintainer:** confirm A (ship an `v1.0.1-rc0` first), or D (skip the RC and fix forward)?
+
+### Q3. PyPI attestation edge cases — wheel-only or wheel + sdist?
+
+`pypa/gh-action-pypi-publish` with `attestations: true` publishes to PyPI's attestation endpoint per [PEP 740](https://peps.python.org/pep-0740/). The question is whether it attests both the wheel AND the sdist, or just the wheel.
+
+- **A) Attest both wheel + sdist** — the action's default in recent versions; covers every artifact PyPI serves.
+- **B) Attest wheel only** — older versions of the action only attested wheels, since many consumers only pull the wheel. Would require explicit config or an older action.
+- **C) Attest neither** — disables `attestations: true`; Wave 1 ships without PyPI attestations (only Release-side bundles). Gives up half of Q3=B's promise.
+
+**Recommendation:** A. The action (recent versions) attests both by default; `.sigstore` bundles for each artifact are published to PyPI's `/simple/` index per PEP 740. Every consumer path (wheel-only install, sdist-only install, or manual tarball) gets attestation coverage.
+
+**Open question for maintainer:** is there a known issue in the sigstore-action ↔ pypa-publish interplay for sdists that you'd want me to hedge around?
+
+## Proposed implementation
+
+### Step 1. `build` job changes
+
+**File:** `.github/workflows/publish.yml`
+**Current:**
+```yaml
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      - name: Set up Python 3.13
+        run: |
+          uv python install 3.13
+          uv python pin 3.13
+      - name: Build package
+        run: uv build
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+```
+
+**Change:**
+1. Add `id-token: write` to `permissions:` (required for OIDC → Fulcio).
+2. Insert a signing step between `Build package` and `Upload distribution artifacts`:
+```yaml
+      - name: Sign artifacts with Sigstore
+        uses: sigstore/gh-action-sigstore-python@<pinned-sha>  # v3.x
+        with:
+          inputs: |
+            dist/*.whl
+            dist/*.tar.gz
+```
+
+The action emits `<artifact>.sigstore` bundle files alongside each input in `dist/`. Because `Upload distribution artifacts` uploads the entire `dist/` directory, no change to that step is needed — the bundles come along for free.
+
+**Permissions final shape:**
+```yaml
+    permissions:
+      contents: read
+      actions: write
+      id-token: write  # NEW: OIDC → Fulcio for keyless signing
+```
+
+### Step 2. `create-release` job changes
+
+**File:** `.github/workflows/publish.yml`
+**Change:** one-line extension to the `files:` glob in the softprops step:
+```yaml
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/*.sigstore  # NEW: Sigstore bundles as Release assets
+```
+
+No permission changes (already has `contents: write`).
+
+### Step 3. `publish` job changes
+
+**File:** `.github/workflows/publish.yml`
+**Change:** add `attestations: true` to the pypa-publish step:
+```yaml
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true  # NEW: PEP 740 attestations via action's OIDC flow
+```
+
+No permission changes (`id-token: write` already present for Trusted Publishing).
+
+## Smoke-test plan
+
+Assuming Q2=A (cut an RC):
+
+1. Merge this PR into `main`.
+2. Locally: `git tag v1.0.1-rc0 && git push origin v1.0.1-rc0` (signed with the maintainer's local GPG key per current runbook; Wave 2 will move this into the workflow).
+3. Watch Actions → verify:
+   - `build` job: Sigstore step completes, `dist/*.sigstore` exists in the uploaded artifact.
+   - `create-release` job: GitHub Release page shows `.whl`, `.tar.gz`, and `.sigstore` files as assets.
+   - `publish` job: PyPI package page for `clickwork 1.0.1rc0` shows "Attestations" section with a `.sigstore` entry per artifact.
+4. Manual verify: `sigstore verify identity dist/clickwork-1.0.1rc0-py3-none-any.whl --bundle dist/clickwork-1.0.1rc0-py3-none-any.whl.sigstore --cert-identity https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1-rc0 --cert-oidc-issuer https://token.actions.githubusercontent.com`
+5. Manual verify: `pypi-attestations verify pypi clickwork==1.0.1rc0`
+6. If all green: yank the RC from PyPI, move to Wave 2 without cutting 1.0.1 yet (Wave 2 is a prereq for Wave 4).
+
+If anything fails, the RC is throwaway — yank on PyPI, delete the GitHub Release + tag, fix, re-cut `rc1`.
+
+## Target diff size
+
+- `publish.yml`: +~10 lines net (one new permission, one new step with 5 lines, one `files:` extension with 1 line, one `with:` option with 1 line).
+- No new files, no changes to `CONTRIBUTING.md` in Wave 1 (documentation is Wave 3).
+
+## Merge-order constraints
+
+- Wave 1 merges independently of Wave 2 (both touch `.github/workflows/` but non-overlapping files).
+- Wave 4 (cut 1.0.1) is gated on Wave 1 merging + the RC smoke-test passing.
+- No dependency on #62 (conda-forge).
+
+## Success criteria
+
+- After this PR merges and an RC tag is pushed: a `pypi-attestations verify` (or equivalent) against the PyPI-hosted RC wheel and sdist returns success, using the workflow identity on Fulcio.
+- `sigstore verify identity --bundle …--cert-identity … --cert-oidc-issuer …` against the GitHub Release-attached `.sigstore` bundle returns success.
+- GitHub Actions for the RC tag shows all three jobs green end-to-end.
+- No regression: `publish.yml` continues to successfully upload unsigned consumers through the normal `pip install clickwork==<older version>` path (i.e., existing releases are unaffected).
+
+## Risks / open
+
+- **Sigstore action breakage mid-flow.** The action could fail (upstream regression, Fulcio outage). Mitigation: workflow fails loudly, release doesn't proceed, we retry. No silent failure mode.
+- **PyPI attestation endpoint returns unexpected shape for sdist.** Q3's concern. Mitigation: the RC exposes this before 1.0.1.
+- **OIDC identity string drift between `refs/tags/v1.0.1-rc0` and `refs/tags/v1.0.1`.** Verifiers need to accept the specific tag form. Mitigation: document the exact identity string in Wave 3's `VERIFYING.md`; downstream verifiers glob on `refs/tags/v*` if needed.
+
+## Out of scope for this plan
+
+- Any code change outside `.github/workflows/publish.yml`.
+- Documentation updates in `CONTRIBUTING.md` or `SECURITY.md` (Wave 3).
+- Tag signing (Wave 2).
+- Release cut (Wave 4).

--- a/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
@@ -5,7 +5,7 @@
 **Parent plan:** [2026-04-19-sigstore-signing-plan.md](2026-04-19-sigstore-signing-plan.md) (locked decisions: Q1=A, Q2=A, Q3=B, Q4=B Path 1, Q5=C, Q6=A)
 **Parent issue:** [#61](https://github.com/qubitrenegade/clickwork/issues/61)
 **Scope:** Wave 1 only — Sigstore bundle signing + PyPI attestations on release artifacts. Waves 2-4 are separate plans/PRs.
-**Relevant files:** [.github/workflows/publish.yml](../../../.github/workflows/publish.yml) (current 3-job pipeline), [.github/workflows/release-smoke.yml](../../../.github/workflows/release-smoke.yml) (existing post-release smoke test pattern)
+**Relevant files:** [.github/workflows/publish.yml](../../../.github/workflows/publish.yml) (current 3-job pipeline), [.github/workflows/release-smoke.yml](../../../.github/workflows/release-smoke.yml) (existing release packaging smoke test pattern — triggered on push/PR/dispatch, not on release)
 
 ## Goal
 
@@ -176,6 +176,8 @@ If anything fails, the RC is throwaway — yank on PyPI, delete the GitHub Relea
 
 - `publish.yml`: +~10 lines net (one new permission, one new step with 5 lines, one `files:` extension with 1 line, one `with:` option with 1 line).
 - No new files, no changes to `CONTRIBUTING.md` in Wave 1 (documentation is Wave 3).
+
+> Note on divergence from parent plan: the parent plan (`2026-04-19-sigstore-signing-plan.md`) estimated "~30 lines of `publish.yml` + workflow smoke-test verification" for Wave 1. This implementation plan refines that estimate by separating the code diff (~10 lines in `publish.yml`) from the smoke-test ritual (a runbook-level procedure in the "Smoke-test plan" section above, executed against an RC tag, not committed code). The parent's ~30-line figure bundled both; this plan splits them so the implementation-PR diff stays crisp and the smoke-test is a release-cutting activity, not code review surface.
 
 ## Merge-order constraints
 

--- a/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
@@ -36,7 +36,7 @@ Three concrete changes, one commit per logical change:
 2. **`create-release` job:** extend `files:` glob to include `dist/*.sigstore` so bundles appear as Release assets alongside wheel+sdist.
 3. **`publish` job:** add `attestations: true` to `pypa/gh-action-pypi-publish`.
 
-All three land in a single PR (small, cohesive diff ~30 lines net).
+All three land in a single PR (small, cohesive diff ~10 lines net — see "Target diff size" below).
 
 ## Design questions
 
@@ -159,17 +159,18 @@ No permission changes (`id-token: write` already present for Trusted Publishing)
 
 Assuming Q2=A (cut an RC):
 
-1. Merge this PR into `main`.
-2. Locally: `git tag v1.0.1-rc0 && git push origin v1.0.1-rc0` (signed with the maintainer's local GPG key per current runbook; Wave 2 will move this into the workflow).
-3. Watch Actions → verify:
-   - `build` job: Sigstore step completes, `dist/*.sigstore` exists in the uploaded artifact.
-   - `create-release` job: GitHub Release page shows `.whl`, `.tar.gz`, and `.sigstore` files as assets.
+1. Merge this PR's implementation into `main`.
+2. Bump the package version on `main` to the PEP 440 prerelease `1.0.1rc0` in `pyproject.toml`, commit, push that commit to `main` first. (`uv build` reads the version from `pyproject.toml`; tagging alone won't produce publishable `1.0.1rc0` artifacts — and PyPI rejects re-uploads of an existing version, so a tag without a version bump would upload-fail.)
+3. Locally: `git tag -s v1.0.1-rc0 -m "v1.0.1-rc0" && git push origin v1.0.1-rc0` (signed annotated tag per current `CONTRIBUTING.md` runbook; Wave 2 will move this into the workflow).
+4. Watch Actions → verify:
+   - `build` job: Sigstore step completes, `dist/*.sigstore` exists in the uploaded artifact, built filenames carry `1.0.1rc0`.
+   - `create-release` job: GitHub Release page shows `1.0.1rc0` `.whl`, `.tar.gz`, and `.sigstore` files as assets.
    - `publish` job: PyPI package page for `clickwork 1.0.1rc0` shows "Attestations" section with a `.sigstore` entry per artifact.
-4. Manual verify: `sigstore verify identity dist/clickwork-1.0.1rc0-py3-none-any.whl --bundle dist/clickwork-1.0.1rc0-py3-none-any.whl.sigstore --cert-identity https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1-rc0 --cert-oidc-issuer https://token.actions.githubusercontent.com`
-5. Manual verify: `pypi-attestations verify pypi clickwork==1.0.1rc0`
-6. If all green: yank the RC from PyPI, move to Wave 2 without cutting 1.0.1 yet (Wave 2 is a prereq for Wave 4).
+5. Manual verify: `sigstore verify identity dist/clickwork-1.0.1rc0-py3-none-any.whl --bundle dist/clickwork-1.0.1rc0-py3-none-any.whl.sigstore --cert-identity https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1-rc0 --cert-oidc-issuer https://token.actions.githubusercontent.com`
+6. Manual verify: `pypi-attestations verify pypi clickwork==1.0.1rc0`
+7. If all green: yank the RC from PyPI, bump `pyproject.toml` back to `1.0.1.dev0` (or similar non-release marker), move to Wave 2 without cutting 1.0.1 yet (Wave 2 is a prereq for Wave 4).
 
-If anything fails, the RC is throwaway — yank on PyPI, delete the GitHub Release + tag, fix, re-cut `rc1`.
+If anything fails, the RC is throwaway — yank on PyPI, delete the GitHub Release + tag, fix, bump `pyproject.toml` to `1.0.1rc1` before re-cutting `rc1` (new prerelease version to avoid PyPI's no-reupload rule).
 
 ## Target diff size
 

--- a/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
@@ -13,8 +13,8 @@ After review on this PR the maintainer confirmed:
 
 | # | Question | Decision |
 |---|---|---|
-| Q1 | Pin the Sigstore action? | **A** — pin `sigstore/gh-action-sigstore-python` by commit SHA with a trailing `# vX.Y.Z` comment (matches the `softprops/action-gh-release` pattern already in `publish.yml`; Dependabot can bump) |
-| Q2 | Pre-1.0.1 smoke test? | **A** — cut a throwaway `v1.0.1-rc0` prerelease tag, exercise the full pipeline end-to-end (build → sign → Release → PyPI). `prerelease: true` is already wired up; yank + re-cut `rc1` if anything fails |
+| Q1 | Pin the Sigstore action? | **A** — pin `sigstore/gh-action-sigstore-python` by commit SHA with a trailing `# vX.Y.Z` comment (matches the `softprops/action-gh-release` pattern already in `publish.yml`; Dependabot, once configured, can bump — see Out-of-scope below) |
+| Q2 | Pre-1.0.1 smoke test? | **A** — cut a throwaway `v1.0.1-rc0` prerelease tag, exercise the full pipeline end-to-end (build → sign → Release → PyPI). Prerelease handling is already wired up for hyphenated tags via `prerelease: ${{ contains(github.ref_name, '-') }}`; yank + re-cut `rc1` if anything fails |
 | Q3 | PyPI attestation scope? | **A** — attest both wheel and sdist (modern sigstore-action + pypa-publish default); covers every consumer path |
 
 Implementation below assumes these decisions are final.
@@ -60,7 +60,7 @@ The A/B/C alternatives below were the options considered; each has a **Decision:
 - **B) Use the moving `@v3` tag** — shorter, matches the pattern used for `astral-sh/setup-uv@v4` and `pypa/gh-action-pypi-publish@release/v1` in this same workflow. Trusts GitHub's tag immutability (which can be force-pushed by the action author in rare cases).
 - **C) Use `@main`** — pinning to upstream HEAD. Definitively rejected: breaks supply-chain guarantees and would fail a reasonable supply-chain audit.
 
-**Decision: A.** The existing workflow is already inconsistent (softprops pinned by SHA, others by moving ref). Pinning this addition by SHA nudges the workflow toward the safer pattern without touching the others in this PR. The tradeoff is one extra Dependabot PR per sigstore-action release, which we want anyway.
+**Decision: A.** The existing workflow is already inconsistent (softprops pinned by SHA, others by moving ref). Pinning this addition by SHA nudges the workflow toward the safer pattern without touching the others in this PR. The tradeoff is one manual SHA update per sigstore-action release — until Dependabot is configured on this repo (no `.github/dependabot.yml` currently), updates are manual; once added, Dependabot would automate the bumps.
 
 ### Q2. How do we smoke-test Wave 1 before cutting 1.0.1?
 
@@ -212,3 +212,4 @@ If anything fails, the RC is throwaway — yank on PyPI, delete the GitHub Relea
 - Documentation updates in `CONTRIBUTING.md` or `SECURITY.md` (Wave 3).
 - Tag signing (Wave 2).
 - Release cut (Wave 4).
+- Adding `.github/dependabot.yml` so SHA-pinned actions are auto-bumped. Currently no Dependabot config on this repo; until added, the SHA pin introduced here is a manual-update surface. Worth filing a follow-up issue but not blocking Wave 1.

--- a/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
@@ -61,7 +61,7 @@ The workflow only runs on `push: tags: v*`. We need verification it works before
 
 **Recommendation:** A with prerelease flag (so it doesn't advance the "latest" pointer). We already have `prerelease: ${{ contains(github.ref_name, '-') }}` in the workflow. A pre-release RC is a real end-to-end test without compromising 1.0.1 itself; if the RC fails we yank and try again without consumer-visible damage. B is tempting but adding a dry-run trigger is a new surface we'd have to maintain.
 
-**Open question for maintainer:** confirm A (ship an `v1.0.1-rc0` first), or D (skip the RC and fix forward)?
+**Open question for maintainer:** confirm A (ship a `v1.0.1-rc0` first), or D (skip the RC and fix forward)?
 
 ### Q3. PyPI attestation edge cases — wheel-only or wheel + sdist?
 
@@ -190,7 +190,7 @@ If anything fails, the RC is throwaway — yank on PyPI, delete the GitHub Relea
 - After this PR merges and an RC tag is pushed: a `pypi-attestations verify` (or equivalent) against the PyPI-hosted RC wheel and sdist returns success, using the workflow identity on Fulcio.
 - `sigstore verify identity --bundle …--cert-identity … --cert-oidc-issuer …` against the GitHub Release-attached `.sigstore` bundle returns success.
 - GitHub Actions for the RC tag shows all three jobs green end-to-end.
-- No regression: `publish.yml` continues to successfully upload unsigned consumers through the normal `pip install clickwork==<older version>` path (i.e., existing releases are unaffected).
+- No regression: `publish.yml` still publishes releases successfully with the added signing/attestation steps, and the normal `pip install clickwork==<older version>` flow for older unsigned releases remains unchanged.
 
 ## Risks / open
 

--- a/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
@@ -195,7 +195,7 @@ If anything fails, the RC is throwaway — yank on PyPI, delete the GitHub Relea
 
 ## Success criteria
 
-- After this PR merges and an RC tag is pushed: a `pypi-attestations verify` (or equivalent) against the PyPI-hosted RC wheel and sdist returns success, using the workflow identity on Fulcio.
+- After the Wave 1 implementation PR merges and an RC tag is pushed: a `pypi-attestations verify` (or equivalent) against the PyPI-hosted RC wheel and sdist returns success, using the workflow identity on Fulcio.
 - `sigstore verify identity --bundle …--cert-identity … --cert-oidc-issuer …` against the GitHub Release-attached `.sigstore` bundle returns success.
 - GitHub Actions for the RC tag shows all three jobs green end-to-end.
 - No regression: `publish.yml` still publishes releases successfully with the added signing/attestation steps, and the normal `pip install clickwork==<older version>` flow for older unsigned releases remains unchanged.

--- a/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md
@@ -7,6 +7,18 @@
 **Scope:** Wave 1 only — Sigstore bundle signing + PyPI attestations on release artifacts. Waves 2-4 are separate plans/PRs.
 **Relevant files:** [.github/workflows/publish.yml](../../../.github/workflows/publish.yml) (current 3-job pipeline), [.github/workflows/release-smoke.yml](../../../.github/workflows/release-smoke.yml) (existing release packaging smoke test pattern — triggered on push/PR/dispatch, not on release)
 
+## Decisions (locked 2026-04-20)
+
+After review on this PR the maintainer confirmed:
+
+| # | Question | Decision |
+|---|---|---|
+| Q1 | Pin the Sigstore action? | **A** — pin `sigstore/gh-action-sigstore-python` by commit SHA with a trailing `# vX.Y.Z` comment (matches the `softprops/action-gh-release` pattern already in `publish.yml`; Dependabot can bump) |
+| Q2 | Pre-1.0.1 smoke test? | **A** — cut a throwaway `v1.0.1-rc0` prerelease tag, exercise the full pipeline end-to-end (build → sign → Release → PyPI). `prerelease: true` is already wired up; yank + re-cut `rc1` if anything fails |
+| Q3 | PyPI attestation scope? | **A** — attest both wheel and sdist (modern sigstore-action + pypa-publish default); covers every consumer path |
+
+Implementation below assumes these decisions are final.
+
 ## Goal
 
 Wire Sigstore keyless signing into the existing release pipeline so that `v1.0.1` ships with `.sigstore` bundles on both the GitHub Release assets AND PyPI's attestation endpoint — without changing what a consumer has to do to `pip install clickwork` or re-architecting the 3-job structure.
@@ -38,7 +50,9 @@ Three concrete changes, one commit per logical change:
 
 All three land in a single PR (small, cohesive diff ~10 lines net — see "Target diff size" below).
 
-## Design questions
+## Design questions (resolved — kept for historical context)
+
+The A/B/C alternatives below were the options considered; each has a **Decision:** line pointing at the locked choice from the table above. Left in the doc so future readers can see what was weighed and why.
 
 ### Q1. Pin `sigstore/gh-action-sigstore-python` by SHA or moving ref?
 
@@ -46,9 +60,7 @@ All three land in a single PR (small, cohesive diff ~10 lines net — see "Targe
 - **B) Use the moving `@v3` tag** — shorter, matches the pattern used for `astral-sh/setup-uv@v4` and `pypa/gh-action-pypi-publish@release/v1` in this same workflow. Trusts GitHub's tag immutability (which can be force-pushed by the action author in rare cases).
 - **C) Use `@main`** — pinning to upstream HEAD. Definitively rejected: breaks supply-chain guarantees and would fail a reasonable supply-chain audit.
 
-**Recommendation:** A. The existing workflow is already inconsistent (softprops pinned by SHA, others by moving ref). Pinning this addition by SHA nudges the workflow toward the safer pattern without touching the others in this PR. The tradeoff is one extra Dependabot PR per sigstore-action release, which we want anyway.
-
-**Open question for maintainer:** A (SHA pin), or B (match the other unpinned actions for consistency with current style)?
+**Decision: A.** The existing workflow is already inconsistent (softprops pinned by SHA, others by moving ref). Pinning this addition by SHA nudges the workflow toward the safer pattern without touching the others in this PR. The tradeoff is one extra Dependabot PR per sigstore-action release, which we want anyway.
 
 ### Q2. How do we smoke-test Wave 1 before cutting 1.0.1?
 
@@ -59,9 +71,7 @@ The workflow only runs on `push: tags: v*`. We need verification it works before
 - **C) Test on a fork with its own PyPI Trusted Publisher** — clean-room, no risk to production. High setup cost and fork drift risk.
 - **D) Just ship it on 1.0.1 and roll forward on failure** — cheapest; yanking a failed 1.0.1 and cutting 1.0.2 is tolerable.
 
-**Recommendation:** A with prerelease flag (so it doesn't advance the "latest" pointer). We already have `prerelease: ${{ contains(github.ref_name, '-') }}` in the workflow. A pre-release RC is a real end-to-end test without compromising 1.0.1 itself; if the RC fails we yank and try again without consumer-visible damage. B is tempting but adding a dry-run trigger is a new surface we'd have to maintain.
-
-**Open question for maintainer:** confirm A (ship a `v1.0.1-rc0` first), or D (skip the RC and fix forward)?
+**Decision: A.** With prerelease flag (so it doesn't advance the "latest" pointer). We already have `prerelease: ${{ contains(github.ref_name, '-') }}` in the workflow. A pre-release RC is a real end-to-end test without compromising 1.0.1 itself; if the RC fails we yank and try again without consumer-visible damage. B is tempting but adding a dry-run trigger is a new surface we'd have to maintain.
 
 ### Q3. PyPI attestation edge cases — wheel-only or wheel + sdist?
 
@@ -71,9 +81,7 @@ The workflow only runs on `push: tags: v*`. We need verification it works before
 - **B) Attest wheel only** — older versions of the action only attested wheels, since many consumers only pull the wheel. Would require explicit config or an older action.
 - **C) Attest neither** — disables `attestations: true`; Wave 1 ships without PyPI attestations (only Release-side bundles). Gives up half of Q3=B's promise.
 
-**Recommendation:** A. The action (recent versions) attests both by default; `.sigstore` bundles for each artifact are published to PyPI's `/simple/` index per PEP 740. Every consumer path (wheel-only install, sdist-only install, or manual tarball) gets attestation coverage.
-
-**Open question for maintainer:** is there a known issue in the sigstore-action ↔ pypa-publish interplay for sdists that you'd want me to hedge around?
+**Decision: A.** The action (recent versions) attests both by default; `.sigstore` bundles for each artifact are published to PyPI's `/simple/` index per PEP 740. Every consumer path (wheel-only install, sdist-only install, or manual tarball) gets attestation coverage.
 
 ## Proposed implementation
 


### PR DESCRIPTION
## Summary

Implementation plan for **Wave 1** of the Sigstore signing work (parent plan: #97, merged). Scope: Sigstore bundle signing on release artifacts + PyPI attestations. Three concrete changes to `publish.yml`, ~10 lines net.

**Status: decisions locked (2026-04-20)** — see the `## Decisions` table at the top of the spec. Three design questions (Q1–Q3) were surfaced with A/B options and answered during review. All per-question blocks are retained as historical context with a `Decision:` pointer per question.

Spec: `docs/superpowers/specs/2026-04-19-sigstore-wave1-impl-plan.md`.

## Locked decisions

| # | Question | Decision |
|---|---|---|
| Q1 | Pin `sigstore/gh-action-sigstore-python`? | **A** — SHA pin with `# vX.Y.Z` comment (matches softprops pattern) |
| Q2 | Pre-1.0.1 smoke test? | **A** — cut `v1.0.1-rc0`, exercise full pipeline, yank + rc1 if broken |
| Q3 | PyPI attestation scope? | **A** — wheel + sdist (modern action default) |

## Proposed changes (Wave 1 scope only)

Three logical changes in one implementation PR:

1. **`build` job**: grant `id-token: write`, add SHA-pinned `sigstore/gh-action-sigstore-python` step after `uv build`.
2. **`create-release` job**: extend `files:` glob to include `dist/*.sigstore`.
3. **`publish` job`**: add `attestations: true` to `pypa/gh-action-pypi-publish`.

## Smoke test plan (locked Q2=A)

After implementation PR merges:

1. Bump `pyproject.toml` version to `1.0.1rc0`, commit, push to main.
2. `git tag -s v1.0.1-rc0 -m "v1.0.1-rc0" && git push origin v1.0.1-rc0`.
3. Watch full pipeline: build → sign → Release → PyPI attestations.
4. Manual verify both paths (`sigstore verify identity` against Release bundle, `pypi-attestations verify` against PyPI).
5. Yank RC from PyPI on success; bump `pyproject.toml` to dev marker; move to Wave 2.

If the RC fails, yank + delete tag + fix + bump to `1.0.1rc1` before retry.

## How to review

Decisions are locked. Review focuses on sanity-checking the implementation steps and success criteria. Once reviewers sign off, this PR merges and a follow-up implementation PR opens with the actual `publish.yml` changes.

## Related

- Parent plan: #97 (merged)
- Parent issue: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)