### PR TITLE
docs: implementation plan for Sigstore Wave 3 (part of #61)

### DIFF
--- a/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
@@ -35,12 +35,13 @@ The current `security.md` "Verifying release artifacts" section is a placeholder
 
 ## Scope of this plan
 
-Four deliverables:
+Five deliverables:
 
 1. **New file** `docs/reference/verifying.md` — the canonical "how to verify a clickwork release" page. Three concrete command blocks (one per verify path), plus a short "troubleshooting" subsection.
 2. **New file** `docs/VERIFYING.md` (top-level) — 1-line redirect stub pointing at `reference/verifying.md`. This matches the existing `docs/SECURITY.md` → `reference/security.md` pattern and honors parent plan #97's Q5=C wording which named the detailed doc as "`docs/VERIFYING.md`".
-3. **Rewrite** `docs/reference/security.md` lines 215–238 from hash-pinning-focused to a short "Verifying release artifacts" summary that names the three paths and links to `verifying.md`.
-4. **Cross-link** from `README.md` (install section mentions the verify doc) and `CONTRIBUTING.md` (release-cutting runbook references the verify doc for consumer-side expectations).
+3. **`mkdocs.yml` updates** — add `VERIFYING.md` to `exclude_docs`, add `VERIFYING.md: reference/verifying.md` to `plugins.redirects.redirect_maps`, add `Verifying: reference/verifying.md` to `nav.Reference`. Without these, RTD's `fail_on_warning` build breaks on (a) the new orphan page in `docs/` and (b) the `reference/verifying.md` page not being in nav.
+4. **Rewrite** `docs/reference/security.md` lines 215–238 from hash-pinning-focused to a short "Verifying release artifacts" summary that names the three paths and links to `verifying.md`.
+5. **Cross-link** from `README.md` (install section mentions the verify doc) and `CONTRIBUTING.md` (release-cutting runbook references the verify doc for consumer-side expectations).
 
 ## Design questions
 
@@ -100,8 +101,8 @@ Structure:
 Every release from 1.0.1 onward is provenance-protected three ways:
 the PyPI package carries PEP 740 attestations, the GitHub Release
 carries Sigstore `.sigstore` bundles, and the git tag is GPG-signed
-by the clickwork-release-bot key. Pick whichever verify path matches
-how you installed.
+(workflow key by default; maintainer key in fallback). Pick whichever
+verify path matches how you installed.
 
 (Examples below use `1.0.1` as the target version — substitute the
 version you installed.)
@@ -188,7 +189,7 @@ unsigned and this fallback flow does not apply.
 
 - [security.md](security.md) — threat model + hash-pinning fallback
   verify path for pre-1.0.1 releases.
-- [CONTRIBUTING.md#cutting-a-release-recommended-workflow-driven](../../CONTRIBUTING.md) — how the release-signing machinery works from the maintainer side.
+- [CONTRIBUTING.md — Cutting a release (recommended: workflow-driven)](https://github.com/qubitrenegade/clickwork/blob/main/CONTRIBUTING.md#cutting-a-release-recommended-workflow-driven) — how the release-signing machinery works from the maintainer side. (Absolute GitHub URL — `CONTRIBUTING.md` isn't published under `docs/` and a relative link would break RTD's `fail_on_warning` build.)
 - Parent issue: [#61](https://github.com/qubitrenegade/clickwork/issues/61).
 ```
 
@@ -202,7 +203,31 @@ Mirrors `docs/SECURITY.md`:
 
 Exists so the parent-plan-named path (`docs/VERIFYING.md`) resolves for anyone who reads the parent plan directly, and so future cross-links can use either the short top-level path or the full `reference/` path.
 
-### Step 3. Rewrite `docs/reference/security.md` "Verifying release artifacts" section (~25 lines → ~15 lines)
+### Step 3. `mkdocs.yml` updates (~6 lines)
+
+Three changes to keep the RTD `fail_on_warning` build green:
+
+1. Add `VERIFYING.md` to `exclude_docs` (top-level stub is a redirect, not a published page):
+
+       exclude_docs: |
+         # ... existing entries ...
+         VERIFYING.md
+
+2. Add a redirect entry in `plugins.redirects.redirect_maps`:
+
+       redirect_maps:
+         # ... existing entries ...
+         VERIFYING.md: reference/verifying.md
+
+3. Add `Verifying: reference/verifying.md` to `nav.Reference` (otherwise the new page is an orphan and `strict`/RTD builds warn):
+
+       nav:
+         # ...
+         - Reference:
+             # ... existing entries ...
+             - Verifying: reference/verifying.md
+
+### Step 4. Rewrite `docs/reference/security.md` "Verifying release artifacts" section (~25 lines → ~15 lines)
 
 Replace the existing hash-pinning-focused paragraph with:
 
@@ -223,25 +248,18 @@ unavailable, pin by hash:
 <retain the existing requirements.txt + pip --require-hashes + uv.lock paragraphs, about 15 lines>
 ```
 
-### Step 4. README cross-link
+### Step 5. README cross-link
 
-Append a short note to the existing `## Installation` section (the actual heading — not "Install"):
+Append a short note to the existing `## Installation` section (the actual heading — not "Install"). The existing section already contains the `uv pip install "clickwork>=1.0,<2"` block and surrounding prose; we add a new trailing paragraph:
 
-```markdown
-## Installation
-
-```bash
-# From PyPI (preferred)
-uv pip install "clickwork>=1.0,<2"
-[existing prose stays]
-```
-
-**Verifying your install:** see [docs/VERIFYING.md](docs/VERIFYING.md) (top-level redirect to [docs/reference/verifying.md](docs/reference/verifying.md)) for the three verify paths — PyPI attestation, Sigstore bundle, signed tag.
-```
+    **Verifying your install:** see [docs/VERIFYING.md](docs/VERIFYING.md)
+    (top-level redirect to [docs/reference/verifying.md](docs/reference/verifying.md))
+    for the three verify paths — PyPI attestation, Sigstore bundle,
+    signed tag.
 
 ~3 lines added.
 
-### Step 5. CONTRIBUTING.md cross-link
+### Step 6. CONTRIBUTING.md cross-link
 
 At the end of the "Cutting a release (recommended: workflow-driven)" subsection, add:
 
@@ -264,11 +282,12 @@ Running those commands against the RC tag during smoke-test
 
 - `docs/reference/verifying.md`: ~120 new lines (real content).
 - `docs/VERIFYING.md`: ~1 new line (redirect stub, mirrors `SECURITY.md`).
+- `mkdocs.yml`: ~6 lines added (exclude_docs entry, redirect_maps entry, nav entry).
 - `docs/reference/security.md`: ~25 lines removed, ~15 added (net −10).
 - `README.md`: ~3 lines added.
 - `CONTRIBUTING.md`: ~4 lines added.
 
-Total: ~130 lines net, 2 new files.
+Total: ~135 lines net, 2 new files.
 
 ## Merge-order constraints
 

--- a/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
@@ -1,0 +1,280 @@
+# Implementation plan — Sigstore Wave 3 (verification docs)
+
+**Date:** 2026-04-20
+**Milestone:** 1.0.x
+**Parent plan:** [2026-04-19-sigstore-signing-plan.md](2026-04-19-sigstore-signing-plan.md) (locked Q5=C: short summary in `docs/SECURITY.md` + detailed dedicated verification doc)
+**Parent issue:** [#61](https://github.com/qubitrenegade/clickwork/issues/61)
+**Scope:** Wave 3 only — user-facing verification documentation. Builds on Wave 1 (#108 Sigstore + PEP 740 attestations) and Wave 2 (#110 workflow-driven signed tags). Wave 4 (cut 1.0.1) is a separate plan.
+**Relevant files:** [docs/reference/security.md](../../reference/security.md) (existing 1-line "Verifying release artifacts" section, last ~25 lines), [docs/SECURITY.md](../../SECURITY.md) (redirect to reference/security.md), [.github/workflows/publish.yml](../../../.github/workflows/publish.yml) (Wave 1 output: Sigstore + attestations), [.github/workflows/sign-release-tag.yml](../../../.github/workflows/sign-release-tag.yml) (Wave 2 output: signed tags)
+
+## Goal
+
+Ship concrete, copy-pasteable verification commands for every provenance path clickwork now supports:
+
+1. **PyPI attestation** (PEP 740) — `pypi-attestations verify` against an installed wheel or sdist.
+2. **Sigstore bundle on the GitHub Release** — `sigstore verify identity` against a downloaded `.sigstore` bundle + artifact.
+3. **Signed git tag** — `git verify-tag vX.Y.Z` against the workflow-signed tag.
+
+The current `security.md` "Verifying release artifacts" section is a placeholder that predates Waves 1+2; it documents a `pip --require-hashes` flow only and notes that Sigstore is "planned for 1.0.1." After this wave the docs catch up to reality.
+
+## Non-goals (Wave 3)
+
+- Cutting 1.0.1 (Wave 4).
+- Automating verification in CI — the verify flow is consumer-side, we document the commands they run.
+- Building a verify-my-install helper script shipped inside `clickwork` itself (separate follow-up issue if we ever want one).
+- Explaining Sigstore's transparency-log (Rekor) internals — the `sigstore verify identity` command does the right thing; deep Rekor mechanics are upstream doc surface.
+
+## Current state
+
+- `docs/reference/security.md` lines 215–238 document only the hash-pinning verify path (pre-Sigstore). It names Sigstore as "planned" with a stale issue reference.
+- `docs/SECURITY.md` is a 1-line redirect to `reference/security.md`.
+- No dedicated verify doc exists.
+- Wave 1 produces `.sigstore` bundles on the Release + PEP 740 attestations on PyPI.
+- Wave 2 produces signed annotated tags `vX.Y.Z` verifiable via `git verify-tag`.
+- No CONTRIBUTING.md cross-link to consumer-side verify (CONTRIBUTING.md covers the maintainer side — how to *cut* a release, not how to *verify* one).
+
+## Scope of this plan
+
+Three deliverables:
+
+1. **New file** `docs/reference/verifying.md` — the canonical "how to verify a clickwork release" page. Three concrete command blocks (one per verify path), plus a short "troubleshooting" subsection.
+2. **Rewrite** `docs/reference/security.md` lines 215–238 from hash-pinning-focused to a short "Verifying release artifacts" summary that names the three paths and links to `verifying.md`.
+3. **Cross-link** from `README.md` (install section mentions the verify doc) and `CONTRIBUTING.md` (release-cutting runbook references the verify doc for consumer-side expectations).
+
+## Design questions
+
+### Q1. File path for the verify doc?
+
+clickwork's `docs/` tree has `reference/`, `how-to/`, `tutorials/`, `explanation/` (Diátaxis-style structure).
+
+- **A) `docs/reference/verifying.md`** — matches `docs/reference/security.md` neighbour; reference-style "these commands, this output" content. Consistent with how `security.md` itself is placed.
+- **B) `docs/how-to/verify-a-release.md`** — Diátaxis says "how-to" is for goal-oriented recipes, which fits verification perfectly.
+- **C) `docs/VERIFYING.md`** (top-level) — matches CONTRIBUTING.md / MIGRATING.md pattern. Shorter URL, easier to link from README.
+
+**Recommendation:** A. `security.md` is already reference-style and the verify doc is naturally a sibling of it. Keeping them adjacent in `docs/reference/` means the short-summary in security.md can link with `verifying.md` (no path prefix). B is defensible but verifying-is-a-recipe vs verifying-is-a-reference-page is a judgment call and we already have `security.md` in reference/; consistency wins.
+
+**Open question for maintainer:** confirm A, or prefer B's how-to placement?
+
+### Q2. Depth of worked examples — templates vs specific version?
+
+- **A) Specific-version worked examples using `1.0.1` as the placeholder** — e.g., `sigstore verify identity dist/clickwork-1.0.1-py3-none-any.whl ...`. Concrete, copy-paste-friendly.
+- **B) Template with `<version>` substitution markers** — e.g., `sigstore verify identity dist/clickwork-<version>-py3-none-any.whl ...`. Less visual noise, reader has to substitute.
+- **C) Both — worked example first, template underneath** — verbose but maximally clear.
+
+**Recommendation:** A with a single-sentence "substitute your target version" note above. Worked examples read faster; the reader sees the real shape of the command. The "1.0.1" placeholder is the first signed release anyway, so it's real-ish.
+
+**Open question for maintainer:** confirm A (worked examples), or B (templates)?
+
+### Q3. How explicit about the "pip/uv auto-verify not yet GA" caveat?
+
+PyPI's PEP 740 attestations are published by our Wave 1 changes, but `pip install --verify-attestations` (or equivalent) is not yet GA in pip or uv at time of writing. Consumers today run `pypi-attestations verify` manually.
+
+- **A) One-paragraph "note" box at the top of the PyPI-attestation section** — explicit about the "manual verify today, auto verify when installers ship it" transition.
+- **B) One sentence inline in the PyPI-attestation section** — less prominent, still honest.
+- **C) No explicit note — just document the `pypi-attestations verify` command as THE way** — cleaner doc, but readers who assume `pip install` already verifies will be surprised later.
+
+**Recommendation:** A. The "manual vs auto-verify" distinction is a real gotcha that will catch readers who assume the attestation does auto-magic. Being explicit up front saves a confused-user-opens-issue cycle.
+
+**Open question for maintainer:** A (note box), or B (single sentence)?
+
+### Q4. Cross-references from README + CONTRIBUTING?
+
+- **A) README.md install section adds a one-line "Verify your install: see docs/reference/verifying.md"** — visible to first-time installers.
+- **B) CONTRIBUTING.md "Cutting a release" section adds a closing note pointing at the verify doc for consumer expectations** — visible to release-cutters thinking about what consumers will do.
+- **C) Both A + B** — redundant but each catches a different audience.
+
+**Recommendation:** C. Low-cost, high-coverage. README reaches consumers. CONTRIBUTING reaches maintainers. They're different audiences with different needs for the same doc.
+
+**Open question for maintainer:** confirm C (both), or just A (README only — consumers are the primary audience)?
+
+## Proposed implementation
+
+### Step 1. `docs/reference/verifying.md` (new file, ~120 lines)
+
+Structure:
+
+```markdown
+# Verifying a clickwork release
+
+Every release from 1.0.1 onward is provenance-protected three ways:
+the PyPI package carries PEP 740 attestations, the GitHub Release
+carries Sigstore `.sigstore` bundles, and the git tag is GPG-signed
+by the clickwork-release-bot key. Pick whichever verify path matches
+how you installed.
+
+(Examples below use `1.0.1` as the target version — substitute the
+version you installed.)
+
+## Verifying the PyPI package
+
+> **Note:** pip's built-in auto-verify of PEP 740 attestations is
+> not yet GA. Today, verification is a manual step via the
+> `pypi-attestations` CLI. When installers ship auto-verify, this
+> section will update to reference the flag.
+
+Install `pypi-attestations` in a scratch venv:
+
+    pip install pypi-attestations
+
+Verify the attestations for an installed clickwork:
+
+    pypi-attestations verify pypi clickwork==1.0.1
+
+Expected output: "OK" per artifact, with the workflow identity
+(`https://github.com/qubitrenegade/clickwork/...@refs/tags/v1.0.1`)
+named.
+
+## Verifying a GitHub Release asset
+
+Download the wheel (or sdist) + its `.sigstore` bundle from the
+Release page. Install `sigstore-python`:
+
+    pip install sigstore
+
+Verify:
+
+    sigstore verify identity \
+      dist/clickwork-1.0.1-py3-none-any.whl \
+      --bundle dist/clickwork-1.0.1-py3-none-any.whl.sigstore \
+      --cert-identity https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1 \
+      --cert-oidc-issuer https://token.actions.githubusercontent.com
+
+(Repeat with the sdist if you pulled the sdist.)
+
+Expected output: "OK: dist/clickwork-1.0.1-py3-none-any.whl"
+
+## Verifying the git tag
+
+    git verify-tag v1.0.1
+
+Expected output: "Good signature from clickwork-release-bot
+<release@clickwork.invalid>" (or whatever the dedicated
+release-signing key's UID shows).
+
+The public half of the release-signing key is published on the
+maintainer's GitHub account (Settings → SSH and GPG keys), which is
+what gives signed tags a green "Verified" badge on the tag detail
+page.
+
+## Troubleshooting
+
+### "no such file or directory" for the `.sigstore` bundle
+
+Releases before 1.0.1 were not signed. If the Release page has no
+`.sigstore` files, the verify path is unavailable and you should
+either upgrade to 1.0.1+ or fall back to the hash-pinning verify
+path documented in `security.md`.
+
+### `pypi-attestations` reports no attestations
+
+Check you're on 1.0.1 or later: `pip show clickwork`. Attestations
+start with 1.0.1.
+
+### `git verify-tag` says "no signature"
+
+The local-GPG fallback path (documented in `CONTRIBUTING.md`) was
+used for this release. The tag is still signed, but with the
+maintainer's personal key rather than the workflow key. Either tag
+signature verifies via `git verify-tag`; this message means your
+local GPG keyring doesn't have the public key. Fetch it:
+
+    gpg --keyserver keys.openpgp.org --recv-keys <fingerprint-from-tag-page>
+
+## See also
+
+- [security.md](security.md) — threat model + hash-pinning fallback
+  verify path for pre-1.0.1 releases.
+- [CONTRIBUTING.md#cutting-a-release-recommended-workflow-driven](../../CONTRIBUTING.md) — how the release-signing machinery works from the maintainer side.
+- Parent issue: [#61](https://github.com/qubitrenegade/clickwork/issues/61).
+```
+
+### Step 2. Rewrite `docs/reference/security.md` "Verifying release artifacts" section (~25 lines → ~15 lines)
+
+Replace the existing hash-pinning-focused paragraph with:
+
+```markdown
+## Verifying release artifacts
+
+Every release from 1.0.1 onward can be verified three ways:
+
+1. **PyPI attestation** (PEP 740): `pypi-attestations verify pypi clickwork==<version>`
+2. **Sigstore bundle** (GitHub Release asset): `sigstore verify identity <wheel> --bundle <wheel>.sigstore --cert-identity <workflow-url> --cert-oidc-issuer https://token.actions.githubusercontent.com`
+3. **Signed git tag**: `git verify-tag v<version>`
+
+See [verifying.md](verifying.md) for full worked examples + troubleshooting.
+
+For pre-1.0.1 releases (no signing) or if the verify tooling is
+unavailable, pin by hash:
+
+<retain the existing requirements.txt + pip --require-hashes + uv.lock paragraphs, about 15 lines>
+```
+
+### Step 3. README cross-link
+
+Add a short note to the existing install section:
+
+```markdown
+## Install
+
+    pip install clickwork
+
+[existing prose stays]
+
+**Verifying your install:** see [docs/reference/verifying.md](docs/reference/verifying.md) for the three verify paths (PyPI attestation, Sigstore bundle, signed tag).
+```
+
+~3 lines added.
+
+### Step 4. CONTRIBUTING.md cross-link
+
+At the end of the "Cutting a release (recommended: workflow-driven)" subsection, add:
+
+```markdown
+Consumers verify the release using the commands in
+[`docs/reference/verifying.md`](docs/reference/verifying.md).
+Running those commands against the RC tag during smoke-test
+(see Wave 2 plan) catches most pipeline bugs before 1.0.1 ships.
+```
+
+~4 lines added.
+
+## Smoke-test plan
+
+- After this PR merges: render the new `verifying.md` in the docs site (mkdocs or whatever generates `clickwork.dev`), confirm links resolve.
+- Dry-run the three verify commands against an existing test RC if Wave 2 produced one. Document any command-string glitches.
+- Do NOT ship 1.0.1 yet — Wave 4 handles that, and its smoke-test explicitly runs these verify commands against the first real signed release.
+
+## Target diff size
+
+- `docs/reference/verifying.md`: ~120 new lines.
+- `docs/reference/security.md`: ~25 lines removed, ~15 added (net −10).
+- `README.md`: ~3 lines added.
+- `CONTRIBUTING.md`: ~4 lines added.
+
+Total: ~130 lines net, 1 new file.
+
+## Merge-order constraints
+
+- Wave 3 depends on Wave 1 (#108) + Wave 2 (#110) having merged — otherwise we'd document commands that verify things that don't exist yet. Both merged 2026-04-20. ✓
+- Wave 4 (cut 1.0.1) is gated on Wave 3 merging + the verify docs being live, so a 1.0.1-release blog post or tweet can link to `verifying.md` without circular dependency.
+- No dependency on #62 (conda-forge).
+
+## Success criteria
+
+- `docs/reference/verifying.md` exists and renders on the docs site.
+- `docs/reference/security.md` "Verifying release artifacts" section no longer references Sigstore as "planned" — it points at the three live verify paths with a link to the detailed doc.
+- README + CONTRIBUTING cross-links resolve to `verifying.md`.
+- A fresh reader can run all three verify commands against the next signed release (Wave 4) without ambiguity.
+
+## Risks / open
+
+- **Identity-string drift between spec + reality.** The `--cert-identity` string in the Sigstore verify command is workflow-path-sensitive — if we ever rename `publish.yml` the string breaks. Mitigation: `verifying.md` mentions the identity-string is "the workflow URL" and shows the current shape, not a regex match — users who copy-paste are fine, but a future `publish.yml` rename will drift the doc. Flagged as a maintenance note in `verifying.md`.
+- **`pypi-attestations verify` command syntax changes.** The CLI is early-stage (0.0.x at time of writing). Version-pinning the install recommendation (`pip install pypi-attestations==X.Y.Z`) could help future-proof, but we'd need to bump with its releases. Open to maintainer preference.
+- **Stale "planned" language elsewhere.** Besides `security.md`, the phrase "Sigstore planned" may appear in other docs. Sweep as part of Step 2.
+
+## Out of scope for this plan
+
+- Shipping `clickwork verify` subcommand (separate feature, not signing-workflow).
+- Deep Rekor transparency-log walkthrough (upstream Sigstore docs do this).
+- Automating verify in CI on the consumer side (tool choice lives in the consumer's hands).
+- Retroactively signing older releases (locked Q6=A: no retroactive).

--- a/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
@@ -11,7 +11,7 @@
 
 Ship concrete, copy-pasteable verification commands for every provenance path clickwork now supports:
 
-1. **PyPI attestation** (PEP 740) — `pypi-attestations verify` against an installed wheel or sdist.
+1. **PyPI attestation** (PEP 740) — `pypi-attestations verify` for a PyPI-hosted `clickwork` release at a given version.
 2. **Sigstore bundle on the GitHub Release** — `sigstore verify identity` against a downloaded `.sigstore` bundle + artifact.
 3. **Signed git tag** — `git verify-tag vX.Y.Z` against the workflow-signed tag.
 
@@ -27,7 +27,7 @@ The current `security.md` "Verifying release artifacts" section is a placeholder
 ## Current state
 
 - `docs/reference/security.md` lines 215–238 document only the hash-pinning verify path (pre-Sigstore). It still describes Sigstore as "planned," which is now stale even though the issue reference points to active tracker #61.
-- `docs/SECURITY.md` is a 1-line redirect to `reference/security.md`.
+- `docs/SECURITY.md` is a short redirect stub to `reference/security.md`.
 - No dedicated verify doc exists.
 - Wave 1 produces `.sigstore` bundles on the Release + PEP 740 attestations on PyPI.
 - Wave 2 produces signed annotated tags `vX.Y.Z` verifiable via `git verify-tag`.
@@ -175,13 +175,18 @@ start with 1.0.1.
 
 ### `git verify-tag` says "Can't check signature: No public key"
 
-The local-GPG fallback path (documented in `CONTRIBUTING.md`) was
-used for this release. The tag is still signed, but with the
-maintainer's personal key rather than the workflow key. Either tag
-signature verifies via `git verify-tag`; this message means your
-local GPG keyring doesn't have the signer public key yet. Fetch it:
+The tag is signed (by the workflow key for the recommended release
+path, or the maintainer's personal key for the local-GPG fallback
+documented in `CONTRIBUTING.md`), but your local GPG keyring doesn't
+have the signer public key yet. Both keys are published as GPG keys
+on the maintainer's GitHub account, which GitHub exposes via
+`https://github.com/<user>.gpg`:
 
-    gpg --keyserver keys.openpgp.org --recv-keys <fingerprint-from-tag-page>
+    curl -fsSL https://github.com/qubitrenegade.gpg | gpg --import
+
+This returns every public GPG key associated with the account
+(workflow key + maintainer key); GPG will pick whichever one matches
+the tag's signature.
 
 If `git verify-tag` instead reports "no signature", the tag is
 unsigned and this fallback flow does not apply.
@@ -256,7 +261,7 @@ Append a short note to the existing `## Installation` section (the actual headin
 `README.md` is PyPI's long-description per `pyproject.toml` (`readme = "README.md"`), so relative `docs/...` links render broken on the PyPI project page. The existing README already uses absolute `clickwork.readthedocs.io` URLs for docs references — match that pattern:
 
     **Verifying your install:** see
-    <https://clickwork.readthedocs.io/en/latest/reference/verifying/>
+    <https://clickwork.readthedocs.io/reference/verifying/>
     for the three verify paths — PyPI attestation, Sigstore bundle,
     signed tag.
 

--- a/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
@@ -125,7 +125,7 @@ Install `pypi-attestations` in a scratch venv:
 
     pip install pypi-attestations
 
-Verify the attestations for an installed clickwork:
+Verify the attestations for clickwork 1.0.1 on PyPI:
 
     pypi-attestations verify pypi clickwork==1.0.1
 

--- a/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
@@ -7,6 +7,19 @@
 **Scope:** Wave 3 only — user-facing verification documentation. Builds on Wave 1 (#108 Sigstore + PEP 740 attestations) and Wave 2 (#110 workflow-driven signed tags). Wave 4 (cut 1.0.1) is a separate plan.
 **Relevant files:** [docs/reference/security.md](../../reference/security.md) (existing 1-line "Verifying release artifacts" section, last ~25 lines), [docs/SECURITY.md](../../SECURITY.md) (redirect to reference/security.md), [.github/workflows/publish.yml](../../../.github/workflows/publish.yml) (Wave 1 output: Sigstore + attestations), [.github/workflows/sign-release-tag.yml](../../../.github/workflows/sign-release-tag.yml) (Wave 2 output: signed tags)
 
+## Decisions (locked 2026-04-20)
+
+After review on this PR the maintainer confirmed:
+
+| # | Question | Decision |
+|---|---|---|
+| Q1 | File path for verify doc? | **A** — `docs/reference/verifying.md` for real content + top-level `docs/VERIFYING.md` redirect stub (matches the existing `SECURITY.md` → `reference/security.md` pattern and honors parent plan #97's Q5=C "docs/VERIFYING.md" wording) |
+| Q2 | Worked examples vs templates? | **A** — concrete worked examples using `1.0.1` as the placeholder, with a single "substitute your version" sentence |
+| Q3 | How explicit about pip/uv auto-verify not GA? | **A** — a dedicated "Note" box at the top of the PyPI-attestation section |
+| Q4 | Cross-references? | **Both** — README install section + CONTRIBUTING release-cutting runbook |
+
+Implementation below assumes these decisions are final.
+
 ## Goal
 
 Ship concrete, copy-pasteable verification commands for every provenance path clickwork now supports:
@@ -43,7 +56,9 @@ Five deliverables:
 4. **Rewrite** `docs/reference/security.md` lines 215–238 from hash-pinning-focused to a short "Verifying release artifacts" summary that names the three paths and links to `verifying.md`.
 5. **Cross-link** from `README.md` (install section mentions the verify doc) and `CONTRIBUTING.md` (release-cutting runbook references the verify doc for consumer-side expectations).
 
-## Design questions
+## Design questions (resolved — kept for historical context)
+
+The A/B/C alternatives below were the options considered; each has a **Decision:** line pointing at the locked choice from the table above. Left in the doc so future readers can see what was weighed and why.
 
 ### Q1. File path for the verify doc?
 
@@ -53,9 +68,7 @@ clickwork's `docs/` tree has `reference/`, `how-to/`, `tutorials/`, `explanation
 - **B) `docs/how-to/verify-a-release.md`** — Diátaxis says "how-to" is for goal-oriented recipes, which fits verification perfectly. Diverges from parent plan.
 - **C) Top-level `docs/VERIFYING.md` with no redirect** — literal reading of parent plan. Inconsistent with how `security.md` is placed (real content lives in `reference/`).
 
-**Recommendation:** A. The `SECURITY.md` → `reference/security.md` redirect pattern is already the project's established convention; applying it to VERIFYING.md keeps docs/reference/ as the home for detailed reference pages while the top-level path still resolves for anyone following the parent plan's wording or wanting a short URL.
-
-**Open question for maintainer:** confirm A (redirect + reference/ content), or push back toward B (how-to) or C (top-level only)?
+**Decision: A.** The `SECURITY.md` → `reference/security.md` redirect pattern is already the project's established convention; applying it to VERIFYING.md keeps docs/reference/ as the home for detailed reference pages while the top-level path still resolves for anyone following the parent plan's wording or wanting a short URL.
 
 ### Q2. Depth of worked examples — templates vs specific version?
 
@@ -63,9 +76,7 @@ clickwork's `docs/` tree has `reference/`, `how-to/`, `tutorials/`, `explanation
 - **B) Template with `<version>` substitution markers** — e.g., `sigstore verify identity dist/clickwork-<version>-py3-none-any.whl ...`. Less visual noise, reader has to substitute.
 - **C) Both — worked example first, template underneath** — verbose but maximally clear.
 
-**Recommendation:** A with a single-sentence "substitute your target version" note above. Worked examples read faster; the reader sees the real shape of the command. The "1.0.1" placeholder is the first signed release anyway, so it's real-ish.
-
-**Open question for maintainer:** confirm A (worked examples), or B (templates)?
+**Decision: A.** Worked examples with a single-sentence "substitute your target version" note above. Worked examples read faster; the reader sees the real shape of the command. The "1.0.1" placeholder is the first signed release anyway, so it's real-ish.
 
 ### Q3. How explicit about the "pip/uv auto-verify not yet GA" caveat?
 
@@ -75,9 +86,7 @@ PyPI's PEP 740 attestations are published by our Wave 1 changes, but `pip instal
 - **B) One sentence inline in the PyPI-attestation section** — less prominent, still honest.
 - **C) No explicit note — just document the `pypi-attestations verify` command as THE way** — cleaner doc, but readers who assume `pip install` already verifies will be surprised later.
 
-**Recommendation:** A. The "manual vs auto-verify" distinction is a real gotcha that will catch readers who assume the attestation does auto-magic. Being explicit up front saves a confused-user-opens-issue cycle.
-
-**Open question for maintainer:** A (note box), or B (single sentence)?
+**Decision: A.** The "manual vs auto-verify" distinction is a real gotcha that will catch readers who assume the attestation does auto-magic. Being explicit up front saves a confused-user-opens-issue cycle.
 
 ### Q4. Cross-references from README + CONTRIBUTING?
 
@@ -85,9 +94,7 @@ PyPI's PEP 740 attestations are published by our Wave 1 changes, but `pip instal
 - **B) CONTRIBUTING.md "Cutting a release" section adds a closing note pointing at the verify doc for consumer expectations** — visible to release-cutters thinking about what consumers will do.
 - **C) Both A + B** — redundant but each catches a different audience.
 
-**Recommendation:** C. Low-cost, high-coverage. README reaches consumers. CONTRIBUTING reaches maintainers. They're different audiences with different needs for the same doc.
-
-**Open question for maintainer:** confirm C (both), or just A (README only — consumers are the primary audience)?
+**Decision: C (both).** Low-cost, high-coverage. README reaches consumers. CONTRIBUTING reaches maintainers. They're different audiences with different needs for the same doc.
 
 ## Proposed implementation
 

--- a/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
@@ -35,25 +35,26 @@ The current `security.md` "Verifying release artifacts" section is a placeholder
 
 ## Scope of this plan
 
-Three deliverables:
+Four deliverables:
 
 1. **New file** `docs/reference/verifying.md` — the canonical "how to verify a clickwork release" page. Three concrete command blocks (one per verify path), plus a short "troubleshooting" subsection.
-2. **Rewrite** `docs/reference/security.md` lines 215–238 from hash-pinning-focused to a short "Verifying release artifacts" summary that names the three paths and links to `verifying.md`.
-3. **Cross-link** from `README.md` (install section mentions the verify doc) and `CONTRIBUTING.md` (release-cutting runbook references the verify doc for consumer-side expectations).
+2. **New file** `docs/VERIFYING.md` (top-level) — 1-line redirect stub pointing at `reference/verifying.md`. This matches the existing `docs/SECURITY.md` → `reference/security.md` pattern and honors parent plan #97's Q5=C wording which named the detailed doc as "`docs/VERIFYING.md`".
+3. **Rewrite** `docs/reference/security.md` lines 215–238 from hash-pinning-focused to a short "Verifying release artifacts" summary that names the three paths and links to `verifying.md`.
+4. **Cross-link** from `README.md` (install section mentions the verify doc) and `CONTRIBUTING.md` (release-cutting runbook references the verify doc for consumer-side expectations).
 
 ## Design questions
 
 ### Q1. File path for the verify doc?
 
-clickwork's `docs/` tree has `reference/`, `how-to/`, `tutorials/`, `explanation/` (Diátaxis-style structure).
+clickwork's `docs/` tree has `reference/`, `how-to/`, `tutorials/`, `explanation/` (Diátaxis-style structure). Parent plan #97's locked Q5=C specifically named `docs/VERIFYING.md` (top-level), but `docs/SECURITY.md` is itself a redirect-stub to `docs/reference/security.md`, so "top-level path" has precedent for being a redirect rather than the real content.
 
-- **A) `docs/reference/verifying.md`** — matches `docs/reference/security.md` neighbour; reference-style "these commands, this output" content. Consistent with how `security.md` itself is placed.
-- **B) `docs/how-to/verify-a-release.md`** — Diátaxis says "how-to" is for goal-oriented recipes, which fits verification perfectly.
-- **C) `docs/VERIFYING.md`** (top-level) — matches CONTRIBUTING.md / MIGRATING.md pattern. Shorter URL, easier to link from README.
+- **A) `docs/reference/verifying.md` for real content + top-level `docs/VERIFYING.md` redirect stub** — matches the existing `SECURITY.md` → `reference/security.md` pattern. Honors parent plan's "docs/VERIFYING.md" wording (the top-level path exists) while keeping the real content beside `security.md` in `reference/`.
+- **B) `docs/how-to/verify-a-release.md`** — Diátaxis says "how-to" is for goal-oriented recipes, which fits verification perfectly. Diverges from parent plan.
+- **C) Top-level `docs/VERIFYING.md` with no redirect** — literal reading of parent plan. Inconsistent with how `security.md` is placed (real content lives in `reference/`).
 
-**Recommendation:** A. `security.md` is already reference-style and the verify doc is naturally a sibling of it. Keeping them adjacent in `docs/reference/` means the short-summary in security.md can link with `verifying.md` (no path prefix). B is defensible but verifying-is-a-recipe vs verifying-is-a-reference-page is a judgment call and we already have `security.md` in reference/; consistency wins.
+**Recommendation:** A. The `SECURITY.md` → `reference/security.md` redirect pattern is already the project's established convention; applying it to VERIFYING.md keeps docs/reference/ as the home for detailed reference pages while the top-level path still resolves for anyone following the parent plan's wording or wanting a short URL.
 
-**Open question for maintainer:** confirm A, or prefer B's how-to placement?
+**Open question for maintainer:** confirm A (redirect + reference/ content), or push back toward B (how-to) or C (top-level only)?
 
 ### Q2. Depth of worked examples — templates vs specific version?
 
@@ -170,15 +171,18 @@ path documented in `security.md`.
 Check you're on 1.0.1 or later: `pip show clickwork`. Attestations
 start with 1.0.1.
 
-### `git verify-tag` says "no signature"
+### `git verify-tag` says "Can't check signature: No public key"
 
 The local-GPG fallback path (documented in `CONTRIBUTING.md`) was
 used for this release. The tag is still signed, but with the
 maintainer's personal key rather than the workflow key. Either tag
 signature verifies via `git verify-tag`; this message means your
-local GPG keyring doesn't have the public key. Fetch it:
+local GPG keyring doesn't have the signer public key yet. Fetch it:
 
     gpg --keyserver keys.openpgp.org --recv-keys <fingerprint-from-tag-page>
+
+If `git verify-tag` instead reports "no signature", the tag is
+unsigned and this fallback flow does not apply.
 
 ## See also
 
@@ -188,7 +192,17 @@ local GPG keyring doesn't have the public key. Fetch it:
 - Parent issue: [#61](https://github.com/qubitrenegade/clickwork/issues/61).
 ```
 
-### Step 2. Rewrite `docs/reference/security.md` "Verifying release artifacts" section (~25 lines → ~15 lines)
+### Step 2. `docs/VERIFYING.md` (top-level redirect stub, ~1 line)
+
+Mirrors `docs/SECURITY.md`:
+
+```markdown
+> This page has moved to [reference/verifying.md](reference/verifying.md).
+```
+
+Exists so the parent-plan-named path (`docs/VERIFYING.md`) resolves for anyone who reads the parent plan directly, and so future cross-links can use either the short top-level path or the full `reference/` path.
+
+### Step 3. Rewrite `docs/reference/security.md` "Verifying release artifacts" section (~25 lines → ~15 lines)
 
 Replace the existing hash-pinning-focused paragraph with:
 
@@ -209,23 +223,25 @@ unavailable, pin by hash:
 <retain the existing requirements.txt + pip --require-hashes + uv.lock paragraphs, about 15 lines>
 ```
 
-### Step 3. README cross-link
+### Step 4. README cross-link
 
-Add a short note to the existing install section:
+Append a short note to the existing `## Installation` section (the actual heading — not "Install"):
 
 ```markdown
-## Install
+## Installation
 
-    pip install clickwork
-
+```bash
+# From PyPI (preferred)
+uv pip install "clickwork>=1.0,<2"
 [existing prose stays]
+```
 
-**Verifying your install:** see [docs/reference/verifying.md](docs/reference/verifying.md) for the three verify paths (PyPI attestation, Sigstore bundle, signed tag).
+**Verifying your install:** see [docs/VERIFYING.md](docs/VERIFYING.md) (top-level redirect to [docs/reference/verifying.md](docs/reference/verifying.md)) for the three verify paths — PyPI attestation, Sigstore bundle, signed tag.
 ```
 
 ~3 lines added.
 
-### Step 4. CONTRIBUTING.md cross-link
+### Step 5. CONTRIBUTING.md cross-link
 
 At the end of the "Cutting a release (recommended: workflow-driven)" subsection, add:
 
@@ -240,18 +256,19 @@ Running those commands against the RC tag during smoke-test
 
 ## Smoke-test plan
 
-- After this PR merges: render the new `verifying.md` in the docs site (mkdocs or whatever generates `clickwork.dev`), confirm links resolve.
+- After this PR merges: render the new `verifying.md` in the published docs site (`clickwork.readthedocs.io` per `mkdocs.yml`), confirm links resolve.
 - Dry-run the three verify commands against an existing test RC if Wave 2 produced one. Document any command-string glitches.
 - Do NOT ship 1.0.1 yet — Wave 4 handles that, and its smoke-test explicitly runs these verify commands against the first real signed release.
 
 ## Target diff size
 
-- `docs/reference/verifying.md`: ~120 new lines.
+- `docs/reference/verifying.md`: ~120 new lines (real content).
+- `docs/VERIFYING.md`: ~1 new line (redirect stub, mirrors `SECURITY.md`).
 - `docs/reference/security.md`: ~25 lines removed, ~15 added (net −10).
 - `README.md`: ~3 lines added.
 - `CONTRIBUTING.md`: ~4 lines added.
 
-Total: ~130 lines net, 1 new file.
+Total: ~130 lines net, 2 new files.
 
 ## Merge-order constraints
 

--- a/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
+++ b/docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md
@@ -26,7 +26,7 @@ The current `security.md` "Verifying release artifacts" section is a placeholder
 
 ## Current state
 
-- `docs/reference/security.md` lines 215–238 document only the hash-pinning verify path (pre-Sigstore). It names Sigstore as "planned" with a stale issue reference.
+- `docs/reference/security.md` lines 215–238 document only the hash-pinning verify path (pre-Sigstore). It still describes Sigstore as "planned," which is now stale even though the issue reference points to active tracker #61.
 - `docs/SECURITY.md` is a 1-line redirect to `reference/security.md`.
 - No dedicated verify doc exists.
 - Wave 1 produces `.sigstore` bundles on the Release + PEP 740 attestations on PyPI.
@@ -129,7 +129,8 @@ named.
 ## Verifying a GitHub Release asset
 
 Download the wheel (or sdist) + its `.sigstore` bundle from the
-Release page. Install `sigstore-python`:
+Release page. Install the `sigstore-python` CLI from PyPI
+(`sigstore`):
 
     pip install sigstore
 
@@ -250,10 +251,12 @@ unavailable, pin by hash:
 
 ### Step 5. README cross-link
 
-Append a short note to the existing `## Installation` section (the actual heading — not "Install"). The existing section already contains the `uv pip install "clickwork>=1.0,<2"` block and surrounding prose; we add a new trailing paragraph:
+Append a short note to the existing `## Installation` section (the actual heading — not "Install"). The existing section already contains the `uv pip install "clickwork>=1.0,<2"` block and surrounding prose; we add a new trailing paragraph.
 
-    **Verifying your install:** see [docs/VERIFYING.md](docs/VERIFYING.md)
-    (top-level redirect to [docs/reference/verifying.md](docs/reference/verifying.md))
+`README.md` is PyPI's long-description per `pyproject.toml` (`readme = "README.md"`), so relative `docs/...` links render broken on the PyPI project page. The existing README already uses absolute `clickwork.readthedocs.io` URLs for docs references — match that pattern:
+
+    **Verifying your install:** see
+    <https://clickwork.readthedocs.io/en/latest/reference/verifying/>
     for the three verify paths — PyPI attestation, Sigstore bundle,
     signed tag.
 
@@ -306,7 +309,7 @@ Total: ~135 lines net, 2 new files.
 
 - **Identity-string drift between spec + reality.** The `--cert-identity` string in the Sigstore verify command is workflow-path-sensitive — if we ever rename `publish.yml` the string breaks. Mitigation: `verifying.md` mentions the identity-string is "the workflow URL" and shows the current shape, not a regex match — users who copy-paste are fine, but a future `publish.yml` rename will drift the doc. Flagged as a maintenance note in `verifying.md`.
 - **`pypi-attestations verify` command syntax changes.** The CLI is early-stage (0.0.x at time of writing). Version-pinning the install recommendation (`pip install pypi-attestations==X.Y.Z`) could help future-proof, but we'd need to bump with its releases. Open to maintainer preference.
-- **Stale "planned" language elsewhere.** Besides `security.md`, the phrase "Sigstore planned" may appear in other docs. Sweep as part of Step 2.
+- **Stale "planned" language elsewhere.** Besides `security.md`, the phrase "Sigstore planned" may appear in other docs. Sweep as part of the implementation PR's general doc cleanup.
 
 ## Out of scope for this plan
 


### PR DESCRIPTION
## Summary

Implementation plan for **Wave 3** of the Sigstore signing work — consumer-facing verification documentation. Follows parent plan #97 (merged), Wave 1 #108 (merged), Wave 2 #110 (merged).

**Status: decisions locked (2026-04-20)** — see the `## Decisions` table at the top of the spec. Four design questions (Q1-Q4) surfaced with A/B/C options and answered during review. Per-question blocks retained as historical context with a `Decision:` pointer each.

Spec: `docs/superpowers/specs/2026-04-20-sigstore-wave3-impl-plan.md`.

## Locked decisions

| # | Question | Decision |
|---|---|---|
| Q1 | File path? | **A** — `docs/reference/verifying.md` + top-level `docs/VERIFYING.md` redirect stub (mirrors `SECURITY.md` pattern) |
| Q2 | Worked examples vs templates? | **A** — worked examples with `1.0.1` placeholder |
| Q3 | PEP 740 auto-verify not-GA caveat? | **A** — dedicated "Note" box at the top of the PyPI-attestation section |
| Q4 | Cross-refs from README + CONTRIBUTING? | **Both** — README install section + CONTRIBUTING release-cutting runbook |

## Proposed deliverables (Wave 3 scope only)

1. **New** `docs/reference/verifying.md` (~120 lines) — three verify-path sections + troubleshooting.
2. **New** `docs/VERIFYING.md` (~1 line) — top-level redirect stub.
3. **mkdocs.yml** updates (~6 lines) — `exclude_docs` + `redirect_maps` + `nav.Reference`.
4. **Rewrite** `docs/reference/security.md` "Verifying release artifacts" section (~25 → ~15 lines).
5. **Cross-links** from `README.md` (absolute RTD URL) + `CONTRIBUTING.md` (end of release-cutting runbook).

Total: ~135 lines net, 2 new files.

## How to review

Decisions are locked. Review is sanity-checking implementation steps. Once reviewers sign off, merge — then the implementation PR opens with the actual `verifying.md` + edits.

## Related

- Parent plan: #97 (merged)
- Wave 1: #107 plan / #108 impl (both merged)
- Wave 2: #109 plan / #110 impl (both merged)
- Parent issue: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)