### PR TITLE
feat(release): workflow-driven tag signing (Wave 2, part of #61)

### DIFF
--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to tag (without leading v), e.g. 1.0.1 or 1.0.1rc0'
+        description: 'Version to tag (without leading v). Final: 1.0.1. Prerelease: 1.0.1-rc0 (hyphenated — publish.yml uses hyphen to mark prerelease).'
         required: true
         type: string
       commit_sha:
@@ -145,10 +145,35 @@ jobs:
               exit 1
               ;;
           esac
-          if printf '%s' "$HEADLINE" | grep -q '[[:cntrl:]]'; then
-            echo "Headline must not contain control characters" >&2
-            exit 1
-          fi
+          # Prereleases must use hyphenated form (1.0.1-rc0) not PEP 440
+          # unhyphenated (1.0.1rc0). publish.yml keys its prerelease
+          # field on whether the tag contains a hyphen (see publish.yml
+          # "prerelease:" line). An unhyphenated prerelease would
+          # create a GitHub Release NOT marked as prerelease, silently
+          # advancing the "latest" pointer.
+          case "$VERSION" in
+            *[a-zA-Z]*)
+              case "$VERSION" in
+                *-*) ;;  # Has letters AND a hyphen — OK
+                *)
+                  echo "Prerelease versions must use hyphenated form: '1.0.1-rc0' not '1.0.1rc0'" >&2
+                  echo "publish.yml marks Release.prerelease=true based on hyphen presence." >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
+          esac
+          # grep -q [[:cntrl:]] is line-oriented and misses embedded
+          # newlines in HEADLINE (the newline becomes the record
+          # separator, so each sub-line is checked independently with
+          # no control chars in it). Shell `case` sees the full string
+          # and correctly matches [[:cntrl:]] anywhere in HEADLINE.
+          case "$HEADLINE" in
+            *[[:cntrl:]]*)
+              echo "Headline must not contain control characters (newlines, tabs, etc.)" >&2
+              exit 1
+              ;;
+          esac
           TAG="v$VERSION"
           msg_file="$(mktemp)"
           trap 'rm -f "$msg_file"' EXIT
@@ -182,6 +207,17 @@ jobs:
             *[!0-9a-zA-Z.+-]*)
               echo "Invalid version: $VERSION (allowed: digits, letters, . + -)" >&2
               exit 1
+              ;;
+          esac
+          case "$VERSION" in
+            *[a-zA-Z]*)
+              case "$VERSION" in
+                *-*) ;;
+                *)
+                  echo "Prerelease versions must use hyphenated form: '1.0.1-rc0' not '1.0.1rc0'" >&2
+                  exit 1
+                  ;;
+              esac
               ;;
           esac
           TAG="v$VERSION"

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -72,13 +72,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Always check out main with full history. If commit_sha is
-          # provided, we validate it in the next step and then
-          # detach-HEAD to that commit. Passing commit_sha directly as
-          # `ref:` would accept branch/tag names too, which could tag
-          # an unintended revision (e.g., a typo matching a branch
-          # name).
-          ref: main
+          # Always check out the repo's default branch (main today)
+          # with full history. If commit_sha is provided, we validate
+          # it in the next step and then detach-HEAD to that commit.
+          # Passing commit_sha directly as `ref:` would accept
+          # branch/tag names too, which could tag an unintended
+          # revision (e.g., a typo matching a branch name).
+          #
+          # Using github.event.repository.default_branch (not
+          # hardcoded 'main') keeps this in sync with the job-level
+          # if: guard above and survives any future default-branch
+          # rename.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Validate + check out requested commit SHA (if provided)

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -24,11 +24,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to tag (without leading v). Final: 1.0.1. Prerelease: 1.0.1-rc0 (hyphenated — publish.yml uses hyphen to mark prerelease).'
+        description: 'Version to tag (without leading v). Use the PEP 440 form that appears in pyproject.toml — final: 1.0.1, prerelease: 1.0.1rc0 (or hyphenated 1.0.1-rc0; normalized internally). The tag gets the hyphen added automatically when needed for publish.yml prerelease detection.'
         required: true
         type: string
       commit_sha:
-        description: 'Commit to tag (default: main HEAD)'
+        description: 'Commit to tag (default: default branch HEAD)'
         required: false
         type: string
       headline:
@@ -117,20 +117,64 @@ jobs:
           fi
           git checkout --detach "$COMMIT_SHA"
 
-      - name: Preflight — inputs.version matches pyproject.toml + CHANGELOG.md
-        # Without this check, a skew between inputs.version and the
-        # pyproject.toml version at the checked-out commit produces a
+      - name: Normalize version — validate + compute PKG_VERSION and TAG_VERSION
+        # Validate inputs.version then derive two normalized forms:
+        #   PKG_VERSION (PEP 440): the canonical package version. This
+        #     is what pyproject.toml holds and what PyPI accepts — no
+        #     hyphen between digits and letters. Produced by stripping
+        #     any digit-letter hyphen (so `1.0.1-rc0` → `1.0.1rc0`).
+        #   TAG_VERSION (hyphenated): the git tag form. publish.yml
+        #     marks Release.prerelease=true when the tag contains a
+        #     hyphen (see publish.yml), so we insert a hyphen between
+        #     digit and letter (so `1.0.1rc0` → `1.0.1-rc0`). Finals
+        #     like `1.0.1` have no letters and stay unchanged in
+        #     both forms.
+        #
+        # Accepting either input form (PEP 440 `1.0.1rc0` or
+        # hyphenated `1.0.1-rc0`) keeps the maintainer from having to
+        # remember two conventions; the workflow handles the mapping.
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          case "$VERSION" in
+            '')
+              echo "Version must not be empty" >&2
+              exit 1
+              ;;
+            v*|V*)
+              echo "Version must NOT start with 'v' — use '1.0.1' not 'v1.0.1' (tag gets 'v' automatically)" >&2
+              exit 1
+              ;;
+            *[!0-9a-zA-Z.+-]*)
+              echo "Invalid version: $VERSION (allowed: digits, letters, . + -)" >&2
+              exit 1
+              ;;
+          esac
+          PKG_VERSION=$(printf '%s' "$VERSION" | sed -E 's/([0-9])-([a-zA-Z])/\1\2/')
+          TAG_VERSION=$(printf '%s' "$PKG_VERSION" | sed -E 's/([0-9])([a-zA-Z])/\1-\2/')
+          echo "PKG_VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+          echo "Normalized: inputs.version='$VERSION' → PKG_VERSION='$PKG_VERSION' (pyproject.toml match target), TAG_VERSION='$TAG_VERSION' (git tag form)"
+
+      - name: Preflight — PKG_VERSION matches pyproject.toml + CHANGELOG.md
+        # Without this check, a skew between the requested version and
+        # pyproject.toml at the checked-out commit produces a
         # silently-broken release: the tag says v1.0.1 but uv build
         # reads pyproject.toml (still 1.0.0) and the artifacts are
         # 1.0.0-named. publish.yml then either fails the PyPI upload
         # (1.0.0 already published) or, worse, overwrites/republishes
         # something unintended. Fail loudly here instead.
         #
+        # Compare PKG_VERSION (PEP 440 normalized form) to
+        # pyproject.toml. Hyphenated inputs like `1.0.1-rc0` normalize
+        # to `1.0.1rc0` which is what pyproject.toml must contain —
+        # hyphenated prereleases are invalid on PyPI.
+        #
         # Also require a matching CHANGELOG.md entry — Keep-a-Changelog
         # format (## [X.Y.Z]) — so a maintainer can't ship a release
-        # without noting it in the changelog.
-        env:
-          VERSION: ${{ inputs.version }}
+        # without noting it in the changelog. Uses PKG_VERSION since
+        # that's the canonical release number.
         run: |
           set -eu
           # awk extracts the first `version = "..."` line (the one
@@ -141,13 +185,13 @@ jobs:
             echo "Could not parse version from pyproject.toml" >&2
             exit 1
           fi
-          if [ "$PROJECT_VERSION" != "$VERSION" ]; then
-            echo "Version mismatch: inputs.version=$VERSION but pyproject.toml has $PROJECT_VERSION." >&2
-            echo "Merge a release PR that bumps pyproject.toml to $VERSION before dispatching this workflow." >&2
+          if [ "$PROJECT_VERSION" != "$PKG_VERSION" ]; then
+            echo "Version mismatch: PKG_VERSION=$PKG_VERSION but pyproject.toml has $PROJECT_VERSION." >&2
+            echo "Merge a release PR that bumps pyproject.toml to $PKG_VERSION before dispatching this workflow." >&2
             exit 1
           fi
-          if ! grep -qF "## [${VERSION}]" CHANGELOG.md; then
-            echo "CHANGELOG.md has no entry '## [$VERSION]'. Add a Keep-a-Changelog entry before cutting the release." >&2
+          if ! grep -qF "## [${PKG_VERSION}]" CHANGELOG.md; then
+            echo "CHANGELOG.md has no entry '## [$PKG_VERSION]'. Add a Keep-a-Changelog entry before cutting the release." >&2
             exit 1
           fi
 
@@ -171,80 +215,34 @@ jobs:
         run: git config user.signingkey "${{ secrets.RELEASE_GPG_FINGERPRINT }}"
 
       - name: Create signed tag
-        # Shell-injection hardening: pass inputs.version and
-        # inputs.headline via env vars rather than direct ${{ }}
-        # interpolation. First validate version against a shell-
-        # metacharacter-free character set (digits, letters, dot,
-        # plus, hyphen), then apply the stricter release-version
-        # rules used by this workflow: finals like 1.0.1 and
-        # hyphenated prereleases like 1.0.1-rc0 are allowed, but
-        # non-hyphenated letter suffixes like 1.0.1rc0 are rejected;
-        # `;`, `$`, `|`, spaces, etc. are also rejected. Write the
-        # annotation body to a temp file and `git tag -F` from it so
-        # quotes/newlines in the headline can't break out of the
-        # shell context.
+        # Shell-injection hardening for HEADLINE: passed via env var
+        # (not direct ${{ }} interpolation), reject control chars,
+        # write annotation body to a temp file and `git tag -F` so
+        # quotes/newlines can't break out of the shell context.
+        # PKG_VERSION + TAG_VERSION come from the normalize step
+        # upstream (set via $GITHUB_ENV).
         env:
-          VERSION: ${{ inputs.version }}
           HEADLINE: ${{ inputs.headline }}
         run: |
           set -eu
-          case "$VERSION" in
-            '')
-              echo "Version must not be empty" >&2
-              exit 1
-              ;;
-            v*|V*)
-              echo "Version must NOT start with 'v' — use '1.0.1' not 'v1.0.1' (tag gets the 'v' prefixed automatically)" >&2
-              exit 1
-              ;;
-            *[!0-9a-zA-Z.+-]*)
-              echo "Invalid version: $VERSION (allowed: digits, letters, . + -)" >&2
-              exit 1
-              ;;
-          esac
-          # Prereleases must use hyphenated form (1.0.1-rc0) not PEP 440
-          # unhyphenated (1.0.1rc0). publish.yml keys its prerelease
-          # field on whether the tag contains a hyphen (see publish.yml
-          # "prerelease:" line). An unhyphenated prerelease would
-          # create a GitHub Release NOT marked as prerelease, silently
-          # advancing the "latest" pointer.
-          case "$VERSION" in
-            *[a-zA-Z]*)
-              case "$VERSION" in
-                *-*) ;;  # Has letters AND a hyphen — OK
-                *)
-                  echo "Prerelease versions must use hyphenated form: '1.0.1-rc0' not '1.0.1rc0'" >&2
-                  echo "publish.yml marks Release.prerelease=true based on hyphen presence." >&2
-                  exit 1
-                  ;;
-              esac
-              ;;
-          esac
-          # grep -q [[:cntrl:]] is line-oriented and misses embedded
-          # newlines in HEADLINE (the newline becomes the record
-          # separator, so each sub-line is checked independently with
-          # no control chars in it). Shell `case` sees the full string
-          # and correctly matches [[:cntrl:]] anywhere in HEADLINE.
           case "$HEADLINE" in
             *[[:cntrl:]]*)
               echo "Headline must not contain control characters (newlines, tabs, etc.)" >&2
               exit 1
               ;;
           esac
-          TAG="v$VERSION"
+          TAG="v$TAG_VERSION"
           msg_file="$(mktemp)"
           trap 'rm -f "$msg_file"' EXIT
-          printf 'clickwork %s — %s\n' "$VERSION" "$HEADLINE" >"$msg_file"
+          printf 'clickwork %s — %s\n' "$PKG_VERSION" "$HEADLINE" >"$msg_file"
           git tag -s -F "$msg_file" "$TAG"
 
       - name: Push tag with PAT
-        # Same hardening: VERSION via env, re-validate (defense in
-        # depth). PAT-authenticated URL authenticates as the PAT
-        # owner, not as GITHUB_TOKEN, so the tag push fires
-        # publish.yml normally.
+        # PAT-authenticated push (not GITHUB_TOKEN) so the tag push
+        # fires publish.yml normally. TAG_VERSION comes from the
+        # normalize step upstream — no re-validation needed.
         env:
           PAT: ${{ secrets.RELEASE_TAG_PUSH_TOKEN }}
-          VERSION: ${{ inputs.version }}
         run: |
           set -eu
           if [ -z "$PAT" ]; then
@@ -252,32 +250,7 @@ jobs:
             echo "See CONTRIBUTING.md 'Release-signing key + PAT rotation' for setup." >&2
             exit 1
           fi
-          case "$VERSION" in
-            '')
-              echo "Version must not be empty" >&2
-              exit 1
-              ;;
-            v*|V*)
-              echo "Version must NOT start with 'v'" >&2
-              exit 1
-              ;;
-            *[!0-9a-zA-Z.+-]*)
-              echo "Invalid version: $VERSION (allowed: digits, letters, . + -)" >&2
-              exit 1
-              ;;
-          esac
-          case "$VERSION" in
-            *[a-zA-Z]*)
-              case "$VERSION" in
-                *-*) ;;
-                *)
-                  echo "Prerelease versions must use hyphenated form: '1.0.1-rc0' not '1.0.1rc0'" >&2
-                  exit 1
-                  ;;
-              esac
-              ;;
-          esac
-          TAG="v$VERSION"
+          TAG="v$TAG_VERSION"
           # Push via git credential helper rather than embedding the
           # PAT in the remote URL. Actions already masks secrets, but
           # putting the PAT in the URL risks it leaking through:

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -1,0 +1,141 @@
+name: Sign release tag
+
+# Creates and pushes a GPG-signed annotated tag for a planned release,
+# using a dedicated workflow-only GPG key (NOT the maintainer's personal
+# key). The pushed tag fires publish.yml and runs the existing 3-job
+# pipeline (build → create-release → publish).
+#
+# This replaces the prior CONTRIBUTING.md runbook of "locally run
+# git tag -s && git push origin vX.Y.Z". See Wave 2 plan
+# (docs/superpowers/specs/2026-04-20-sigstore-wave2-impl-plan.md)
+# and parent plan (docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md)
+# for the full rationale and design decisions.
+#
+# Why a PAT instead of GITHUB_TOKEN for the push: pushes authored by
+# GITHUB_TOKEN do NOT fire sibling on:push workflows (GitHub's
+# anti-recursion guard). So a naive GITHUB_TOKEN push here would
+# silently skip publish.yml. The RELEASE_TAG_PUSH_TOKEN PAT bypasses
+# that restriction while keeping least-privilege (contents:write on
+# this repo only).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag (without leading v), e.g. 1.0.1 or 1.0.1rc0'
+        required: true
+        type: string
+      commit_sha:
+        description: 'Commit to tag (default: main HEAD)'
+        required: false
+        type: string
+      headline:
+        description: 'Release headline for tag annotation (e.g. "Sigstore signing end-to-end")'
+        required: true
+        type: string
+
+# Workflow-level deny-all. The job re-grants only what it needs.
+permissions: {}
+
+jobs:
+  sign-and-push:
+    name: Sign and push release tag
+    runs-on: ubuntu-latest
+    # Same pypi environment as publish.yml — the maintainer approves
+    # a deployment here before the release-signing secrets become
+    # readable to the job. First of the two release-flow approvals
+    # (second is publish.yml's PyPI job).
+    environment: pypi
+
+    # contents:read is for checkout only. The actual tag push is
+    # authenticated with RELEASE_TAG_PUSH_TOKEN (a fine-scoped PAT
+    # with contents:write on this repo), NOT with GITHUB_TOKEN.
+    # See workflow header for why.
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the tag points at a real commit. Default
+          # shallow fetch would work for main HEAD but not for an
+          # arbitrary commit_sha input.
+          ref: ${{ inputs.commit_sha || 'main' }}
+          fetch-depth: 0
+
+      - name: Import GPG key + configure git identity
+        # crazy-max/ghaction-import-gpg sets user.name, user.email,
+        # user.signingkey, and enables tag GPG signing from the
+        # imported key's UID. The runner starts with an unconfigured
+        # git identity, so without this step `git tag -s` would fail
+        # with "please tell me who you are".
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_tag_gpgsign: true
+
+      - name: Pin signing key by fingerprint
+        # Belt-and-suspenders: the import step sets user.signingkey
+        # to whatever identifier the action derives. We override with
+        # the full 40-char fingerprint so collisions against any
+        # other key in the ephemeral keyring are impossible.
+        run: git config user.signingkey "${{ secrets.RELEASE_GPG_FINGERPRINT }}"
+
+      - name: Create signed tag
+        # Shell-injection hardening: pass inputs.version and
+        # inputs.headline via env vars rather than direct ${{ }}
+        # interpolation. Validate version against a shell-
+        # metacharacter-free character set (digits, letters, dot,
+        # plus, hyphen) so PEP 440 prereleases like 1.0.1rc0 and
+        # hyphenated tags like 1.0.1-rc0 both pass, but `;`, `$`,
+        # `|`, spaces, etc. are rejected. Write the annotation body
+        # to a temp file and `git tag -F` from it so quotes/newlines
+        # in the headline can't break out of the shell context.
+        env:
+          VERSION: ${{ inputs.version }}
+          HEADLINE: ${{ inputs.headline }}
+        run: |
+          set -eu
+          case "$VERSION" in
+            '')
+              echo "Version must not be empty" >&2
+              exit 1
+              ;;
+            *[!0-9a-zA-Z.+-]*)
+              echo "Invalid version: $VERSION (allowed: digits, letters, . + -)" >&2
+              exit 1
+              ;;
+          esac
+          if printf '%s' "$HEADLINE" | grep -q '[[:cntrl:]]'; then
+            echo "Headline must not contain control characters" >&2
+            exit 1
+          fi
+          TAG="v$VERSION"
+          msg_file="$(mktemp)"
+          trap 'rm -f "$msg_file"' EXIT
+          printf 'clickwork %s — %s\n' "$VERSION" "$HEADLINE" >"$msg_file"
+          git tag -s "$TAG" -F "$msg_file"
+
+      - name: Push tag with PAT
+        # Same hardening: VERSION via env, re-validate (defense in
+        # depth). PAT-authenticated URL authenticates as the PAT
+        # owner, not as GITHUB_TOKEN, so the tag push fires
+        # publish.yml normally.
+        env:
+          PAT: ${{ secrets.RELEASE_TAG_PUSH_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          case "$VERSION" in
+            '')
+              echo "Version must not be empty" >&2
+              exit 1
+              ;;
+            *[!0-9a-zA-Z.+-]*)
+              echo "Invalid version: $VERSION (allowed: digits, letters, . + -)" >&2
+              exit 1
+              ;;
+          esac
+          TAG="v$VERSION"
+          git push "https://x-access-token:${PAT}@github.com/${{ github.repository }}.git" "$TAG"

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -221,7 +221,33 @@ jobs:
         # to whatever identifier the action derives. We override with
         # the full 40-char fingerprint so collisions against any
         # other key in the ephemeral keyring are impossible.
-        run: git config user.signingkey "${{ secrets.RELEASE_GPG_FINGERPRINT }}"
+        #
+        # Validate the fingerprint secret is non-empty and exactly 40
+        # hex chars before applying. An empty value would overwrite
+        # user.signingkey with "" and the subsequent git tag -s would
+        # either error cryptically or (worse) fall back to some other
+        # default key.
+        env:
+          FP: ${{ secrets.RELEASE_GPG_FINGERPRINT }}
+        run: |
+          set -eu
+          if [ -z "$FP" ]; then
+            echo "RELEASE_GPG_FINGERPRINT secret is empty or missing in the pypi environment." >&2
+            echo "See CONTRIBUTING.md 'Release-signing key + PAT rotation' for setup." >&2
+            exit 1
+          fi
+          case "$FP" in
+            *[!0-9a-fA-F]*)
+              echo "RELEASE_GPG_FINGERPRINT must contain only hexadecimal characters (0-9, a-f, A-F)." >&2
+              exit 1
+              ;;
+          esac
+          if [ "${#FP}" -ne 40 ]; then
+            echo "RELEASE_GPG_FINGERPRINT must be exactly 40 characters (full GPG fingerprint, not a short/long key ID)." >&2
+            echo "Current length: ${#FP}. See CONTRIBUTING.md setup section." >&2
+            exit 1
+          fi
+          git config user.signingkey "$FP"
 
       - name: Create signed tag
         # Shell-injection hardening for HEADLINE: passed via env var

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -119,13 +119,16 @@ jobs:
       - name: Create signed tag
         # Shell-injection hardening: pass inputs.version and
         # inputs.headline via env vars rather than direct ${{ }}
-        # interpolation. Validate version against a shell-
+        # interpolation. First validate version against a shell-
         # metacharacter-free character set (digits, letters, dot,
-        # plus, hyphen) so PEP 440 prereleases like 1.0.1rc0 and
-        # hyphenated tags like 1.0.1-rc0 both pass, but `;`, `$`,
-        # `|`, spaces, etc. are rejected. Write the annotation body
-        # to a temp file and `git tag -F` from it so quotes/newlines
-        # in the headline can't break out of the shell context.
+        # plus, hyphen), then apply the stricter release-version
+        # rules used by this workflow: finals like 1.0.1 and
+        # hyphenated prereleases like 1.0.1-rc0 are allowed, but
+        # non-hyphenated letter suffixes like 1.0.1rc0 are rejected;
+        # `;`, `$`, `|`, spaces, etc. are also rejected. Write the
+        # annotation body to a temp file and `git tag -F` from it so
+        # quotes/newlines in the headline can't break out of the
+        # shell context.
         env:
           VERSION: ${{ inputs.version }}
           HEADLINE: ${{ inputs.headline }}

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -115,7 +115,7 @@ jobs:
           msg_file="$(mktemp)"
           trap 'rm -f "$msg_file"' EXIT
           printf 'clickwork %s — %s\n' "$VERSION" "$HEADLINE" >"$msg_file"
-          git tag -s "$TAG" -F "$msg_file"
+          git tag -s -F "$msg_file" "$TAG"
 
       - name: Push tag with PAT
         # Same hardening: VERSION via env, re-validate (defense in

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -5,8 +5,10 @@ name: Sign release tag
 # key). The pushed tag fires publish.yml and runs the existing 3-job
 # pipeline (build → create-release → publish).
 #
-# This replaces the prior CONTRIBUTING.md runbook of "locally run
-# git tag -s && git push origin vX.Y.Z". See Wave 2 plan
+# This workflow is the recommended path for most releases and
+# supersedes the prior CONTRIBUTING.md runbook of "locally run
+# git tag -s && git push origin vX.Y.Z" in the common case, while
+# keeping the local-GPG flow documented as a fallback. See Wave 2 plan
 # (docs/superpowers/specs/2026-04-20-sigstore-wave2-impl-plan.md)
 # and parent plan (docs/superpowers/specs/2026-04-19-sigstore-signing-plan.md)
 # for the full rationale and design decisions.
@@ -41,6 +43,19 @@ jobs:
   sign-and-push:
     name: Sign and push release tag
     runs-on: ubuntu-latest
+    # Defense-in-depth branch guard: workflow_dispatch can be fired
+    # from any branch that contains this workflow file. Without this
+    # check, a maintainer could accidentally (or an attacker with
+    # write access could intentionally) push a modified copy of this
+    # workflow to a non-main branch, dispatch it, and that modified
+    # workflow would run with access to the pypi environment's
+    # RELEASE_GPG_PRIVATE_KEY + RELEASE_TAG_PUSH_TOKEN secrets.
+    # Comparing github.ref_name to the repo's default_branch ensures
+    # we only sign tags from trusted main-branch workflow contents.
+    # The pypi environment's deployment_branch_policy is the other
+    # layer of this protection; this if: guard makes the same rule
+    # enforced in the workflow itself, visible in code review.
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
     # Same pypi environment as publish.yml — the maintainer approves
     # a deployment here before the release-signing secrets become
     # readable to the job. First of the two release-flow approvals

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -278,4 +278,19 @@ jobs:
               ;;
           esac
           TAG="v$VERSION"
-          git push "https://x-access-token:${PAT}@github.com/${{ github.repository }}.git" "$TAG"
+          # Push via git credential helper rather than embedding the
+          # PAT in the remote URL. Actions already masks secrets, but
+          # putting the PAT in the URL risks it leaking through:
+          # - git error messages that echo the remote URL
+          # - git remote/config inspection inside the runner
+          # - process listings (/proc/*/cmdline) on self-hosted runners
+          # - downstream tool logs that capture command strings
+          # The credential helper file keeps the PAT out of the URL
+          # and out of argv; mktemp + 0600 + trap-rm contains its
+          # lifetime to this one push.
+          cred_file="$(mktemp)"
+          chmod 600 "$cred_file"
+          trap 'rm -f "$cred_file"' EXIT
+          printf 'https://x-access-token:%s@github.com\n' "$PAT" >"$cred_file"
+          git -c "credential.helper=store --file=$cred_file" \
+              push "https://github.com/${{ github.repository }}.git" "$TAG"

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -151,8 +151,17 @@ jobs:
               exit 1
               ;;
           esac
+          # Strip any digit-letter hyphen from input: "1.0.1-rc0" →
+          # "1.0.1rc0". Produces canonical PEP 440.
           PKG_VERSION=$(printf '%s' "$VERSION" | sed -E 's/([0-9])-([a-zA-Z])/\1\2/')
-          TAG_VERSION=$(printf '%s' "$PKG_VERSION" | sed -E 's/([0-9])([a-zA-Z])/\1-\2/')
+          # Insert a hyphen before a recognized prerelease/dev label so
+          # publish.yml's hyphen-based prerelease detection fires. Matches
+          # PEP 440 pre-releases (a, b, c, rc, alpha, beta, pre) and dev
+          # releases (.dev), letting an optional dot precede the label
+          # so "1.0.1.dev0" → "1.0.1-dev0". Post-releases (.post) are
+          # intentionally NOT in this list — post1 is not a prerelease
+          # and should NOT flip publish.yml's prerelease flag.
+          TAG_VERSION=$(printf '%s' "$PKG_VERSION" | sed -E 's/([0-9])\.?(a|b|c|rc|alpha|beta|pre|dev)([0-9]+)/\1-\2\3/')
           echo "PKG_VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
           echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
           echo "Normalized: inputs.version='$VERSION' → PKG_VERSION='$PKG_VERSION' (pyproject.toml match target), TAG_VERSION='$TAG_VERSION' (git tag form)"

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -97,6 +97,40 @@ jobs:
           fi
           git checkout --detach "$COMMIT_SHA"
 
+      - name: Preflight — inputs.version matches pyproject.toml + CHANGELOG.md
+        # Without this check, a skew between inputs.version and the
+        # pyproject.toml version at the checked-out commit produces a
+        # silently-broken release: the tag says v1.0.1 but uv build
+        # reads pyproject.toml (still 1.0.0) and the artifacts are
+        # 1.0.0-named. publish.yml then either fails the PyPI upload
+        # (1.0.0 already published) or, worse, overwrites/republishes
+        # something unintended. Fail loudly here instead.
+        #
+        # Also require a matching CHANGELOG.md entry — Keep-a-Changelog
+        # format (## [X.Y.Z]) — so a maintainer can't ship a release
+        # without noting it in the changelog.
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          # awk extracts the first `version = "..."` line (the one
+          # under [project]; pyproject.toml doesn't have others at
+          # time of writing, but if it did we'd only match the first).
+          PROJECT_VERSION=$(awk -F'"' '/^version = "/ { print $2; exit }' pyproject.toml)
+          if [ -z "$PROJECT_VERSION" ]; then
+            echo "Could not parse version from pyproject.toml" >&2
+            exit 1
+          fi
+          if [ "$PROJECT_VERSION" != "$VERSION" ]; then
+            echo "Version mismatch: inputs.version=$VERSION but pyproject.toml has $PROJECT_VERSION." >&2
+            echo "Merge a release PR that bumps pyproject.toml to $VERSION before dispatching this workflow." >&2
+            exit 1
+          fi
+          if ! grep -qF "## [${VERSION}]" CHANGELOG.md; then
+            echo "CHANGELOG.md has no entry '## [$VERSION]'. Add a Keep-a-Changelog entry before cutting the release." >&2
+            exit 1
+          fi
+
       - name: Import GPG key + configure git identity
         # crazy-max/ghaction-import-gpg sets user.name, user.email,
         # user.signingkey, and enables tag GPG signing from the

--- a/.github/workflows/sign-release-tag.yml
+++ b/.github/workflows/sign-release-tag.yml
@@ -57,11 +57,45 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Full history so the tag points at a real commit. Default
-          # shallow fetch would work for main HEAD but not for an
-          # arbitrary commit_sha input.
-          ref: ${{ inputs.commit_sha || 'main' }}
+          # Always check out main with full history. If commit_sha is
+          # provided, we validate it in the next step and then
+          # detach-HEAD to that commit. Passing commit_sha directly as
+          # `ref:` would accept branch/tag names too, which could tag
+          # an unintended revision (e.g., a typo matching a branch
+          # name).
+          ref: main
           fetch-depth: 0
+
+      - name: Validate + check out requested commit SHA (if provided)
+        # When commit_sha is empty the step is a no-op and we tag main
+        # HEAD. When it's set, validate hex-only + length 7–40, then
+        # confirm it resolves to a commit object, then detach-HEAD to
+        # it. Without this, actions/checkout would happily accept a
+        # branch name like "main" or "feat/x" as commit_sha and we'd
+        # tag the wrong revision.
+        if: ${{ inputs.commit_sha != '' }}
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: |
+          set -eu
+          case "$COMMIT_SHA" in
+            *[!0-9a-fA-F]*)
+              echo "Invalid commit_sha: must contain only hexadecimal characters" >&2
+              exit 1
+              ;;
+          esac
+          case "${#COMMIT_SHA}" in
+            [7-9]|[1-3][0-9]|40) ;;
+            *)
+              echo "Invalid commit_sha: must be 7 to 40 hexadecimal characters" >&2
+              exit 1
+              ;;
+          esac
+          if ! git cat-file -e "${COMMIT_SHA}^{commit}" 2>/dev/null; then
+            echo "Invalid commit_sha: ${COMMIT_SHA} not found or not a commit" >&2
+            exit 1
+          fi
+          git checkout --detach "$COMMIT_SHA"
 
       - name: Import GPG key + configure git identity
         # crazy-max/ghaction-import-gpg sets user.name, user.email,
@@ -102,6 +136,10 @@ jobs:
               echo "Version must not be empty" >&2
               exit 1
               ;;
+            v*|V*)
+              echo "Version must NOT start with 'v' — use '1.0.1' not 'v1.0.1' (tag gets the 'v' prefixed automatically)" >&2
+              exit 1
+              ;;
             *[!0-9a-zA-Z.+-]*)
               echo "Invalid version: $VERSION (allowed: digits, letters, . + -)" >&2
               exit 1
@@ -127,9 +165,18 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -eu
+          if [ -z "$PAT" ]; then
+            echo "RELEASE_TAG_PUSH_TOKEN secret is empty or missing in the pypi environment." >&2
+            echo "See CONTRIBUTING.md 'Release-signing key + PAT rotation' for setup." >&2
+            exit 1
+          fi
           case "$VERSION" in
             '')
               echo "Version must not be empty" >&2
+              exit 1
+              ;;
+            v*|V*)
+              echo "Version must NOT start with 'v'" >&2
               exit 1
               ;;
             *[!0-9a-zA-Z.+-]*)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -306,7 +306,7 @@ account's GPG keys and to any keyservers it was distributed to).
 Revocation is for compromise handling, NOT routine yearly rotation
 — revoking a key causes historical tag signatures made with it to
 be treated as suspect by verifiers, which is appropriate when the
-key was stolen but a regression in the routine-rotation case.
+key was stolen but is a regression in the routine-rotation case.
 
 ## Code of conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,12 +162,13 @@ they were created and how to rotate).
    adds the new entry to `CHANGELOG.md`, and (if relevant) updates
    the trove classifier from Beta -> Production/Stable.
 2. Go to **Actions → Sign release tag → Run workflow**. Fill in:
-   - `version`: e.g. `1.0.1` (no leading `v`). For prereleases, use
-     the hyphenated form `1.0.1-rc0` — `publish.yml` marks
-     `prerelease: true` only when the tag contains a hyphen, so
-     PEP 440's unhyphenated form (`1.0.1rc0`) would silently land
-     as a "latest" release. The workflow rejects unhyphenated
-     letter forms at validation.
+   - `version`: e.g. `1.0.1` for a final release. For prereleases
+     either PEP 440 (`1.0.1rc0`) or hyphenated (`1.0.1-rc0`) is
+     accepted — the workflow normalizes internally. The package
+     version (what lands in `pyproject.toml` and on PyPI) is the
+     unhyphenated PEP 440 form; the git tag is the hyphenated form
+     (so `publish.yml` marks it as prerelease). No leading `v` on
+     input — the tag gets `v` prefixed automatically.
    - `commit_sha`: leave blank for the default branch HEAD, or paste
      a SHA if the default branch has moved since the release PR
      merged and you want to tag a specific commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,9 +179,10 @@ they were created and how to rotate).
 3. Click **Run workflow**. The `pypi` environment's approval gate
    fires — open the run, click "Review deployments", approve
    `pypi`. The workflow imports the release-signing GPG key,
-   creates and pushes a signed `vX.Y.Z` tag using the PAT
-   (`RELEASE_TAG_PUSH_TOKEN`) so the tag push fires
-   `publish.yml` normally.
+   creates and pushes a signed `v...` tag using the PAT
+   (`RELEASE_TAG_PUSH_TOKEN`) — `vX.Y.Z` for final releases, or
+   a hyphenated prerelease tag such as `vX.Y.Z-rc0` / `vX.Y.Z-dev0`
+   — so the tag push fires `publish.yml` normally.
 4. The push fires `.github/workflows/publish.yml`: build wheel +
    sdist, Sigstore-sign them, create the GitHub Release with
    auto-generated notes (from `.github/release.yml` label

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,20 +285,28 @@ PAT rotate **yearly, or immediately on any suspected exposure**.
    - `RELEASE_GPG_FINGERPRINT` — 40-character fingerprint from step 4.
    - `RELEASE_TAG_PUSH_TOKEN` — PAT from step 5.
 
-**Yearly rotation:**
+**Yearly rotation (no compromise suspected):**
 
 1. Generate a new GPG key + PAT, same procedure as steps 1-5
    above.
 2. Upload the new public GPG key to your GitHub account. Do NOT
-   delete the old public key yet — existing tag signatures
-   reference it.
+   delete the old public key — existing tag signatures reference
+   it and should remain verifiable.
 3. Update `RELEASE_GPG_PRIVATE_KEY`, `RELEASE_GPG_FINGERPRINT`,
    and `RELEASE_TAG_PUSH_TOKEN` in the `pypi` environment.
 4. Run the next release through the workflow to confirm it signs
    cleanly against the new key.
-5. After a clean release with the new key: revoke the old GPG key
-   (upload the revocation certificate to your GitHub account) and
-   delete the old PAT.
+5. After a clean release with the new key: delete the old PAT.
+   Keep the old public GPG key published on your GitHub account so
+   historical signed tags continue to show as "Verified".
+
+**If the old GPG private key is exposed or compromised:** revoke
+the old GPG key (publish the revocation certificate to your GitHub
+account's GPG keys and to any keyservers it was distributed to).
+Revocation is for compromise handling, NOT routine yearly rotation
+— revoking a key causes historical tag signatures made with it to
+be treated as suspect by verifiers, which is appropriate when the
+key was stolen but a regression in the routine-rotation case.
 
 ## Code of conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,9 +168,9 @@ they were created and how to rotate).
      PEP 440's unhyphenated form (`1.0.1rc0`) would silently land
      as a "latest" release. The workflow rejects unhyphenated
      letter forms at validation.
-   - `commit_sha`: leave blank for `main` HEAD, or paste a SHA if
-     `main` has moved since the release PR merged and you want to
-     tag a specific commit.
+   - `commit_sha`: leave blank for the default branch HEAD, or paste
+     a SHA if the default branch has moved since the release PR
+     merged and you want to tag a specific commit.
    - `headline`: short description for the tag annotation. The
      workflow templates the full message as
      `clickwork X.Y.Z — <headline>` so you only need to supply the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,51 @@ single-PR cuts that bump version and changelog. If you're unsure
 whether a change you want to make warrants a roadmap-style rollout,
 open an issue and ask.
 
-### Cutting a release
+### Cutting a release (recommended: workflow-driven)
+
+The tag is signed by a dedicated release-signing GPG key that lives
+in the `pypi` environment as a secret. No local GPG setup required.
+Prerequisite: the `RELEASE_GPG_PRIVATE_KEY`, `RELEASE_GPG_FINGERPRINT`,
+and `RELEASE_TAG_PUSH_TOKEN` secrets must already exist in the `pypi`
+environment (see "Release-signing key + PAT rotation" below for how
+they were created and how to rotate).
+
+1. Merge a release PR that bumps `version` in `pyproject.toml`,
+   adds the new entry to `CHANGELOG.md`, and (if relevant) updates
+   the trove classifier from Beta -> Production/Stable.
+2. Go to **Actions → Sign release tag → Run workflow**. Fill in:
+   - `version`: e.g. `1.0.1` (no leading `v`). PEP 440 prereleases
+     like `1.0.1rc0` and hyphenated forms like `1.0.1-rc0` are both
+     accepted.
+   - `commit_sha`: leave blank for `main` HEAD, or paste a SHA if
+     `main` has moved since the release PR merged and you want to
+     tag a specific commit.
+   - `headline`: short description for the tag annotation. The
+     workflow templates the full message as
+     `clickwork X.Y.Z — <headline>` so you only need to supply the
+     trailing bit.
+3. Click **Run workflow**. The `pypi` environment's approval gate
+   fires — open the run, click "Review deployments", approve
+   `pypi`. The workflow imports the release-signing GPG key,
+   creates and pushes a signed `vX.Y.Z` tag using the PAT
+   (`RELEASE_TAG_PUSH_TOKEN`) so the tag push fires
+   `publish.yml` normally.
+4. The push fires `.github/workflows/publish.yml`: build wheel +
+   sdist, Sigstore-sign them, create the GitHub Release with
+   auto-generated notes (from `.github/release.yml` label
+   grouping) and the dist + `.sigstore` bundle files attached,
+   then publish to PyPI via Trusted Publishing with PEP 740
+   attestations.
+5. Approve the `pypi` environment a **second time** for
+   `publish.yml`'s PyPI job. (Two approvals per release by design
+   — one for tag signing, one for PyPI publish.) The publish job
+   finishes shortly after (typically under a minute).
+
+### Cutting a release (fallback: local GPG)
+
+Use this path if the release-signing secrets aren't configured yet,
+or if you need to tag from a machine-local build for some reason
+(e.g., emergency cut while the signing workflow is broken).
 
 1. Merge a release PR that bumps `version` in `pyproject.toml`,
    adds the new entry to `CHANGELOG.md`, and (if relevant) updates
@@ -178,14 +222,83 @@ open an issue and ask.
    future releases.
 
 3. The push fires `.github/workflows/publish.yml`: build wheel +
-   sdist, create the GitHub Release with auto-generated notes
-   (from `.github/release.yml` label grouping) and the dist files
-   attached, then publish to PyPI via Trusted Publishing.
+   sdist, Sigstore-sign them, create the GitHub Release with
+   auto-generated notes and the dist + `.sigstore` bundle files
+   attached, then publish to PyPI via Trusted Publishing with
+   PEP 740 attestations.
 4. The `pypi` environment is gated on maintainer approval. After
    the tag push, open the Actions tab, find the Publish run, click
    "Review deployments", approve `pypi`. The publish job finishes
    shortly after (typically under a minute; longer if runner load
    or the PyPI upload API is slow).
+
+### Release-signing key + PAT rotation
+
+The dedicated release-signing GPG key and the `RELEASE_TAG_PUSH_TOKEN`
+PAT rotate **yearly, or immediately on any suspected exposure**.
+
+**One-time setup (if the secrets don't exist yet):**
+
+1. Generate the release-signing GPG key. This is a dedicated key,
+   NOT the maintainer's personal identity:
+
+   ```bash
+   gpg --batch --pinentry-mode loopback --passphrase '' \
+       --quick-gen-key 'clickwork-release-bot <release@clickwork.invalid>' rsa4096 sign 0
+   ```
+
+   `--pinentry-mode loopback` is required on GnuPG 2.1+ for
+   `--passphrase ''` to be honored in batch mode.
+
+2. Export and upload the public half to the maintainer's GitHub
+   account (Settings → SSH and GPG keys → New GPG key). This is
+   what lets GitHub show tags signed with this key as "Verified"
+   on the maintainer's account:
+
+   ```bash
+   gpg --armor --export 'clickwork-release-bot <release@clickwork.invalid>'
+   ```
+
+3. Export the private half (ASCII-armored block):
+
+   ```bash
+   gpg --armor --export-secret-keys 'clickwork-release-bot <release@clickwork.invalid>'
+   ```
+
+4. Capture the full 40-character fingerprint (filter by UID so
+   multiple secret keys in the keyring don't cause a wrong pickup):
+
+   ```bash
+   gpg --list-secret-keys --with-colons 'clickwork-release-bot <release@clickwork.invalid>' \
+     | awk -F: '$1=="fpr" {print $10; exit}'
+   ```
+
+5. Create a fine-scoped PAT (Settings → Developer settings →
+   Personal access tokens → Fine-grained):
+   - Repository access: Only `qubitrenegade/clickwork`.
+   - Repository permissions: **Contents: Read and write**.
+   - Expiration: one year out.
+
+6. Store the three secrets in the `pypi` environment (Settings →
+   Environments → pypi → Secrets):
+   - `RELEASE_GPG_PRIVATE_KEY` — armored private block from step 3.
+   - `RELEASE_GPG_FINGERPRINT` — 40-character fingerprint from step 4.
+   - `RELEASE_TAG_PUSH_TOKEN` — PAT from step 5.
+
+**Yearly rotation:**
+
+1. Generate a new GPG key + PAT, same procedure as steps 1-5
+   above.
+2. Upload the new public GPG key to your GitHub account. Do NOT
+   delete the old public key yet — existing tag signatures
+   reference it.
+3. Update `RELEASE_GPG_PRIVATE_KEY`, `RELEASE_GPG_FINGERPRINT`,
+   and `RELEASE_TAG_PUSH_TOKEN` in the `pypi` environment.
+4. Run the next release through the workflow to confirm it signs
+   cleanly against the new key.
+5. After a clean release with the new key: revoke the old GPG key
+   (upload the revocation certificate to your GitHub account) and
+   delete the old PAT.
 
 ## Code of conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,9 +162,12 @@ they were created and how to rotate).
    adds the new entry to `CHANGELOG.md`, and (if relevant) updates
    the trove classifier from Beta -> Production/Stable.
 2. Go to **Actions → Sign release tag → Run workflow**. Fill in:
-   - `version`: e.g. `1.0.1` (no leading `v`). PEP 440 prereleases
-     like `1.0.1rc0` and hyphenated forms like `1.0.1-rc0` are both
-     accepted.
+   - `version`: e.g. `1.0.1` (no leading `v`). For prereleases, use
+     the hyphenated form `1.0.1-rc0` — `publish.yml` marks
+     `prerelease: true` only when the tag contains a hyphen, so
+     PEP 440's unhyphenated form (`1.0.1rc0`) would silently land
+     as a "latest" release. The workflow rejects unhyphenated
+     letter forms at validation.
    - `commit_sha`: leave blank for `main` HEAD, or paste a SHA if
      `main` has moved since the release PR merged and you want to
      tag a specific commit.
@@ -244,11 +247,16 @@ PAT rotate **yearly, or immediately on any suspected exposure**.
 
    ```bash
    gpg --batch --pinentry-mode loopback --passphrase '' \
-       --quick-gen-key 'clickwork-release-bot <release@clickwork.invalid>' rsa4096 sign 0
+       --quick-gen-key 'clickwork-release-bot <release@clickwork.invalid>' rsa4096 sign 1y
    ```
 
    `--pinentry-mode loopback` is required on GnuPG 2.1+ for
-   `--passphrase ''` to be honored in batch mode.
+   `--passphrase ''` to be honored in batch mode. The `1y`
+   expiration matches the yearly rotation cadence — if a rotation
+   is missed, the key expires on its own instead of silently
+   working past its intended lifetime. Extend manually with
+   `gpg --edit-key <fingerprint>` → `expire` if you need to push
+   the expiry forward before rotating.
 
 2. Export and upload the public half to the maintainer's GitHub
    account (Settings → SSH and GPG keys → New GPG key). This is


### PR DESCRIPTION
## Summary

Wave 2 implementation for #61. Follows parent plan #97 (merged) and Wave 2 implementation plan #109 (merged).

**Two deliverables:**

1. **New workflow** `.github/workflows/sign-release-tag.yml` — `workflow_dispatch` trigger, imports dedicated release-signing GPG key from secrets, creates and pushes a signed annotated tag, gated on the `pypi` environment + default-branch, PAT-authenticated push via git credential helper (not URL-embedded) to fire `publish.yml`.
2. **`CONTRIBUTING.md` updates** — recommended workflow-driven path + local-GPG fallback + rotation runbook.

## Security + correctness hardening (per review loop)

- **Shell-injection**: inputs passed via env vars, not `${{ }}` interpolation. Headline rejects control characters. Tag annotation written to `mktemp`'d file, applied via `git tag -F` (quote/newline safe).
- **PAT**: passed via `credential.helper=store` pointing at a 0600 mktemp'd file — never in URL, command line, or git config.
- **Branch guard**: job `if:` requires `github.ref_name == github.event.repository.default_branch` so dispatch from a modified workflow on a non-default branch can't exfiltrate pypi env secrets.
- **Commit SHA validation**: when provided, hex-only + 7-40 chars + `git cat-file -e` existence check, then `git checkout --detach` — avoids tagging a branch name typoed into commit_sha.
- **Preflight match**: PKG_VERSION must equal `pyproject.toml` version AND CHANGELOG.md must have a matching `## [X.Y.Z]` entry before the tag is cut.
- **Version normalization**: accepts either PEP 440 (`1.0.1rc0`) or hyphenated (`1.0.1-rc0`) input; derives `PKG_VERSION` (PEP 440 form for pyproject.toml/PyPI match) and `TAG_VERSION` (hyphenated form for `publish.yml` prerelease detection). Handles `.dev` prereleases, leaves `.post` unhyphenated.
- **GPG**: dedicated workflow-only key (not maintainer's personal), uploaded to GitHub for Verified badge, 1y expiry matching yearly rotation cadence, SHA-pinned `crazy-max/ghaction-import-gpg@2dc316d # v7.0.0`.

## Prereq for the workflow to run

Three secrets in the `pypi` environment: `RELEASE_GPG_PRIVATE_KEY`, `RELEASE_GPG_FINGERPRINT`, `RELEASE_TAG_PUSH_TOKEN`. Full one-time setup + yearly rotation + compromise-revocation procedures in the new `CONTRIBUTING.md` subsection "Release-signing key + PAT rotation".

**Until secrets configured, the local-GPG fallback continues to work unchanged.** No regression on existing releases.

## How this ships a release

1. Actions → Sign release tag → Run workflow → fill `version` (PEP 440 or hyphenated, workflow normalizes), optional `commit_sha`, `headline`.
2. Approve `pypi` env gate (first of two approvals per release).
3. Workflow normalizes the version, preflight-checks pyproject.toml + CHANGELOG match, creates signed tag + pushes via PAT-helper → fires `publish.yml`.
4. Approve `pypi` env gate again (second of two, for the PyPI upload job).
5. Release lands on GitHub + PyPI with Sigstore bundles + PEP 740 attestations.

## Smoke-test plan (post-merge)

Per the Wave 2 plan — maintainer completes the one-time secret setup, dispatches with a throwaway version matching a test `pyproject.toml` bump, verifies tag + Verified badge + `publish.yml` fires, cancels the PyPI publish job, deletes test tag + Release.

## Related

- Parent plan: #97 (merged)
- Wave 2 implementation plan: #109 (merged)
- Wave 1 implementation: #108 (merged)
- Parent issue: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)