### PR TITLE
release: 1.0.1 — release-infrastructure hardening (Wave 4a, part of #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to clickwork will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - <release-date>
+## [1.0.1] - TBD
 
 Release-infrastructure hardening. No user-facing API changes; every
 consumer who was running 1.0.0 can upgrade to 1.0.1 as a drop-in.
@@ -278,6 +278,7 @@ subsection.
   redacts all env values (secret-sourced as `<redacted>`, other env
   entries as `<set>`) from the single INFO-level log line. (#11)
 
+[1.0.1]: https://github.com/qubitrenegade/clickwork/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/qubitrenegade/clickwork/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/qubitrenegade/clickwork/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/qubitrenegade/clickwork/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to clickwork will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - <release-date>
+
+Release-infrastructure hardening. No user-facing API changes; every
+consumer who was running 1.0.0 can upgrade to 1.0.1 as a drop-in.
+
+### Added
+
+- **Sigstore keyless signing** of release artifacts (PR #108, part
+  of #61). Wheel and sdist are signed inside the `build` job of
+  `publish.yml` using `sigstore/gh-action-sigstore-python`; the
+  resulting `.sigstore` bundles appear as GitHub Release assets
+  alongside the wheel/sdist.
+- **PEP 740 attestations on PyPI** (PR #108, part of #61).
+  `pypa/gh-action-pypi-publish` now publishes attestations via the
+  existing Trusted Publishing OIDC exchange; consumers can verify
+  with `pypi-attestations verify pypi clickwork==1.0.1` (see
+  [docs/reference/verifying.md](docs/reference/verifying.md)).
+- **Workflow-driven signed git tags** (PR #110, part of #61). A
+  new `sign-release-tag.yml` workflow signs release tags from a
+  dedicated workflow-only GPG key (not the maintainer's personal
+  key) with defense-in-depth input validation and a PAT-based push
+  that triggers `publish.yml`. The local-GPG fallback path stays
+  documented in `CONTRIBUTING.md` for emergencies.
+- **Verification documentation** (PR #112, part of #61). New
+  [docs/reference/verifying.md](docs/reference/verifying.md) with
+  concrete worked examples for all three verify paths, plus
+  troubleshooting for common failure modes. Cross-linked from
+  `README.md` and `CONTRIBUTING.md`.
+
+### Changed
+
+- **`docs/reference/security.md`** "Verifying release artifacts"
+  section (PR #112, part of #61) rewritten from pre-Sigstore
+  hash-pinning-only to a summary of the three verify paths with a
+  link to `verifying.md` for the full examples. Hash-pinning
+  retained as a fallback for pre-1.0.1 releases and
+  tooling-unavailable scenarios.
+
 ## [1.0.0] - 2026-04-18
 
 First stable release. The public surface is now covered by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clickwork"
-version = "1.0.0"
+version = "1.0.1"
 description = "Reusable CLI framework for project automation"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Wave 4a release-cut PR — version bump + CHANGELOG entry for the first Sigstore-signed release. Follows the locked Wave 4 plan (#113, merged).

**⚠️ Do not merge until the release session. Per locked Q5=C in the Wave 4 plan, this PR is intentionally left open for maintainer review.**

## Changes

- `pyproject.toml`: 1.0.0 → 1.0.1 (1 line)
- `CHANGELOG.md`: new `## [1.0.1] - TBD` entry framing release-infrastructure hardening + `[1.0.1]: ...compare/v1.0.0...v1.0.1` link definition at the bottom (~40 lines added)

No `src/clickwork/` changes. `__version__` is derived from `importlib.metadata`, so the pyproject.toml version is the single source of truth.

## Release-session runbook

(Full text in `docs/superpowers/specs/2026-04-20-sigstore-wave4-impl-plan.md` Wave 4c.)

1. **Replace `TBD`** in `CHANGELOG.md`'s `## [1.0.1] - TBD` heading with today's date in `YYYY-MM-DD` form.
2. Review + merge this PR, copy the merge commit SHA.
3. Complete one-time secrets setup if not already done (Wave 4b — see `CONTRIBUTING.md` "Release-signing key + PAT rotation").
4. **Actions → Sign release tag → Run workflow** with:
   - `version`: `1.0.1`
   - `commit_sha`: paste the merge commit SHA from step 2 so the tag is pinned to the reviewed commit
   - `headline`: short description (suggested: "Release infrastructure: Sigstore signing, attestations, verify docs.")
5. Approve the `pypi` env gate twice:
   - First approval → `sign-release-tag.yml` creates + pushes signed `v1.0.1` tag → fires `publish.yml`
   - Second approval → `publish.yml` uploads to PyPI with PEP 740 attestations
6. Verify:
   - Tag detail page for `v1.0.1` shows Verified badge
   - Release page has `clickwork-1.0.1-py3-none-any.whl`, `clickwork-1.0.1.tar.gz`, and matching `.sigstore` bundle files
   - PyPI page shows 1.0.1 with Attestations section
7. Run all three verify commands from `docs/reference/verifying.md` against the real 1.0.1 artifacts:
   - `pypi-attestations verify pypi clickwork==1.0.1`
   - `sigstore verify identity ./clickwork-1.0.1-py3-none-any.whl --bundle ./clickwork-1.0.1-py3-none-any.whl.sigstore --cert-identity https://github.com/qubitrenegade/clickwork/.github/workflows/publish.yml@refs/tags/v1.0.1 --cert-oidc-issuer https://token.actions.githubusercontent.com`
   - `git verify-tag v1.0.1`
8. Close #61.

## Related

- Parent plan: #97 (merged)
- Wave 4 plan: #113 (merged)
- Waves 1+2+3 implementations: #108, #110, #112 (all merged)
- Parent issue: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)