### PR TITLE
docs(verify): ship Wave 3 verification documentation (part of #61)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,6 +74,7 @@ jobs:
             !docs/GUIDE.md
             !docs/PLUGINS.md
             !docs/SECURITY.md
+            !docs/VERIFYING.md
             !docs/MIGRATING.md
             !docs/LLM_REFERENCE.md
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -13,6 +13,7 @@ ignores:
   - docs/GUIDE.md
   - docs/PLUGINS.md
   - docs/SECURITY.md
+  - docs/VERIFYING.md
   - docs/MIGRATING.md
   - docs/LLM_REFERENCE.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,11 @@ they were created and how to rotate).
    — one for tag signing, one for PyPI publish.) The publish job
    finishes shortly after (typically under a minute).
 
+Consumers verify the release using the commands documented in
+[`docs/reference/verifying.md`](docs/reference/verifying.md). Running
+those commands against an RC tag during smoke-test catches most
+pipeline bugs before a final release ships.
+
 ### Cutting a release (fallback: local GPG)
 
 Use this path if the release-signing secrets aren't configured yet,

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ cd your-project
 uv pip install -e ../clickwork
 ```
 
+**Verifying your install:** see <https://clickwork.readthedocs.io/reference/verifying/> for the three verify paths — PyPI attestation, Sigstore bundle, signed tag. (Applies to 1.0.1 and later; pre-1.0.1 releases can be verified via the hash-pinning fallback documented in [Security](https://clickwork.readthedocs.io/reference/security/).)
+
 ## Quick Start
 
 ### 1. Create your entry point

--- a/docs/VERIFYING.md
+++ b/docs/VERIFYING.md
@@ -1,0 +1,1 @@
+> This page has moved to [reference/verifying.md](reference/verifying.md).

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -219,7 +219,7 @@ Every release from 1.0.1 onward can be verified three ways:
 1. **PyPI attestation** (PEP 740) —
    `pypi-attestations verify pypi clickwork==<version>`
 2. **Sigstore bundle** (GitHub Release asset) —
-   `sigstore verify identity <wheel> --bundle <wheel>.sigstore --cert-identity <workflow-url> --cert-oidc-issuer https://token.actions.githubusercontent.com`
+   `sigstore verify identity <artifact> --bundle <artifact>.sigstore --cert-identity <workflow-url> --cert-oidc-issuer https://token.actions.githubusercontent.com`
 3. **Signed git tag** — `git verify-tag v<version>`
 
 See [verifying.md](verifying.md) for worked examples + troubleshooting.

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -214,9 +214,19 @@ Implementation: `clickwork.config._check_owner_only_permissions`.
 
 ## Verifying release artifacts
 
-For 1.0.0, verify PyPI downloads by pinning the release hash. pip's
-hash-checking mode reads hashes from a requirements file rather than
-the command line:
+Every release from 1.0.1 onward can be verified three ways:
+
+1. **PyPI attestation** (PEP 740) —
+   `pypi-attestations verify pypi clickwork==<version>`
+2. **Sigstore bundle** (GitHub Release asset) —
+   `sigstore verify identity <wheel> --bundle <wheel>.sigstore --cert-identity <workflow-url> --cert-oidc-issuer https://token.actions.githubusercontent.com`
+3. **Signed git tag** — `git verify-tag v<version>`
+
+See [verifying.md](verifying.md) for worked examples + troubleshooting.
+
+For pre-1.0.1 releases (no signing) or as a fallback if verify
+tooling is unavailable, pin by hash. `pip`'s hash-checking mode
+reads hashes from a requirements file rather than the command line:
 
 ```text
 # requirements.txt
@@ -231,11 +241,6 @@ PyPI publishes SHA-256 hashes for each artifact on the release page.
 `uv.lock` captures the same hashes when `uv add clickwork==1.0.0` is
 used, and `uv sync --locked` refuses to install anything whose hash
 no longer matches the lockfile.
-
-Sigstore keyless signing is planned for 1.0.1 and tracked in
-[#61](https://github.com/qubitrenegade/clickwork/issues/61). Once it
-ships, `cosign verify-blob` or `sigstore-python` will be the
-recommended verification path.
 
 ## Cross-references
 

--- a/docs/reference/verifying.md
+++ b/docs/reference/verifying.md
@@ -1,0 +1,118 @@
+# Verifying a clickwork release
+
+Every release from 1.0.1 onward is provenance-protected three ways:
+the PyPI package carries PEP 740 attestations, the GitHub Release
+carries Sigstore `.sigstore` bundles, and the git tag is GPG-signed
+(workflow key by default; maintainer key in fallback). Pick whichever
+verify path matches how you installed.
+
+(Examples below use `1.0.1` as the target version — substitute the
+version you installed.)
+
+## Verifying the PyPI package
+
+!!! note "Manual verify today"
+    `pip`'s built-in auto-verify of PEP 740 attestations is not yet
+    GA. Today, verification is a manual step via the
+    [`pypi-attestations`](https://pypi.org/project/pypi-attestations/)
+    CLI. When installers ship auto-verify, this section will update
+    to reference the flag.
+
+Install the `pypi-attestations` CLI in a scratch venv:
+
+    pip install pypi-attestations
+
+Verify the attestations for clickwork 1.0.1 on PyPI:
+
+    pypi-attestations verify pypi clickwork==1.0.1
+
+Expected output: "OK" per artifact, with the workflow identity
+(`https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1`)
+named.
+
+## Verifying a GitHub Release asset
+
+Download the wheel (or sdist) + its `.sigstore` bundle from the
+Release page. Install the `sigstore-python` CLI from PyPI
+(`sigstore`):
+
+    pip install sigstore
+
+Verify (adjust the `--cert-identity` tag ref to match the version
+you downloaded — for a prerelease use the hyphenated form, e.g.
+`@refs/tags/v1.0.1-rc0`):
+
+    sigstore verify identity \
+      dist/clickwork-1.0.1-py3-none-any.whl \
+      --bundle dist/clickwork-1.0.1-py3-none-any.whl.sigstore \
+      --cert-identity https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1 \
+      --cert-oidc-issuer https://token.actions.githubusercontent.com
+
+(Repeat with the sdist if you pulled the sdist.)
+
+Expected output: `OK: dist/clickwork-1.0.1-py3-none-any.whl`.
+
+## Verifying the git tag
+
+    git verify-tag v1.0.1
+
+Expected output: "Good signature from" followed by either the
+release-signing key UID (workflow path, default for 1.0.1+) or the
+maintainer's personal key UID (local-GPG fallback path, documented in
+`CONTRIBUTING.md` for emergency release cuts).
+
+The public half of whichever key signed the tag is published on the
+maintainer's GitHub account (Settings → SSH and GPG keys), which is
+what gives signed tags a green "Verified" badge on the tag detail
+page.
+
+## Troubleshooting
+
+### No `.sigstore` bundle on the Release page
+
+Releases before 1.0.1 were not signed. If the Release page has no
+`.sigstore` files, the bundle verify path is unavailable and you
+should either upgrade to 1.0.1+ or fall back to the hash-pinning
+verify path documented in [security.md](security.md).
+
+### `pypi-attestations` reports no attestations
+
+Check you're on 1.0.1 or later: `pip show clickwork`. Attestations
+start with 1.0.1.
+
+### `git verify-tag` says "Can't check signature: No public key"
+
+The tag is signed (by the workflow key for the recommended release
+path, or the maintainer's personal key for the local-GPG fallback
+documented in `CONTRIBUTING.md`), but your local GPG keyring doesn't
+have the signer public key yet. Both keys are published as GPG keys
+on the maintainer's GitHub account, which GitHub exposes via
+`https://github.com/<user>.gpg`:
+
+    curl -fsSL https://github.com/qubitrenegade.gpg | gpg --import
+
+This returns every public GPG key associated with the account
+(workflow key + maintainer key); GPG will pick whichever one matches
+the tag's signature.
+
+If `git verify-tag` instead reports "no signature", the tag is
+unsigned and this fallback flow does not apply.
+
+### `sigstore verify identity` rejects the certificate identity
+
+The `--cert-identity` is the workflow URL that signed the artifact.
+For a final release `vX.Y.Z`, the ref form is `refs/tags/vX.Y.Z`;
+for a hyphenated prerelease `vX.Y.Z-rc0`, it's `refs/tags/vX.Y.Z-rc0`
+exactly as the tag reads. If your `--cert-identity` string doesn't
+match the tag you installed from, verification will (correctly)
+reject — adjust and retry.
+
+## See also
+
+- [security.md](security.md) — threat model + hash-pinning fallback
+  verify path for pre-1.0.1 releases.
+- [CONTRIBUTING.md — Cutting a release (recommended: workflow-driven)](https://github.com/qubitrenegade/clickwork/blob/main/CONTRIBUTING.md#cutting-a-release-recommended-workflow-driven)
+  — how the release-signing machinery works from the maintainer
+  side. (Absolute GitHub URL because `CONTRIBUTING.md` isn't under
+  `docs/` — a relative link would break the docs build.)
+- Parent issue: [#61](https://github.com/qubitrenegade/clickwork/issues/61).

--- a/docs/reference/verifying.md
+++ b/docs/reference/verifying.md
@@ -43,14 +43,14 @@ you downloaded — for a prerelease use the hyphenated form, e.g.
 `@refs/tags/v1.0.1-rc0`):
 
     sigstore verify identity \
-      dist/clickwork-1.0.1-py3-none-any.whl \
-      --bundle dist/clickwork-1.0.1-py3-none-any.whl.sigstore \
+      ./clickwork-1.0.1-py3-none-any.whl \
+      --bundle ./clickwork-1.0.1-py3-none-any.whl.sigstore \
       --cert-identity https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1 \
       --cert-oidc-issuer https://token.actions.githubusercontent.com
 
 (Repeat with the sdist if you pulled the sdist.)
 
-Expected output: `OK: dist/clickwork-1.0.1-py3-none-any.whl`.
+Expected output: `OK: ./clickwork-1.0.1-py3-none-any.whl`.
 
 ## Verifying the git tag
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ exclude_docs: |
   GUIDE.md
   PLUGINS.md
   SECURITY.md
+  VERIFYING.md
   MIGRATING.md
   ARCHITECTURE.md
   API_POLICY.md
@@ -75,6 +76,7 @@ plugins:
         GUIDE.md: reference/guide.md
         PLUGINS.md: reference/plugins.md
         SECURITY.md: reference/security.md
+        VERIFYING.md: reference/verifying.md
         MIGRATING.md: reference/migrating.md
         LLM_REFERENCE.md: reference/llm-reference.md
         ARCHITECTURE.md: explanation/architecture.md
@@ -103,6 +105,7 @@ nav:
       - User Guide: reference/guide.md
       - Plugins: reference/plugins.md
       - Security: reference/security.md
+      - Verifying: reference/verifying.md
       - Migrating: reference/migrating.md
       - API Reference: reference/api.md
       - LLM Reference: reference/llm-reference.md


### PR DESCRIPTION
## Summary

Wave 3 implementation for #61. Follows parent plan #97 (merged), Wave 3 plan #111 (merged), Wave 1 #108 (merged), Wave 2 #110 (merged).

Consumer-facing verification docs catch up to the signing machinery now in place.

## Changes (6 files, ~142 insertions)

1. **New** `docs/reference/verifying.md` (~118 lines) — three verify-path sections (PyPI attestation / Sigstore bundle / signed git tag) + troubleshooting. Worked examples use `1.0.1`. PyPI-attestation section leads with a "Manual verify today" note box (pip/uv auto-verify isn't GA yet).
2. **New** `docs/VERIFYING.md` (1 line) — top-level redirect stub (mirrors `SECURITY.md`).
3. **`mkdocs.yml`** — `exclude_docs` + `redirect_maps` + `nav.Reference` updates so RTD `fail_on_warning` build stays green.
4. **`docs/reference/security.md`** — rewrite "Verifying release artifacts" section. Drops stale "Sigstore planned" language; names three paths; retains hash-pinning fallback for pre-1.0.1 + tooling-unavailable scenarios.
5. **`README.md`** — one-line "Verifying your install" pointer using absolute RTD URL (README is PyPI's long description, relative paths would break).
6. **`CONTRIBUTING.md`** — end of workflow-driven release runbook now points at `verifying.md` so maintainers know what consumers will run.

## Locked decisions applied (from #111)

| # | Q | A |
|---|---|---|
| Q1 | File path | **A** — `reference/verifying.md` real content + `VERIFYING.md` redirect stub (matches `SECURITY.md` pattern) |
| Q2 | Examples | **A** — worked with `1.0.1` placeholder |
| Q3 | Auto-verify not-GA caveat | **A** — note box at top of PyPI-attestation section |
| Q4 | Cross-refs | **Both** — README + CONTRIBUTING |

## Smoke-test plan

- After merge: confirm the RTD build stays green and that [https://clickwork.readthedocs.io/reference/verifying/](https://clickwork.readthedocs.io/reference/verifying/) renders with correct links.
- Dry-run the three verify commands against an existing RC tag if Wave 2 produced one.
- Wave 4 (cut 1.0.1) will exercise all three commands against the first real signed release.

## Related

- Parent plan: #97 (merged)
- Wave 3 plan: #111 (merged)
- Wave 1: #107 plan / #108 impl (both merged)
- Wave 2: #109 plan / #110 impl (both merged)
- Parent issue: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)