### PR TITLE
feat(release): Sigstore signing + PyPI attestations (Wave 1, part of #61)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,9 +31,14 @@ jobs:
     # zero rights by default, so we must re-grant here or
     # actions/upload-artifact@v4 will 403 and later jobs have nothing
     # to download.
+    #
+    # id-token: write is required for Sigstore keyless signing: the
+    # sigstore action exchanges the job's OIDC token for an ephemeral
+    # signing certificate from Fulcio. No long-lived keys involved.
     permissions:
       contents: read
       actions: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +62,20 @@ jobs:
 
       - name: Build package
         run: uv build
+
+      # Sigstore keyless signing. The action emits a `.sigstore` bundle
+      # file alongside each input, so with `inputs:` pointing at wheel +
+      # sdist we get two bundles written into dist/. The subsequent
+      # upload-artifact step uploads the whole dist/ directory, so the
+      # bundles flow to create-release and publish jobs without any
+      # additional plumbing. SHA-pinned (v3.3.0) for supply-chain
+      # discipline; Dependabot will need to be enabled to auto-bump.
+      - name: Sign artifacts with Sigstore
+        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0
+        with:
+          inputs: |
+            dist/*.whl
+            dist/*.tar.gz
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v4
@@ -108,6 +127,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+            dist/*.sigstore
 
   publish:
     name: Publish to PyPI
@@ -137,3 +157,10 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Publish PEP 740 attestations alongside the wheel + sdist.
+          # The action uses the same id-token OIDC exchange Trusted
+          # Publishing already relies on, so no additional secrets or
+          # permissions are needed. Covers both wheel and sdist by
+          # default in recent versions of the action.
+          attestations: true


### PR DESCRIPTION
## Summary

Wave 1 of the Sigstore signing work for #61. Three additions to `publish.yml` implementing the locked decisions from the parent plan (#97) + the implementation plan (#107):

1. **`build` job** — grant `id-token: write`, sign `dist/*.whl` and `dist/*.tar.gz` with SHA-pinned `sigstore/gh-action-sigstore-python@04cffa1` (v3.3.0) after `uv build`. Bundles land in `dist/` alongside artifacts.
2. **`create-release` job** — extend `files:` glob to include `dist/*.sigstore` so bundles appear as Release assets.
3. **`publish` job** — add `attestations: true` to `pypa/gh-action-pypi-publish` for PEP 740 attestations.

Net diff: ~27 lines (of which ~10 are the functional changes; the rest are teaching-style comments for maintenance context).

## Locked decisions implemented

| # | Decision | Shape |
|---|---|---|
| Q1 | SHA pin | `@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0` |
| Q2 | `v1.0.1-rc0` smoke test | (post-merge activity, not in this PR) |
| Q3 | Wheel + sdist attestation | `inputs:` covers both; `attestations: true` publishes both to PyPI |

## Smoke-test plan (post-merge, per Q2=A)

1. Merge this PR.
2. Bump `pyproject.toml` version to `1.0.1rc0`, commit, push.
3. `git tag -s v1.0.1-rc0 -m "v1.0.1-rc0" && git push origin v1.0.1-rc0`.
4. Watch Actions:
   - `build`: Sigstore step produces `dist/*.sigstore`.
   - `create-release`: Release page shows `.whl`, `.tar.gz`, `.sigstore` assets.
   - `publish`: PyPI page for `clickwork 1.0.1rc0` shows Attestations.
5. Manual verify:
   - `sigstore verify identity <wheel> --bundle <wheel>.sigstore --cert-identity https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1-rc0 --cert-oidc-issuer https://token.actions.githubusercontent.com`
   - `pypi-attestations verify pypi clickwork==1.0.1rc0`
6. Yank RC from PyPI, bump `pyproject.toml` back, move to Wave 2.

If the RC fails, yank + delete tag + bump to `1.0.1rc1` before retry (PyPI no-reupload rule).

## Non-goals (Wave 1)

- Tag signing (Wave 2)
- Verification docs (Wave 3)
- Cut 1.0.1 (Wave 4)
- Adding `.github/dependabot.yml` (tracked as out-of-scope in the plan — worth a follow-up issue)

## Related

- Parent plan: #97 (merged)
- Implementation plan: #107 (merged)
- Parent issue: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)