### PR TITLE
docs: stamp 1.0.1 release date in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to clickwork will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - TBD
+## [1.0.1] - 2026-04-22
 
 Release-infrastructure hardening. No user-facing API changes; every
 consumer who was running 1.0.0 can upgrade to 1.0.1 as a drop-in.


### PR DESCRIPTION
## Summary

1-line follow-up to #114: replace `TBD` with `2026-04-22` in the `## [1.0.1]` heading.

## Why

#114 (Wave 4a release-cut) merged with `TBD` left in place — the release-session runbook step 1 (substitute TBD with today's date) was skipped at merge time. This PR does it directly.

Required before dispatching `sign-release-tag.yml` so the visible release date in CHANGELOG matches when 1.0.1 actually ships.

## Related

- Follow-up to #114
- Parent plan: #113 (merged)
- Parent issue: #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)